### PR TITLE
fix: command+w will close two tabs

### DIFF
--- a/src/renderer/src/views/layouts/TerminalLayout.vue
+++ b/src/renderer/src/views/layouts/TerminalLayout.vue
@@ -113,6 +113,7 @@
               >
                 <div class="agents-chat-container">
                   <AiTab
+                    v-if="props.currentMode === 'agents'"
                     ref="aiTabRef"
                     :toggle-sidebar="() => {}"
                     :saved-state="savedAiSidebarState || undefined"
@@ -209,7 +210,7 @@
                   </pane>
                   <!-- AI sidebar -->
                   <pane
-                    v-if="showAiSidebar"
+                    v-if="props.currentMode === 'terminal' && showAiSidebar"
                     :size="aiSidebarSize"
                     :min-size="aiMinSize"
                   >


### PR DESCRIPTION
When multiple tabs exist (A, B, C) and the user is on Tab B, pressing Command+W causes both Tab B and Tab C to close simultaneously instead of just Tab B.

The bug happened because two AiTab components were mounted at the same time (Agents view + right sidebar), while their tab state (useSessionState) is a global singleton. Each AiTab instance registered its own window.keydown handler for Cmd+W, so a single keypress triggered the close logic twice. After the first close, currentChatId moved to the next tab, so the second handler immediately closed the next tab as well (e.g., closing B then C).

Test
I added a regression test that creates three tabs, activates the middle tab, presses Cmd+W once, and asserts that the tab count decreases from 3 → 2 (not 3 → 1).