### PR TITLE
fix(editableContent): add command popup trigger for standalone slashes

### DIFF
--- a/src/renderer/src/views/components/AiTab/composables/__tests__/useEditableContent.test.ts
+++ b/src/renderer/src/views/components/AiTab/composables/__tests__/useEditableContent.test.ts
@@ -336,7 +336,7 @@ describe('useEditableContent', () => {
       const { editableRef, handleEditableKeyDown } = setup({ handleShowCommandPopup })
       const el = editableRef.value as HTMLDivElement
       document.body.appendChild(el)
-      el.textContent = 'hello'
+      el.textContent = 'hello '
 
       const textNode = el.firstChild as Text
       const range = document.createRange()
@@ -348,7 +348,7 @@ describe('useEditableContent', () => {
 
       // Keydown reports '/', then browser inserts '/' before the scheduled handler runs.
       handleEditableKeyDown({ key: '/', shiftKey: false, isComposing: false } as unknown as KeyboardEvent, 'create')
-      textNode.data = 'hello/'
+      textNode.data = 'hello /'
       range.setStart(textNode, textNode.data.length)
       range.collapse(true)
       selection?.removeAllRanges()
@@ -390,6 +390,86 @@ describe('useEditableContent', () => {
       expect(handleShowCommandPopup).not.toHaveBeenCalled()
 
       el.remove()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('command popup slash trigger', () => {
+    const setupSlash = (initialText: string, caretOffset: number) => {
+      const handleShowCommandPopup = vi.fn()
+      const { editableRef, handleEditableKeyDown } = setup({ handleShowCommandPopup })
+      const el = editableRef.value as HTMLDivElement
+      el.textContent = ''
+      const textNode = document.createTextNode(initialText)
+      el.appendChild(textNode)
+      document.body.appendChild(el)
+
+      const selection = window.getSelection()
+      const range = document.createRange()
+      if (!selection) {
+        throw new Error('Selection or text node not available in test environment')
+      }
+      const safeOffset = Math.max(0, Math.min(caretOffset, textNode.data.length))
+      range.setStart(textNode, safeOffset)
+      range.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(range)
+
+      return { el, textNode, selection, range, handleShowCommandPopup, handleEditableKeyDown }
+    }
+
+    const insertSlashAtCaret = (textNode: Text, selection: Selection) => {
+      const r = selection.getRangeAt(0)
+      const offset = r.startOffset
+      textNode.data = textNode.data.slice(0, offset) + '/' + textNode.data.slice(offset)
+      const newRange = document.createRange()
+      newRange.setStart(textNode, offset + 1)
+      newRange.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(newRange)
+    }
+
+    it('should trigger popup only when slash is surrounded by whitespace or boundaries', () => {
+      vi.useFakeTimers()
+
+      const okCases: Array<{ text: string; caretOffset: number }> = [
+        { text: '', caretOffset: 0 }, // "/" at start/end
+        { text: ' ', caretOffset: 1 }, // " /" (before is space, after is boundary)
+        { text: 'a ', caretOffset: 2 }, // "a /" (before is space, after is boundary)
+        { text: 'a  b', caretOffset: 2 } // "a / b" (between two spaces)
+      ]
+      for (const c of okCases) {
+        const { el, textNode, selection, handleShowCommandPopup, handleEditableKeyDown } = setupSlash(c.text, c.caretOffset)
+        const event = { key: '/', isComposing: false } as unknown as KeyboardEvent
+        handleEditableKeyDown(event)
+        insertSlashAtCaret(textNode, selection)
+        vi.runAllTimers()
+        expect(handleShowCommandPopup).toHaveBeenCalledTimes(1)
+        el.remove()
+      }
+
+      vi.useRealTimers()
+    })
+
+    it('should not trigger popup when slash is part of a path token', () => {
+      vi.useFakeTimers()
+
+      const badCases: Array<{ text: string; caretOffset: number }> = [
+        { text: 'Users', caretOffset: 0 }, // "/Users" (after is 'U')
+        { text: 'cd Users', caretOffset: 3 }, // "cd /Users" (after is 'U')
+        { text: 'a', caretOffset: 1 }, // "a/" (before is 'a')
+        { text: 'ab', caretOffset: 1 } // "a/b" (after is 'b')
+      ]
+      for (const c of badCases) {
+        const { el, textNode, selection, handleShowCommandPopup, handleEditableKeyDown } = setupSlash(c.text, c.caretOffset)
+        const event = { key: '/', isComposing: false } as unknown as KeyboardEvent
+        handleEditableKeyDown(event)
+        insertSlashAtCaret(textNode, selection)
+        vi.runAllTimers()
+        expect(handleShowCommandPopup).toHaveBeenCalledTimes(0)
+        el.remove()
+      }
+
       vi.useRealTimers()
     })
   })

--- a/src/renderer/src/views/components/AiTab/composables/useEditableContent.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useEditableContent.ts
@@ -144,6 +144,36 @@ export function useEditableContent(options: UseEditableContentOptions) {
     return null
   }
 
+  /**
+   * Determine whether a slash just inserted before the caret should trigger the command popup.
+   * We only trigger when the slash is a standalone token: both sides are whitespace or boundaries.
+   *
+   * Note: This is intentionally conservative; if we cannot reliably inspect neighbors, do not trigger.
+   */
+  const shouldTriggerCommandPopupForSlash = (): boolean => {
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0) return false
+
+    const range = selection.getRangeAt(0)
+    const editableEl = editableRef.value
+    if (!editableEl || !editableEl.contains(range.startContainer)) return false
+
+    if (range.startContainer.nodeType !== Node.TEXT_NODE) return false
+    const textNode = range.startContainer as Text
+    const text = textNode.data
+    const offset = range.startOffset
+
+    // Caret should be positioned right after the inserted '/'.
+    if (offset <= 0 || offset > text.length) return false
+    if (text[offset - 1] !== '/') return false
+
+    const beforeChar = offset - 2 >= 0 ? text[offset - 2] : null
+    const afterChar = offset < text.length ? text[offset] : null
+
+    const isBoundaryOrWs = (ch: string | null) => ch === null || /\s/.test(ch)
+    return isBoundaryOrWs(beforeChar) && isBoundaryOrWs(afterChar)
+  }
+
   // ============================================================================
   // Selection Management
   // ============================================================================
@@ -695,6 +725,7 @@ export function useEditableContent(options: UseEditableContentOptions) {
       setTimeout(() => {
         // Only open when actual '/' was inserted (IME may insert '、' etc. for the same key).
         if (getCharBeforeCaret() !== '/') return
+        if (!shouldTriggerCommandPopupForSlash()) return
         saveSelection()
         handleShowCommandPopup(editableRef.value)
       }, 0)


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced slash (/) command detection to trigger the command popup only when slashes are properly delimited by whitespace or text boundaries. This prevents unwanted popup activation in contexts like file paths, ensuring the command feature works more intuitively when typing actual commands versus using slashes in other text patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->