### PR TITLE
feat: Implement Ctrl+R reload prevention with terminal reverse-i-search support

### DIFF
--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -723,14 +723,22 @@ onMounted(async () => {
   if (terminal.value?.textarea) {
     terminal.value.textarea.addEventListener('focus', () => {
       inputManager.setActiveTerm(connectionId.value)
+      window.electron?.ipcRenderer?.send('terminal:focus-changed', true)
     })
-    terminal.value.textarea.addEventListener('blur', hideSelectionButton)
+    terminal.value.textarea.addEventListener('blur', () => {
+      hideSelectionButton()
+      window.electron?.ipcRenderer?.send('terminal:focus-changed', false)
+    })
     cleanupListeners.value.push(() => {
       if (terminal.value?.textarea) {
         terminal.value.textarea.removeEventListener('focus', () => {
           inputManager.setActiveTerm(connectionId.value)
+          window.electron?.ipcRenderer?.send('terminal:focus-changed', true)
         })
-        terminal.value.textarea.removeEventListener('blur', hideSelectionButton)
+        terminal.value.textarea.removeEventListener('blur', () => {
+          hideSelectionButton()
+          window.electron?.ipcRenderer?.send('terminal:focus-changed', false)
+        })
       }
     })
   }


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard shortcut handling with platform-aware reload prevention that respects terminal focus state.
  * Added terminal focus tracking to improve responsiveness of keyboard commands.

* **Tests**
  * Added comprehensive unit tests covering keyboard shortcut behavior across multiple platforms and terminal focus states, including edge cases with modifier keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->