### PR TITLE
feat: Disable reload shortcut (Command+R/Ctrl+R) in main window to pr…

### DIFF
--- a/src/main/windowManager.ts
+++ b/src/main/windowManager.ts
@@ -115,5 +115,15 @@ export async function createMainWindow(onCookieUrlChange?: (url: string) => void
     mainWindow.webContents.send('window:unmaximized')
   })
 
+  // Disable Command+R (macOS) / Ctrl+R (Windows/Linux) reload shortcut
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type === 'keyDown') {
+      const isReloadShortcut = (input.key === 'r' || input.key === 'R') && (input.meta || input.control) && !input.alt && !input.shift
+      if (isReloadShortcut) {
+        event.preventDefault()
+      }
+    }
+  })
+
   return mainWindow
 }


### PR DESCRIPTION
…event accidental reloads Co-authored-by: fish <46886228+fishyu-mushroom@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the in-app reload keyboard shortcut (Command+R on macOS, Ctrl+R on Windows/Linux).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->