### PR TITLE
refactor: make props in zmodemProgress component optional

### DIFF
--- a/src/renderer/src/views/components/Ssh/utils/zmodemProgress.vue
+++ b/src/renderer/src/views/components/Ssh/utils/zmodemProgress.vue
@@ -83,16 +83,16 @@ import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 
 interface Props {
-  visible: boolean
-  type: 'upload' | 'download'
-  progress: number
-  transferSpeed: number
-  transferSize: number
-  totalSize: number
-  fileName: string
-  isCanceling: boolean
-  status: 'normal' | 'error'
-  getContainer: () => HTMLElement
+  visible?: boolean
+  type?: 'upload' | 'download'
+  progress?: number
+  transferSpeed?: number
+  transferSize?: number
+  totalSize?: number
+  fileName?: string
+  isCanceling?: boolean
+  status?: 'normal' | 'error'
+  getContainer?: () => HTMLElement
 }
 
 const props = withDefaults(defineProps<Props>(), {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made all SSH file transfer progress component properties optional to improve flexibility and configuration adaptability. Default values are preserved to ensure consistent behavior and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->