### PR TITLE
chore: update known good SHA256 hash for ffmpeg.dll to match Electron 40.4.0

### DIFF
--- a/scripts/verify-ffmpeg.js
+++ b/scripts/verify-ffmpeg.js
@@ -7,8 +7,8 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-// The known good SHA256 hash for Electron 30.5.1 ffmpeg.dll (Windows x64)
-const KNOWN_HASH = '26EED00C4DA27DE095BA76030B47BC0436BA659A7443E05F11EE162DC225E828'
+// The known good SHA256 hash for Electron 40.4.0 ffmpeg.dll (Windows x64)
+const KNOWN_HASH = '2E76D5300D01FEF3337AB96C748DE3E05669EFD1F5AFFBBEBFA41D45F217CAE5'
 
 const ffmpegPath = path.join(__dirname, '../node_modules/electron/dist/ffmpeg.dll')
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -128,7 +128,7 @@ app.whenReady().then(async () => {
     try {
       const crypto = require('crypto')
       const ffmpegPath = path.join(path.dirname(process.execPath), 'ffmpeg.dll')
-      const KNOWN_HASH = '26EED00C4DA27DE095BA76030B47BC0436BA659A7443E05F11EE162DC225E828'
+      const KNOWN_HASH = '2E76D5300D01FEF3337AB96C748DE3E05669EFD1F5AFFBBEBFA41D45F217CAE5'
 
       if (fsSync.existsSync(ffmpegPath)) {
         console.log('[Security] Verifying ffmpeg.dll integrity...')


### PR DESCRIPTION


<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated security verification checks to support the latest Electron version. Internal integrity verification constants have been refreshed to ensure proper app functionality and security on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->