### PR TITLE
fix(agent): normalize tool_result JSON handling

### DIFF
--- a/src/main/agent/core/task/__tests__/api-conversation-history.integration.test.ts
+++ b/src/main/agent/core/task/__tests__/api-conversation-history.integration.test.ts
@@ -61,6 +61,7 @@ vi.mock('@core/storage/disk', () => ({
   saveTaskMetadata: vi.fn(async () => undefined)
 }))
 
+import { Anthropic } from '@anthropic-ai/sdk'
 import { Task } from '../index'
 import { getApiConversationHistoryLogic, saveApiConversationHistoryLogic } from '../../../../storage/db/chaterm/agent'
 
@@ -186,6 +187,43 @@ describe('Bug 1: conversationHistoryIndex points to wrong message', () => {
   })
 })
 
+describe('Tool result normalization with JSON content', () => {
+  it('normalizeToolResultsForApi should flatten JSON-encoded tool_result content into text', async () => {
+    const task = Object.create((Task as unknown as { prototype: object }).prototype) as any
+    task.normalizeToolResultsForApi = Task.prototype['normalizeToolResultsForApi'].bind(task)
+
+    const toolResult = {
+      toolName: 'execute_command',
+      toolDescription: '[execute_command for \"ls\"]',
+      taskId: 'test-task',
+      timestamp: Date.now(),
+      result: 'ls output here'
+    }
+
+    const conversationHistory: Anthropic.MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: JSON.stringify(toolResult),
+            is_error: false
+          } as any
+        ]
+      }
+    ]
+
+    const normalized = task.normalizeToolResultsForApi(conversationHistory)
+    expect(normalized).toHaveLength(1)
+    expect(Array.isArray(normalized[0].content)).toBe(true)
+
+    const block = normalized[0].content![0] as Anthropic.TextBlockParam
+    expect(block.type).toBe('text')
+    expect(block.text).toContain('ls output here')
+  })
+})
+
 describe('Bug 2: apiConversationHistory flattening on save/restore', () => {
   /**
    * This test uses a mock database to verify save/restore logic
@@ -258,7 +296,7 @@ describe('Bug 2: apiConversationHistory flattening on save/restore', () => {
   })
 
   it('Bug2: save then load should preserve message count', async () => {
-    const originalHistory = [
+    const originalHistory: Anthropic.MessageParam[] = [
       {
         role: 'user',
         content: [
@@ -294,7 +332,7 @@ describe('Bug 2: apiConversationHistory flattening on save/restore', () => {
   })
 
   it('Bug2: save then load should preserve content structure per message', async () => {
-    const originalHistory = [
+    const originalHistory: Anthropic.MessageParam[] = [
       {
         role: 'user',
         content: [
@@ -320,7 +358,7 @@ describe('Bug 2: apiConversationHistory flattening on save/restore', () => {
   })
 
   it('Bug2: save then load should preserve conversationHistoryIndex mapping', async () => {
-    const originalHistory = [
+    const originalHistory: Anthropic.MessageParam[] = [
       {
         role: 'user',
         content: [
@@ -354,5 +392,40 @@ describe('Bug 2: apiConversationHistory flattening on save/restore', () => {
 
     // With fix: index 3 still points to assistant message
     expect(restoredHistory[chatermMessage.conversationHistoryIndex].role).toBe('assistant')
+  })
+
+  it('should persist ephemeral tool_result content as (expired)', async () => {
+    const originalHistory: Anthropic.MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            // Use any here to allow extended ToolResult payload for testing
+            content: JSON.stringify({ ephemeral: true, result: '(expired)' }) as any,
+            is_error: false
+          } as any
+        ]
+      }
+    ]
+
+    const db = createMockDb()
+
+    await saveApiConversationHistoryLogic(db as never, taskId, originalHistory)
+
+    const toolResultRow = mockDbRows.find((r) => r.content_type === 'tool_result')
+    expect(toolResultRow).toBeTruthy()
+    const contentData = JSON.parse(toolResultRow!.content_data)
+    const raw = contentData.content
+
+    if (typeof raw === 'string') {
+      const parsed = JSON.parse(raw)
+      expect(typeof parsed).toBe('object')
+      expect(parsed.result).toBe('(expired)')
+    } else {
+      expect(typeof raw).toBe('object')
+      expect(raw.result).toBe('(expired)')
+    }
   })
 })

--- a/src/main/agent/core/task/index.ts
+++ b/src/main/agent/core/task/index.ts
@@ -606,13 +606,13 @@ export class Task {
     for (const result of this.pendingToolResults) {
       const isError = result.isError ?? false
 
-      const toolResultBlock: any = {
+      const toolResultBlock: Anthropic.ToolResultBlockParam = {
         type: 'tool_result',
-        tool_use_id: undefined,
+        tool_use_id: `${result.taskId}`,
         // Directly store the structured ToolResult payload in content.
         // Downstream provider adapters will see only text because
         // normalizeToolResultsForApi() flattens these blocks before sending.
-        content: [result],
+        content: JSON.stringify(result),
         is_error: isError
       }
 
@@ -626,9 +626,24 @@ export class Task {
   }
 
   /**
-   * Transform file_ref content blocks to text blocks with metadata
-   * This ensures API compatibility while preserving file reference information
+   * Parse a tool_result.content payload (JSON string or plain object)
+   * into a single ToolResult object.
    */
+  private parseToolResultContent(raw: string): ToolResult | null {
+    if (raw === undefined || raw === null) {
+      return null
+    }
+    let value: ToolResult
+    try {
+      value = JSON.parse(raw)
+    } catch (error) {
+      logger.warn('[parseToolResultContent] Failed to parse tool_result content as JSON', { error })
+      return null
+    }
+
+    return value
+  }
+
   private normalizeToolResultsForApi(conversationHistory: Anthropic.MessageParam[]): Anthropic.MessageParam[] {
     return conversationHistory.map((message) => {
       if (!Array.isArray(message.content)) {
@@ -636,13 +651,10 @@ export class Task {
       }
 
       const transformedContent = message.content.map((block) => {
-        const anyBlock = block as any
-
         // New V2: tool_result blocks contain structured ToolResult payloads.
         // Before sending to the provider, we flatten these into plain text so
         // that downstream adapters only see supported block types.
-        if (anyBlock.type === 'tool_result') {
-          const toolResult = anyBlock
+        if (block.type === 'tool_result') {
           const lines: string[] = []
 
           const addFromToolResult = (tr: ToolResult) => {
@@ -676,12 +688,11 @@ export class Task {
             }
           }
 
-          if (Array.isArray(toolResult.content)) {
-            for (const tr of toolResult.content as ToolResult[]) {
-              addFromToolResult(tr)
+          if (typeof block.content === 'string') {
+            const toolResult = this.parseToolResultContent(block.content)
+            if (toolResult) {
+              addFromToolResult(toolResult)
             }
-          } else if (toolResult.content) {
-            addFromToolResult(toolResult.content as ToolResult)
           }
 
           return {
@@ -1373,6 +1384,7 @@ export class Task {
     await this.overwriteChatermMessages(modifiedChatermMessages)
     this.chatermMessages = await getChatermMessages(this.taskId)
     this.apiConversationHistory = await getSavedApiConversationHistory(this.taskId)
+    await this.clearEphemeralToolResults()
     await this.contextManager.initializeContextHistory(this.taskId)
 
     // Restore conversationHistoryDeletedRange from the latest message that carries it.
@@ -2790,6 +2802,34 @@ export class Task {
     }
   }
 
+  private async clearEphemeralToolResults(): Promise<void> {
+    let didChange = false
+
+    for (const message of this.apiConversationHistory) {
+      if (!Array.isArray(message?.content)) continue
+      for (const block of message.content) {
+        if (!block || block.type !== 'tool_result' || typeof block.content !== 'string') continue
+
+        const toolResult = this.parseToolResultContent(block.content)
+        const hasEphemeral = toolResult && toolResult.ephemeral === true
+
+        if (!hasEphemeral) continue
+
+        const updated: ToolResult = {
+          ...toolResult,
+          result: '(expired)'
+        }
+
+        block.content = JSON.stringify(updated)
+        didChange = true
+      }
+    }
+
+    if (didChange) {
+      await saveApiConversationHistory(this.taskId, this.apiConversationHistory)
+    }
+  }
+
   private async pushAdditionalToolFeedback(feedback?: string): Promise<void> {
     if (!feedback) return
     const normalizedFeedback = this.truncateCommandOutput(feedback)
@@ -2989,6 +3029,8 @@ export class Task {
         await addNewChangesFlagToLastCompletionResultMessage()
         telemetryService.captureTaskCompleted(this.taskId)
       }
+
+      await this.clearEphemeralToolResults()
 
       const { response, text, contentParts } = await this.ask('completion_result', '', false)
       if (response === 'yesButtonClicked') {

--- a/src/main/agent/integrations/misc/__tests__/export-markdown.test.ts
+++ b/src/main/agent/integrations/misc/__tests__/export-markdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { Anthropic } from '@anthropic-ai/sdk'
+import { formatContentBlockToMarkdown } from '../export-markdown'
+
+describe('formatContentBlockToMarkdown - tool_result with JSON string content', () => {
+  it('should extract result text from JSON-encoded ToolResult', () => {
+    const toolResult = {
+      toolName: 'execute_command',
+      toolDescription: '[execute_command for "ls"]',
+      ip: '127.0.0.1',
+      result: 'ls output here'
+    }
+
+    const block: Anthropic.ToolResultBlockParam = {
+      type: 'tool_result',
+      tool_use_id: 'tool-1',
+      content: JSON.stringify(toolResult),
+      is_error: false
+    }
+
+    const markdown = formatContentBlockToMarkdown(block as Anthropic.ContentBlockParam)
+
+    expect(markdown).toContain('execute_command')
+    expect(markdown).toContain('ls output here')
+  })
+
+  it('should fall back to raw string when JSON is invalid', () => {
+    const raw = '{not-valid-json'
+    const block: Anthropic.ToolResultBlockParam = {
+      type: 'tool_result',
+      tool_use_id: 'tool-1',
+      content: raw,
+      is_error: false
+    }
+
+    const markdown = formatContentBlockToMarkdown(block as Anthropic.ContentBlockParam)
+
+    expect(markdown).toContain(raw)
+  })
+})

--- a/src/main/agent/integrations/misc/export-markdown.ts
+++ b/src/main/agent/integrations/misc/export-markdown.ts
@@ -6,6 +6,55 @@
 
 import { Anthropic } from '@anthropic-ai/sdk'
 
+function formatToolResultJsonContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw)
+
+    const formatSingle = (tr: any): string | null => {
+      if (!tr || typeof tr !== 'object') return null
+
+      const parts: string[] = []
+
+      if (typeof tr.toolDescription === 'string' && tr.toolDescription.length > 0) {
+        parts.push(tr.toolDescription)
+      } else if (typeof tr.toolName === 'string' && tr.toolName.length > 0) {
+        parts.push(tr.toolName)
+      }
+
+      if (typeof tr.ip === 'string' && tr.ip.length > 0) {
+        parts.push(`on ${tr.ip}`)
+      }
+
+      if (typeof tr.result === 'string' && tr.result.length > 0) {
+        parts.push(tr.result)
+      }
+
+      if (parts.length === 0) {
+        return null
+      }
+
+      return parts.join(' - ')
+    }
+
+    if (Array.isArray(parsed)) {
+      const lines = parsed.map((item) => formatSingle(item)).filter((line): line is string => typeof line === 'string' && line.length > 0)
+
+      if (lines.length > 0) {
+        return lines.join('\n')
+      }
+    } else {
+      const line = formatSingle(parsed)
+      if (line) {
+        return line
+      }
+    }
+  } catch {
+    // Fallback to raw string when JSON parsing fails
+  }
+
+  return raw
+}
+
 export function formatContentBlockToMarkdown(block: Anthropic.ContentBlockParam): string {
   switch (block.type) {
     case 'text':
@@ -26,14 +75,15 @@ export function formatContentBlockToMarkdown(block: Anthropic.ContentBlockParam)
       return `[Tool Use: ${block.name}]\n${input}`
     case 'tool_result':
       if (typeof block.content === 'string') {
-        return `[Tool${block.is_error ? ' (Error)' : ''}]\n${block.content}`
-      } else if (Array.isArray(block.content)) {
+        const body = formatToolResultJsonContent(block.content)
+        return `[Tool${block.is_error ? ' (Error)' : ''}]\n${body}`
+      }
+      if (Array.isArray(block.content)) {
         return `[Tool${block.is_error ? ' (Error)' : ''}]\n${block.content
           .map((contentBlock) => formatContentBlockToMarkdown(contentBlock))
           .join('\n')}`
-      } else {
-        return `[Tool${block.is_error ? ' (Error)' : ''}]`
       }
+      return `[Tool${block.is_error ? ' (Error)' : ''}]`
     default:
       return '[Unexpected content type]'
   }

--- a/src/main/storage/db/chaterm.service.ts
+++ b/src/main/storage/db/chaterm.service.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3'
+import type { Anthropic } from '@anthropic-ai/sdk'
 import { initChatermDatabase, getCurrentUserId } from './connection'
 import {
   getLocalAssetRouteLogic,
@@ -196,7 +197,7 @@ export class ChatermDatabaseService {
     return getApiConversationHistoryLogic(this.db, taskId)
   }
 
-  async saveApiConversationHistory(taskId: string, apiConversationHistory: any[]): Promise<void> {
+  async saveApiConversationHistory(taskId: string, apiConversationHistory: Anthropic.MessageParam[]): Promise<void> {
     return saveApiConversationHistoryLogic(this.db, taskId, apiConversationHistory)
   }
 


### PR DESCRIPTION
fix(agent): normalize tool_result JSON handling
Ensure tool_result blocks store ToolResult payloads as JSON strings,
normalize them to plain text for Anthropic API and markdown export,
and persist ephemeral tool results as '(expired)' when restoring history
or completing a task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ephemeral tool results now automatically expire after use and are marked as outdated in the system.
  * Enhanced formatting for tool results when exporting conversations to markdown files.

* **Bug Fixes**
  * Improved tool result content parsing with more robust error handling and validation.

* **Tests**
  * Added comprehensive tests for tool result normalization and ephemeral content persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->