### PR TITLE
fix: Fix the lagging issue when dragging the sidebar when there is a large amount of AI chat content

### DIFF
--- a/src/renderer/src/views/components/AiTab/composables/useAutoScroll.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useAutoScroll.ts
@@ -3,6 +3,31 @@ import { useSessionState } from './useSessionState'
 import { focusChatInput } from './useTabManagement'
 
 /**
+ * Module-level resize state shared across all instances.
+ * When panels are being resized, MutationObserver and ResizeObserver
+ * callbacks are paused to avoid layout thrashing with large chat content.
+ */
+const _isResizing = ref(false)
+let _resizeEndTimer: ReturnType<typeof setTimeout> | null = null
+const RESIZE_END_DELAY = 200
+
+/**
+ * Signal that a panel resize is in progress.
+ * Call with `true` on every resize event; the flag auto-resets
+ * after RESIZE_END_DELAY ms of inactivity.
+ */
+export function signalResizeStart(): void {
+  _isResizing.value = true
+  if (_resizeEndTimer) {
+    clearTimeout(_resizeEndTimer)
+  }
+  _resizeEndTimer = setTimeout(() => {
+    _isResizing.value = false
+    _resizeEndTimer = null
+  }, RESIZE_END_DELAY)
+}
+
+/**
  * Composable for auto-scroll management
  * Handles automatic scrolling to bottom functionality for chat container (sticky scroll)
  */
@@ -13,6 +38,18 @@ export function useAutoScroll() {
   // Container height for dynamic min-height on last message pair
   const containerHeight = ref<number>(0)
   let resizeObserver: ResizeObserver | null = null
+  let resizeObserverDebounceTimer: ReturnType<typeof setTimeout> | null = null
+  const RESIZE_OBSERVER_DEBOUNCE = 150
+
+  const debouncedUpdateContainerHeight = () => {
+    if (resizeObserverDebounceTimer) {
+      clearTimeout(resizeObserverDebounceTimer)
+    }
+    resizeObserverDebounceTimer = setTimeout(() => {
+      updateContainerHeight()
+      resizeObserverDebounceTimer = null
+    }, RESIZE_OBSERVER_DEBOUNCE)
+  }
 
   const STICKY_THRESHOLD = 24
 
@@ -212,6 +249,8 @@ export function useAutoScroll() {
     if (!responseEl || !(responseEl instanceof Node)) return
 
     domObserver.value = new MutationObserver((mutations) => {
+      // Skip scroll adjustments during panel resize to avoid layout thrashing
+      if (_isResizing.value) return
       if (isTerminalToggleMutation(mutations, responseEl)) return
 
       if (shouldStickToBottom.value) {
@@ -243,7 +282,7 @@ export function useAutoScroll() {
       // so we guard it to avoid unhandled rejections during tests.
       if (chatContainer.value && typeof ResizeObserver !== 'undefined') {
         resizeObserver = new ResizeObserver(() => {
-          updateContainerHeight()
+          debouncedUpdateContainerHeight()
         })
         resizeObserver.observe(chatContainer.value)
       }
@@ -316,7 +355,7 @@ export function useAutoScroll() {
             // so we guard it to avoid unhandled rejections during tests.
             if (typeof ResizeObserver !== 'undefined') {
               resizeObserver = new ResizeObserver(() => {
-                updateContainerHeight()
+                debouncedUpdateContainerHeight()
               })
               resizeObserver.observe(container)
             }
@@ -325,6 +364,13 @@ export function useAutoScroll() {
       }
     }
   )
+
+  // When resize ends, do a single catch-up scroll if we should be at bottom
+  watch(_isResizing, (resizing) => {
+    if (!resizing && shouldStickToBottom.value) {
+      executeScroll()
+    }
+  })
 
   onUnmounted(() => {
     if (domObserver.value) {
@@ -338,6 +384,10 @@ export function useAutoScroll() {
     if (resizeObserver) {
       resizeObserver.disconnect()
       resizeObserver = null
+    }
+    if (resizeObserverDebounceTimer) {
+      clearTimeout(resizeObserverDebounceTimer)
+      resizeObserverDebounceTimer = null
     }
   })
 

--- a/src/renderer/src/views/components/AiTab/index.less
+++ b/src/renderer/src/views/components/AiTab/index.less
@@ -234,6 +234,14 @@
   width: 100%;
   min-width: 0;
 
+  .user-assistant-pair-message {
+    // Isolate layout/style calculations per message pair to reduce reflow cost during resize
+    contain: layout style;
+    // Enable browser-native content skipping for off-screen message pairs
+    content-visibility: auto;
+    contain-intrinsic-size: auto 200px;
+  }
+
   .message {
     display: inline-block;
     padding: 8px 12px;

--- a/src/renderer/src/views/layouts/TerminalLayout.vue
+++ b/src/renderer/src/views/layouts/TerminalLayout.vue
@@ -305,6 +305,7 @@ import { Pane, Splitpanes } from 'splitpanes'
 import 'splitpanes/dist/splitpanes.css'
 import AiTab from '@views/components/AiTab/index.vue'
 import { isImageFile } from '@views/components/AiTab/utils'
+import { signalResizeStart } from '@views/components/AiTab/composables/useAutoScroll'
 import Header from '@views/components/Header/index.vue'
 import LeftTab from '@views/components/LeftTab/index.vue'
 import Workspace from '@views/components/Workspace/index.vue'
@@ -1168,6 +1169,9 @@ const handleLeftPaneResize = (params: ResizeParams) => {
   if (isQuickClosing.value) {
     return
   }
+
+  // Signal resize to pause expensive chat observers
+  signalResizeStart()
 
   const container = document.querySelector('.left-sidebar-container') as HTMLElement
   const containerWidth = container ? container.offsetWidth : 1000
@@ -2072,6 +2076,9 @@ const onMainSplitResize = (params) => {
   if (isQuickClosing.value) {
     return
   }
+
+  // Signal resize to pause expensive chat observers
+  signalResizeStart()
 
   mainTerminalSize.value = params.prevPane.size
   if (showAiSidebar.value) {


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized layout rendering behavior during panel resizing operations to eliminate visual stuttering and improve overall responsiveness during interactions.
  * Enhanced message display rendering efficiency through improved browser rendering optimization techniques.
  * Reduced layout thrashing during resize operations to provide a smoother and more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->