### PR TITLE
feat: add localization for "Show IP" and "Show Hostname" in multiple languages and implement display mode toggle in workspace

### DIFF
--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -741,6 +741,8 @@ export default {
     folderDeleteConfirmContent: 'Sind Sie sicher, dass Sie den Ordner "{name}" löschen möchten?',
     folderDeleteConfirmWithAssets:
       'Sind Sie sicher, dass Sie den Ordner "{name}" löschen möchten? Dieser Ordner enthält {count} Assets, und nach dem Löschen werden die Assets wieder in ihren ursprünglichen Zustand zurückkehren.',
+    showIp: 'IP anzeigen',
+    showHostname: 'Hostname anzeigen',
     missingAssetId: 'Asset ID fehlt',
     supportedFormats: 'Unterstützte Formate',
     standardFormat: 'Standard Format',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -735,6 +735,8 @@ export default {
     folderDeleteConfirmContent: 'Are you sure you want to delete folder "{name}"?',
     folderDeleteConfirmWithAssets:
       'Are you sure you want to delete folder "{name}"? This folder contains {count} assets, and after deletion, the assets will return to their original position.',
+    showIp: 'Show IP',
+    showHostname: 'Show Hostname',
     missingAssetId: 'Missing asset ID',
     supportedFormats: 'Supported Formats',
     standardFormat: 'Standard Format',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -742,6 +742,8 @@ export default {
     folderDeleteConfirmContent: 'Êtes-vous sûr de vouloir supprimer le groupe "{name}"?',
     folderDeleteConfirmWithAssets:
       'Êtes-vous sûr de vouloir supprimer le groupe "{name}"? Ce groupe contient {count} actifs, et après suppression, les actifs retourneront à leur position originale.',
+    showIp: 'Afficher IP',
+    showHostname: "Afficher le nom d'hôte",
     missingAssetId: "ID de l'actif manquant",
     supportedFormats: 'Formats supportés',
     standardFormat: 'Format standard',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -740,6 +740,8 @@ export default {
     folderDeleteConfirmContent: 'Sei sicuro di voler eliminare la cartella "{name}"?',
     folderDeleteConfirmWithAssets:
       'Sei sicuro di voler eliminare la cartella "{name}"? Questa cartella contiene {count} asset, e dopo l\'eliminazione, gli asset torneranno alla loro posizione originale.',
+    showIp: 'Mostra IP',
+    showHostname: 'Mostra nome host',
     missingAssetId: 'ID asset mancante',
     supportedFormats: 'Formati supportati',
     standardFormat: 'Formato standard',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -731,6 +731,8 @@ export default {
     folderDeleteConfirmContent: 'フォルダ "{name}" を削除してもよろしいですか？',
     folderDeleteConfirmWithAssets:
       'フォルダ "{name}" を削除してもよろしいですか？このフォルダには {count} 個の資産が含まれており、削除後、資産は元の位置に戻ります。',
+    showIp: 'IPを表示',
+    showHostname: 'ホスト名を表示',
     missingAssetId: '資産IDが不足しています',
     supportedFormats: 'サポートされているフォーマット',
     standardFormat: '標準フォーマット',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -727,6 +727,8 @@ export default {
     folderDeleteConfirmContent: '폴더 "{name}"을 삭제하시겠습니까?',
     folderDeleteConfirmWithAssets:
       '폴더 "{name}"을 삭제하시겠습니까? 이 폴더에는 {count}개의 자산이 포함되어 있으며, 삭제 후 자산은 원래 위치로 돌아갑니다.',
+    showIp: 'IP 표시',
+    showHostname: '호스트 이름 표시',
     missingAssetId: '자산 ID 누락',
     supportedFormats: '지원되는 파일 형식',
     standardFormat: '표준 형식',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -739,6 +739,8 @@ export default {
     folderDeleteConfirmContent: 'Tem certeza que deseja deletar a pasta "{name}"?',
     folderDeleteConfirmWithAssets:
       'Tem certeza que deseja deletar a pasta "{name}"? Esta pasta contém {count} ativos, e após a exclusão, os ativos retornarão à sua posição original.',
+    showIp: 'Mostrar IP',
+    showHostname: 'Mostrar nome do host',
     missingAssetId: 'ID do ativo faltando',
     supportedFormats: 'Formatos suportados',
     standardFormat: 'Formato padrão',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -737,6 +737,8 @@ export default {
     folderDeleteConfirmContent: 'Вы уверены, что хотите удалить папку "{name}"?',
     folderDeleteConfirmWithAssets:
       'Вы уверены, что хотите удалить папку "{name}"? Эта папка содержит {count} активов, и после удаления активы вернутся на свои исходные позиции.',
+    showIp: 'Показать IP',
+    showHostname: 'Показать имя хоста',
     missingAssetId: 'Отсутствует ID актива',
     supportedFormats: 'Поддерживаемые форматы',
     standardFormat: 'Стандартный формат',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -724,6 +724,8 @@ export default {
     folderDeleteConfirm: '删除分组确认',
     folderDeleteConfirmContent: '确定要删除分组 "{name}" 吗？删除后分组中的资产将回到原位置。',
     folderDeleteConfirmWithAssets: '确定要删除分组 "{name}" 吗？该分组包含 {count} 个资产，删除后资产将回到原位置。',
+    showIp: '显示IP',
+    showHostname: '显示主机名',
     missingAssetId: '缺少资产 ID',
     supportedFormats: '支持的格式',
     standardFormat: '标准格式',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -723,6 +723,8 @@ export default {
     folderDeleteConfirm: '刪除分組確認',
     folderDeleteConfirmContent: '確定要刪除分組 "{name}" 嗎？刪除後分組中的資產將回到原位置。',
     folderDeleteConfirmWithAssets: '確定要刪除分組 "{name}" 嗎？該分組包含 {count} 個資產，刪除後資產將回到原位置。',
+    showIp: '顯示IP',
+    showHostname: '顯示主機名',
     missingAssetId: '缺少資產 ID',
     supportedFormats: '支持的格式',
     standardFormat: '標準格式',

--- a/src/renderer/src/services/userConfigStoreService.ts
+++ b/src/renderer/src/services/userConfigStoreService.ts
@@ -48,6 +48,7 @@ export interface UserConfig {
     password?: string
   }>
   workspaceExpandedKeys?: string[]
+  workspaceShowIpMode?: boolean
   background: BackgroundConfig
 }
 


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `npm run lint` and fixed any issues.
- [x] I have run `npm run format` to ensure code formatting is consistent.
- [x] I have run `npm run typecheck` and there are no type errors.
- [x] I have run `npm test` and all tests pass.
- [x] If UI changes are involved, I have updated i18n files (`src/renderer/src/locales/lang/*.ts`).
- [x] If this is a user-visible change, I have updated `README.md` or `README_zh.md` accordingly.
- [x] My changes follow the project's code style and conventions.
- [x] I have verified my changes work correctly with `npm run dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace display mode toggle allowing users to switch between showing IP addresses or hostnames, with preference automatically saved for future sessions.

* **Localization**
  * Added translations for the new IP/hostname toggle across 10 languages: German, English, French, Italian, Japanese, Korean, Portuguese, Russian, and Simplified and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->