### PR TITLE
fix: Update session state management in useCommandInteraction to handle response loading and retry button visibility

### DIFF
--- a/src/renderer/src/views/components/AiTab/composables/useCommandInteraction.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useCommandInteraction.ts
@@ -316,6 +316,8 @@ export function useCommandInteraction(params: CommandInteractionOptions) {
 
     logger.info('handleRetry: retry')
     session.isCancelled = false
+    session.responseLoading = true
+    session.showRetryButton = false
     const messageRsp: WebviewMessage = {
       type: 'askResponse',
       askResponse: 'yesButtonClicked'
@@ -323,7 +325,6 @@ export function useCommandInteraction(params: CommandInteractionOptions) {
     logger.info('Send message to main process', { data: messageRsp })
     const response = await window.api.sendToMain(attachTabContext(messageRsp))
     logger.info('Main process response', { data: response })
-    session.showRetryButton = false
   }
 
   return {


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate state mutations in the retry functionality to prevent conflicting UI state updates and ensure the retry button behaves correctly during response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->