### PR TITLE
feat: Enhance SkillsManager to recursively scan subdirectories for resource files

### DIFF
--- a/src/main/agent/services/skills/SkillsManager.ts
+++ b/src/main/agent/services/skills/SkillsManager.ts
@@ -230,50 +230,13 @@ export class SkillsManager {
   }
 
   /**
-   * Scan skill directory for resource files
+   * Scan skill directory for resource files (recursively includes subdirectories)
    */
   private async scanSkillResources(directory: string): Promise<SkillResource[]> {
     const resources: SkillResource[] = []
 
     try {
-      const entries = await fs.readdir(directory, { withFileTypes: true })
-
-      for (const entry of entries) {
-        // Skip ignored files and directories
-        if (IGNORED_RESOURCE_FILES.includes(entry.name)) {
-          continue
-        }
-
-        // Skip directories for now (could be extended to support nested resources)
-        if (entry.isDirectory()) {
-          continue
-        }
-
-        const filePath = path.join(directory, entry.name)
-        const stat = await fs.stat(filePath)
-        const ext = path.extname(entry.name).toLowerCase()
-
-        // Determine resource type
-        const type = RESOURCE_TYPE_MAP[ext] || 'other'
-
-        const resource: SkillResource = {
-          name: entry.name,
-          path: filePath,
-          type,
-          size: stat.size
-        }
-
-        // Auto-load content for small text files
-        if (stat.size <= MAX_RESOURCE_AUTO_LOAD_SIZE && this.isTextFile(ext)) {
-          try {
-            resource.content = await fs.readFile(filePath, 'utf-8')
-          } catch {
-            // Ignore read errors, content will be undefined
-          }
-        }
-
-        resources.push(resource)
-      }
+      await this.scanSkillResourcesRecursive(directory, directory, resources)
 
       if (resources.length > 0) {
         logger.debug(`[SkillsManager] Found ${resources.length} resource files in ${directory}`)
@@ -283,6 +246,55 @@ export class SkillsManager {
     }
 
     return resources
+  }
+
+  /**
+   * Recursively scan a directory for resource files
+   */
+  private async scanSkillResourcesRecursive(rootDir: string, currentDir: string, resources: SkillResource[]): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      // Skip ignored files and directories
+      if (IGNORED_RESOURCE_FILES.includes(entry.name)) {
+        continue
+      }
+
+      const filePath = path.join(currentDir, entry.name)
+
+      if (entry.isDirectory()) {
+        // Recursively scan subdirectories (e.g., references/, scripts/)
+        await this.scanSkillResourcesRecursive(rootDir, filePath, resources)
+        continue
+      }
+
+      const stat = await fs.stat(filePath)
+      const ext = path.extname(entry.name).toLowerCase()
+
+      // Determine resource type
+      const type = RESOURCE_TYPE_MAP[ext] || 'other'
+
+      // Use relative path from skill root directory as resource name
+      const relativeName = path.relative(rootDir, filePath)
+
+      const resource: SkillResource = {
+        name: relativeName,
+        path: filePath,
+        type,
+        size: stat.size
+      }
+
+      // Auto-load content for small text files
+      if (stat.size <= MAX_RESOURCE_AUTO_LOAD_SIZE && this.isTextFile(ext)) {
+        try {
+          resource.content = await fs.readFile(filePath, 'utf-8')
+        } catch {
+          // Ignore read errors, content will be undefined
+        }
+      }
+
+      resources.push(resource)
+    }
   }
 
   /**

--- a/src/main/agent/services/skills/__tests__/SkillsManager.test.ts
+++ b/src/main/agent/services/skills/__tests__/SkillsManager.test.ts
@@ -234,6 +234,66 @@ describe('SkillsManager', () => {
       expect(configResource).toBeDefined()
       expect(configResource!.type).toBe('config')
     })
+
+    it('should recursively scan subdirectories for resource files', async () => {
+      const skillContent = createSkillMdContent('Nested Skill', 'A skill with nested resources')
+
+      setupMemfs({
+        '/tmp/skills/nested-skill/SKILL.md': skillContent,
+        '/tmp/skills/nested-skill/script.sh': '#!/bin/bash\necho "Root"',
+        '/tmp/skills/nested-skill/references/cluster.yaml': 'apiVersion: v1\nkind: Config',
+        '/tmp/skills/nested-skill/references/deploy.json': '{"replicas": 3}',
+        '/tmp/skills/nested-skill/scripts/setup.py': 'print("setup")'
+      })
+
+      const result = await skillsManager.parseSkillFile('/tmp/skills/nested-skill/SKILL.md')
+
+      expect(result.success).toBe(true)
+      expect(result.skill!.resources).toBeDefined()
+      expect(result.skill!.resources!.length).toBe(4)
+
+      // Root-level file should use bare filename
+      const scriptResource = result.skill!.resources!.find((r) => r.name === 'script.sh')
+      expect(scriptResource).toBeDefined()
+      expect(scriptResource!.type).toBe('script')
+      expect(scriptResource!.content).toBe('#!/bin/bash\necho "Root"')
+
+      // Files in references/ subdirectory should use relative path as name
+      const yamlResource = result.skill!.resources!.find((r) => r.name === path.join('references', 'cluster.yaml'))
+      expect(yamlResource).toBeDefined()
+      expect(yamlResource!.type).toBe('config')
+      expect(yamlResource!.content).toBe('apiVersion: v1\nkind: Config')
+
+      const jsonResource = result.skill!.resources!.find((r) => r.name === path.join('references', 'deploy.json'))
+      expect(jsonResource).toBeDefined()
+      expect(jsonResource!.type).toBe('config')
+      expect(jsonResource!.content).toBe('{"replicas": 3}')
+
+      // Files in scripts/ subdirectory
+      const pyResource = result.skill!.resources!.find((r) => r.name === path.join('scripts', 'setup.py'))
+      expect(pyResource).toBeDefined()
+      expect(pyResource!.type).toBe('script')
+      expect(pyResource!.content).toBe('print("setup")')
+    })
+
+    it('should skip ignored directories during recursive scan', async () => {
+      const skillContent = createSkillMdContent('Ignore Dirs', 'Skill with ignored dirs')
+
+      setupMemfs({
+        '/tmp/skills/ignore-dirs/SKILL.md': skillContent,
+        '/tmp/skills/ignore-dirs/references/data.yaml': 'key: value',
+        '/tmp/skills/ignore-dirs/node_modules/pkg/index.js': 'module.exports = {}',
+        '/tmp/skills/ignore-dirs/.git/config': '[core]'
+      })
+
+      const result = await skillsManager.parseSkillFile('/tmp/skills/ignore-dirs/SKILL.md')
+
+      expect(result.success).toBe(true)
+      expect(result.skill!.resources).toBeDefined()
+      // Only references/data.yaml should be included; node_modules and .git should be ignored
+      expect(result.skill!.resources!.length).toBe(1)
+      expect(result.skill!.resources![0].name).toBe(path.join('references', 'data.yaml'))
+    })
   })
 
   describe('buildSkillsPrompt', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now recursively scan for resources in nested directories while properly excluding ignored directories.
* **Tests**
  * Added tests verifying recursive resource scanning and directory exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->