### PR TITLE
chore: Adjust the prompt language for import

### DIFF
--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -768,7 +768,7 @@ export default {
     showHostname: 'Hostname anzeigen',
     missingAssetId: 'Asset ID fehlt',
     supportedFormats: 'Unterstützte Formate',
-    standardFormat: 'Standard Format',
+    standardFormat: 'Exportformat',
     sessionFiles: 'Session Dateien',
     configFiles: 'Config Dateien',
     unsupportedFileFormat: 'Nicht unterstütztes Dateiformat',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -762,7 +762,7 @@ export default {
     showHostname: 'Show Hostname',
     missingAssetId: 'Missing asset ID',
     supportedFormats: 'Supported Formats',
-    standardFormat: 'Standard Format',
+    standardFormat: 'Export Format',
     sessionFiles: 'Session Files',
     configFiles: 'Config Files',
     unsupportedFileFormat: 'Unsupported File Format',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -769,7 +769,7 @@ export default {
     showHostname: "Afficher le nom d'hôte",
     missingAssetId: "ID de l'actif manquant",
     supportedFormats: 'Formats supportés',
-    standardFormat: 'Format standard',
+    standardFormat: "Format d'exportation",
     sessionFiles: 'Fichiers de session',
     configFiles: 'Fichiers de configuration',
     unsupportedFileFormat: 'Format de fichier non supporté',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -767,7 +767,7 @@ export default {
     showHostname: 'Mostra nome host',
     missingAssetId: 'ID asset mancante',
     supportedFormats: 'Formati supportati',
-    standardFormat: 'Formato standard',
+    standardFormat: 'Formato di esportazione',
     sessionFiles: 'File sessione',
     configFiles: 'File configurazione',
     unsupportedFileFormat: 'Formato file non supportato',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -758,7 +758,7 @@ export default {
     showHostname: 'ホスト名を表示',
     missingAssetId: '資産IDが不足しています',
     supportedFormats: 'サポートされているフォーマット',
-    standardFormat: '標準フォーマット',
+    standardFormat: 'エクスポート形式',
     sessionFiles: 'セッションファイル',
     configFiles: '設定ファイル',
     unsupportedFileFormat: 'サポートされていないフォーマット',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -754,7 +754,7 @@ export default {
     showHostname: '호스트 이름 표시',
     missingAssetId: '자산 ID 누락',
     supportedFormats: '지원되는 파일 형식',
-    standardFormat: '표준 형식',
+    standardFormat: '내보내기 형식',
     sessionFiles: '세션 파일',
     configFiles: '설정 파일',
     unsupportedFileFormat: '지원되지 않는 파일 형식',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -766,7 +766,7 @@ export default {
     showHostname: 'Mostrar nome do host',
     missingAssetId: 'ID do ativo faltando',
     supportedFormats: 'Formatos suportados',
-    standardFormat: 'Formato padrão',
+    standardFormat: 'Formato de exportação',
     sessionFiles: 'Arquivos de sessão',
     configFiles: 'Arquivos de configuração',
     unsupportedFileFormat: 'Formato de arquivo não suportado',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -764,7 +764,7 @@ export default {
     showHostname: 'Показать имя хоста',
     missingAssetId: 'Отсутствует ID актива',
     supportedFormats: 'Поддерживаемые форматы',
-    standardFormat: 'Стандартный формат',
+    standardFormat: 'Формат экспорта',
     sessionFiles: 'Файлы сессий',
     configFiles: 'Файлы конфигурации',
     unsupportedFileFormat: 'Неподдерживаемый формат файла',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -749,7 +749,7 @@ export default {
     showHostname: '显示主机名',
     missingAssetId: '缺少资产 ID',
     supportedFormats: '支持的格式',
-    standardFormat: '标准格式',
+    standardFormat: '导出格式',
     sessionFiles: '会话文件',
     configFiles: '配置文件',
     unsupportedFileFormat: '不支持的文件格式',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -750,7 +750,7 @@ export default {
     showHostname: '顯示主機名',
     missingAssetId: '缺少資產 ID',
     supportedFormats: '支持的格式',
-    standardFormat: '標準格式',
+    standardFormat: '導出格式',
     sessionFiles: '會話文件',
     configFiles: '配置文件',
     unsupportedFileFormat: '不支持的文件格式',

--- a/src/renderer/src/views/components/LeftTab/components/AssetSearch.vue
+++ b/src/renderer/src/views/components/LeftTab/components/AssetSearch.vue
@@ -31,7 +31,7 @@
           <template #title>
             <div class="import-tooltip">
               <div class="tooltip-title">{{ t('personal.supportedFormats') }}</div>
-              <div class="format-item">JSON - Chaterm {{ t('personal.standardFormat') }}</div>
+              <div class="format-item">chaterm.json - Chaterm {{ t('personal.standardFormat') }}</div>
               <div class="format-item">XSH/XTS - XShell {{ t('personal.sessionFiles') }}</div>
               <div class="format-item">INI/XML - SecureCRT {{ t('personal.configFiles') }}</div>
               <div class="format-item">MXTSESSIONS - MobaXterm {{ t('personal.sessionFiles') }}</div>
@@ -204,7 +204,7 @@ const showSupportedFormatsDialog = () => {
     content: h('div', [
       h('p', t('personal.pleaseSelectSupportedFormat')),
       h('div', { class: 'supported-formats-list' }, [
-        h('div', 'JSON - Chaterm ' + t('personal.standardFormat')),
+        h('div', 'chaterm.json - Chaterm ' + t('personal.standardFormat')),
         h('div', 'XSH/XTS - XShell ' + t('personal.sessionFiles')),
         h('div', 'INI/XML - SecureCRT ' + t('personal.configFiles')),
         h('div', 'MXTSESSIONS - MobaXterm ' + t('personal.sessionFiles'))


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated localization strings across 10 language variants—German, English, French, Italian, Japanese, Korean, Portuguese, Russian, and Chinese (both Simplified and Traditional)—to ensure consistent terminology throughout the entire application interface.
  * Refined display text for JSON import format identification to enhance user experience and clarity in the supported formats listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->