### PR TITLE
refactor: update database directory structure to 'chaterm_db' and implement migration from legacy 'databases' directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13363,9 +13363,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "version": "24.10.10",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.10.tgz",
+      "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"

--- a/src/main/plugin/pluginManager.test.ts
+++ b/src/main/plugin/pluginManager.test.ts
@@ -61,7 +61,7 @@ describe('pluginManager per-user storage', () => {
     const zipPath = createPluginZip()
     const record = installPlugin(zipPath)
 
-    expect(record.path).toBe(path.join(userData, 'databases', '42', 'plugins', 'p1-1.0.0'))
+    expect(record.path).toBe(path.join(userData, 'chaterm_db', '42', 'plugins', 'p1-1.0.0'))
     expect(fs.existsSync(record.path)).toBe(true)
 
     const registry = listPlugins()
@@ -75,7 +75,7 @@ describe('pluginManager per-user storage', () => {
 
     const { getPluginCacheRoot } = await import('./pluginManager')
 
-    expect(getPluginCacheRoot()).toBe(path.join(userData, 'databases', '42', 'plugins', '.cache'))
+    expect(getPluginCacheRoot()).toBe(path.join(userData, 'chaterm_db', '42', 'plugins', '.cache'))
   })
 
   it('falls back to guest user directory when no current user', async () => {
@@ -84,7 +84,7 @@ describe('pluginManager per-user storage', () => {
     mockGetCurrentUserId.mockReturnValue(null)
     mockGetGuestUserId.mockReturnValue(123)
 
-    const registryPath = path.join(userData, 'databases', '123', 'plugins', 'plugins.json')
+    const registryPath = path.join(userData, 'chaterm_db', '123', 'plugins', 'plugins.json')
     fs.mkdirSync(path.dirname(registryPath), { recursive: true })
     fs.writeFileSync(registryPath, JSON.stringify([{ id: 'p2', displayName: 'P2', version: '1.0.0', path: '/tmp/p2', enabled: true }]))
 

--- a/src/main/plugin/pluginManager.ts
+++ b/src/main/plugin/pluginManager.ts
@@ -35,10 +35,13 @@ export interface InstalledPlugin {
   enabled: boolean
 }
 
+// Database directory name - must match connection.ts DB_DIR_NAME
+const DB_DIR_NAME = 'chaterm_db'
+
 // Lazy getters to ensure path is resolved after initUserDataPath() is called
 function getExtensionsRoot(): string {
   const userId = getCurrentUserId() ?? getGuestUserId()
-  return path.join(getUserDataPath(), 'databases', `${userId}`, 'plugins')
+  return path.join(getUserDataPath(), DB_DIR_NAME, `${userId}`, 'plugins')
 }
 
 function getRegistryPath(): string {


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `npm run lint` and fixed any issues.
- [x] I have run `npm run format` to ensure code formatting is consistent.
- [x] I have run `npm run typecheck` and there are no type errors.
- [x] I have run `npm test` and all tests pass.
- [x] If UI changes are involved, I have updated i18n files (`src/renderer/src/locales/lang/*.ts`).
- [x] If this is a user-visible change, I have updated `README.md` or `README_zh.md` accordingly.
- [x] My changes follow the project's code style and conventions.
- [x] I have verified my changes work correctly with `npm run dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent database initialization race conditions to prevent conflicts when multiple processes access the database simultaneously.

* **Chores**
  * Updated internal storage directory structure and added automatic migration system for existing data.
  * Enhanced database initialization with diagnostic logging and schema synchronization to ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->