### PR TITLE
style: Add margin to editor settings section in general.vue

### DIFF
--- a/src/renderer/src/views/components/LeftTab/setting/general.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/general.vue
@@ -170,7 +170,7 @@
         </a-form-item>
 
         <!-- Editor Settings -->
-        <a-form-item>
+        <a-form-item class="editor-settings-section">
           <template #label>
             <span class="label-text">{{ $t('user.editorSettings') }}</span>
           </template>
@@ -840,5 +840,9 @@ const saveEditorConfig = async () => {
 
 .mt-2 {
   margin-top: 8px;
+}
+
+.editor-settings-section {
+  margin-top: 35px;
 }
 </style>


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized spacing in the Editor Settings configuration area, providing improved visual separation and a more refined user interface layout for better navigation and readability throughout the settings panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->