### PR TITLE
feat: add assets reference and clear selection on panel close

### DIFF
--- a/src/renderer/src/views/layouts/TerminalLayout.vue
+++ b/src/renderer/src/views/layouts/TerminalLayout.vue
@@ -161,6 +161,7 @@
                 />
                 <Assets
                   v-else-if="currentMenu == 'assets'"
+                  ref="assetsRef"
                   :toggle-sidebar="toggleSideBar"
                   @open-user-tab="openUserTab"
                 />
@@ -348,6 +349,7 @@ const configStore = piniaUserConfigStore()
 const isTransparent = computed(() => !!configStore.getUserConfig.background.image)
 const headerRef = ref<InstanceType<typeof Header> | null>(null)
 const allTabs = ref<InstanceType<typeof TabsPanel> | null>(null)
+const assetsRef = ref<InstanceType<typeof Assets> | null>(null)
 const isSkippedLogin = computed(() => {
   return localStorage.getItem('login-skipped') === 'true'
 })
@@ -2075,8 +2077,13 @@ const onDockReady = (event: DockviewReadyEvent) => {
     panelCount.value = dockApi?.panels.length ?? 0
   })
 
-  dockApi.onDidRemovePanel(() => {
+  dockApi.onDidRemovePanel((panel) => {
     panelCount.value = dockApi?.panels.length ?? 0
+    // Clear Assets menu selection when corresponding tab is closed
+    const content = panel.params?.content
+    if (content === 'assetConfig' || content === 'keyManagement' || content === 'files') {
+      assetsRef.value?.handleExplorerActive(content)
+    }
   })
 
   dockApi.onDidActivePanelChange(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Assets explorer state synchronization when closing related panels, ensuring the interface maintains consistency across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->