### PR TITLE
fix: Prevent black screen issue on macOS by exiting fullscreen before hiding the main window

### DIFF
--- a/src/main/windowManager.ts
+++ b/src/main/windowManager.ts
@@ -58,7 +58,18 @@ export async function createMainWindow(onCookieUrlChange?: (url: string) => void
     mainWindow.on('close', (event) => {
       if (shouldPreventClose ? shouldPreventClose() : true) {
         event.preventDefault()
-        mainWindow.hide()
+        // Exit fullscreen before hiding to prevent black screen issue on macOS
+        if (mainWindow.isFullScreen()) {
+          mainWindow.once('leave-full-screen', () => {
+            mainWindow.hide()
+          })
+          mainWindow.setFullScreen(false)
+        } else {
+          if (mainWindow.isMaximized()) {
+            mainWindow.unmaximize()
+          }
+          mainWindow.hide()
+        }
       }
     })
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window closing behavior to prevent black screen issues and ensure smooth transitions. Windows now properly exit fullscreen and maximized states before closing, delivering more reliable window management during application shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->