### PR TITLE
chore: Update model configuration tests to reflect new model names and IDs for Anthropic and OpenAI providers

### DIFF
--- a/src/renderer/src/views/components/AiTab/composables/__tests__/useModelConfiguration.test.ts
+++ b/src/renderer/src/views/components/AiTab/composables/__tests__/useModelConfiguration.test.ts
@@ -31,9 +31,9 @@ vi.mock('../useSessionState', () => ({
 
 describe('useModelConfiguration', () => {
   const mockModelOptions = [
-    { id: '1', name: 'claude-3-5-sonnet', checked: true, type: 'chat', apiProvider: 'anthropic' },
-    { id: '2', name: 'gpt-4', checked: true, type: 'chat', apiProvider: 'openai' },
-    { id: '3', name: 'claude-3-opus', checked: false, type: 'chat', apiProvider: 'anthropic' },
+    { id: '1', name: 'claude-4-5-sonnet', checked: true, type: 'chat', apiProvider: 'anthropic' },
+    { id: '2', name: 'gpt-5', checked: true, type: 'chat', apiProvider: 'openai' },
+    { id: '3', name: 'claude-4-opus', checked: false, type: 'chat', apiProvider: 'anthropic' },
     { id: '4', name: 'deepseek-chat', checked: true, type: 'chat', apiProvider: 'deepseek' }
   ]
 
@@ -47,7 +47,7 @@ describe('useModelConfiguration', () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return mockModelOptions
         if (key === 'apiProvider') return 'anthropic'
-        if (key === 'defaultModelId') return 'claude-3-5-sonnet'
+        if (key === 'defaultModelId') return 'claude-4-5-sonnet'
         return null
       })
 
@@ -55,45 +55,45 @@ describe('useModelConfiguration', () => {
       await initModel()
 
       expect(AgentAiModelsOptions.value).toHaveLength(3) // Only checked models
-      expect(AgentAiModelsOptions.value[0].label).toBe('claude-3-5-sonnet')
+      expect(AgentAiModelsOptions.value[0].label).toBe('claude-4-5-sonnet')
       expect(AgentAiModelsOptions.value[1].label).toBe('deepseek-chat')
-      expect(AgentAiModelsOptions.value[2].label).toBe('gpt-4')
+      expect(AgentAiModelsOptions.value[2].label).toBe('gpt-5')
     })
 
     it('should filter out unchecked models', async () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return mockModelOptions
         if (key === 'apiProvider') return 'anthropic'
-        if (key === 'defaultModelId') return 'claude-3-5-sonnet'
+        if (key === 'defaultModelId') return 'claude-4-5-sonnet'
         return null
       })
 
       const { initModel, AgentAiModelsOptions } = useModelConfiguration()
       await initModel()
 
-      const hasUncheckedModel = AgentAiModelsOptions.value.some((option) => option.label === 'claude-3-opus')
+      const hasUncheckedModel = AgentAiModelsOptions.value.some((option) => option.label === 'claude-4-opus')
       expect(hasUncheckedModel).toBe(false)
     })
 
-    it('should use default model when current model is not set', async () => {
+    it('should use provider-specific model when current model is not set', async () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return mockModelOptions
         if (key === 'apiProvider') return 'anthropic'
-        if (key === 'defaultModelId') return 'claude-3-5-sonnet'
+        if (key === 'anthropicModelId') return 'claude-4-5-sonnet'
         return null
       })
 
       const { initModel } = useModelConfiguration()
       await initModel()
 
-      expect(stateModule.getGlobalState).toHaveBeenCalledWith('defaultModelId')
+      expect(stateModule.getGlobalState).toHaveBeenCalledWith('anthropicModelId')
     })
 
     it('should use provider-specific model key based on apiProvider', async () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return mockModelOptions
         if (key === 'apiProvider') return 'openai'
-        if (key === 'openAiModelId') return 'gpt-4'
+        if (key === 'openAiModelId') return 'gpt-5'
         return null
       })
 
@@ -107,7 +107,7 @@ describe('useModelConfiguration', () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return mockModelOptions
         if (key === 'apiProvider') return 'bedrock'
-        if (key === 'apiModelId') return 'claude-3-5-sonnet'
+        if (key === 'apiModelId') return 'claude-4-5-sonnet'
         return null
       })
 
@@ -119,15 +119,15 @@ describe('useModelConfiguration', () => {
 
     it('should sort thinking models first', async () => {
       const modelsWithThinking = [
-        { id: '1', name: 'claude-3-5-sonnet', checked: true, type: 'chat', apiProvider: 'anthropic' },
-        { id: '2', name: 'gpt-4-Thinking', checked: true, type: 'chat', apiProvider: 'openai' },
-        { id: '3', name: 'claude-3-opus-Thinking', checked: true, type: 'chat', apiProvider: 'anthropic' }
+        { id: '1', name: 'claude-4-5-sonnet', checked: true, type: 'chat', apiProvider: 'anthropic' },
+        { id: '2', name: 'gpt-5-Thinking', checked: true, type: 'chat', apiProvider: 'openai' },
+        { id: '3', name: 'claude-4-opus-Thinking', checked: true, type: 'chat', apiProvider: 'anthropic' }
       ]
 
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return modelsWithThinking
         if (key === 'apiProvider') return 'anthropic'
-        if (key === 'defaultModelId') return 'claude-3-5-sonnet'
+        if (key === 'defaultModelId') return 'claude-4-5-sonnet'
         return null
       })
 
@@ -135,9 +135,9 @@ describe('useModelConfiguration', () => {
       await initModel()
 
       // Thinking models should come first
-      expect(AgentAiModelsOptions.value[0].label).toBe('claude-3-opus-Thinking')
-      expect(AgentAiModelsOptions.value[1].label).toBe('gpt-4-Thinking')
-      expect(AgentAiModelsOptions.value[2].label).toBe('claude-3-5-sonnet')
+      expect(AgentAiModelsOptions.value[0].label).toBe('claude-4-opus-Thinking')
+      expect(AgentAiModelsOptions.value[1].label).toBe('gpt-5-Thinking')
+      expect(AgentAiModelsOptions.value[2].label).toBe('claude-4-5-sonnet')
     })
 
     it('should prefer current tab model when it is still available', async () => {
@@ -146,15 +146,15 @@ describe('useModelConfiguration', () => {
         return null
       })
 
-      mockChatAiModelValue.value = 'gpt-4'
+      mockChatAiModelValue.value = 'gpt-5'
 
       const { initModel } = useModelConfiguration()
       await initModel()
 
-      expect(mockChatAiModelValue.value).toBe('gpt-4')
+      expect(mockChatAiModelValue.value).toBe('gpt-5')
       expect(stateModule.getGlobalState).not.toHaveBeenCalledWith('apiProvider')
       expect(stateModule.updateGlobalState).toHaveBeenCalledWith('apiProvider', 'openai')
-      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('openAiModelId', 'gpt-4')
+      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('openAiModelId', 'gpt-5')
     })
 
     it('should fallback to first available model when stored default model is not available', async () => {
@@ -168,13 +168,13 @@ describe('useModelConfiguration', () => {
       const { initModel } = useModelConfiguration()
       await initModel()
 
-      expect(mockChatAiModelValue.value).toBe('claude-3-5-sonnet')
+      expect(mockChatAiModelValue.value).toBe('claude-4-5-sonnet')
       expect(stateModule.updateGlobalState).toHaveBeenCalledWith('apiProvider', 'anthropic')
-      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('defaultModelId', 'claude-3-5-sonnet')
+      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('anthropicModelId', 'claude-4-5-sonnet')
     })
 
     it('should not change model when there are no available models', async () => {
-      const noAvailableModels = [{ id: '1', name: 'claude-3-5-sonnet', checked: false, type: 'chat', apiProvider: 'anthropic' }]
+      const noAvailableModels = [{ id: '1', name: 'claude-4-5-sonnet', checked: false, type: 'chat', apiProvider: 'anthropic' }]
 
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return noAvailableModels
@@ -206,7 +206,7 @@ describe('useModelConfiguration', () => {
     it('should fetch and save model options when none exist', async () => {
       const mockGetUser = vi.fn().mockResolvedValue({
         data: {
-          models: ['claude-3-5-sonnet', 'gpt-4'],
+          models: ['claude-4-5-sonnet', 'gpt-5'],
           llmGatewayAddr: 'https://api.example.com',
           key: 'test-key'
         }
@@ -240,7 +240,7 @@ describe('useModelConfiguration', () => {
         return null
       })
 
-      mockChatAiModelValue.value = 'gpt-4'
+      mockChatAiModelValue.value = 'gpt-5'
       const { handleChatAiModelChange } = useModelConfiguration()
 
       await handleChatAiModelChange()
@@ -254,12 +254,12 @@ describe('useModelConfiguration', () => {
         return null
       })
 
-      mockChatAiModelValue.value = 'gpt-4'
+      mockChatAiModelValue.value = 'gpt-5'
       const { handleChatAiModelChange } = useModelConfiguration()
 
       await handleChatAiModelChange()
 
-      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('openAiModelId', 'gpt-4')
+      expect(stateModule.updateGlobalState).toHaveBeenCalledWith('openAiModelId', 'gpt-5')
     })
 
     it('should handle deepseek provider model key', async () => {
@@ -281,9 +281,14 @@ describe('useModelConfiguration', () => {
     it('should validate model configuration', async () => {
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'apiProvider') return 'anthropic'
-        if (key === 'defaultModelId') return 'claude-3-5-sonnet'
+        if (key === 'anthropicModelId') return 'claude-4-5-sonnet'
         if (key === 'modelOptions') return [{ id: '1', name: 'test', checked: true, type: 'standard', apiProvider: 'default' }]
         return null
+      })
+
+      vi.mocked(stateModule.getSecret).mockImplementation(async (key) => {
+        if (key === 'anthropicApiKey') return 'test-key'
+        return undefined
       })
 
       const { checkModelConfig } = useModelConfiguration()
@@ -313,15 +318,15 @@ describe('useModelConfiguration', () => {
       localStorage.removeItem('login-skipped')
 
       const existing = [
-        { id: 's1', name: 'gpt-4', checked: false, type: 'standard', apiProvider: 'default' },
+        { id: 's1', name: 'gpt-5', checked: false, type: 'standard', apiProvider: 'default' },
         { id: 'c1', name: 'custom-x', checked: true, type: 'custom', apiProvider: 'openai' },
         { id: 's2', name: 'old-standard', checked: true, type: 'standard', apiProvider: 'default' }
       ]
 
       // Expected order: retained standard, new standard, then custom
       const mergedOptions = [
-        { id: 's1', name: 'gpt-4', checked: false, type: 'standard', apiProvider: 'default' },
-        { id: 'claude-3', name: 'claude-3', checked: true, type: 'standard', apiProvider: 'default' },
+        { id: 's1', name: 'gpt-5', checked: false, type: 'standard', apiProvider: 'default' },
+        { id: 'claude-4', name: 'claude-4', checked: true, type: 'standard', apiProvider: 'default' },
         { id: 'c1', name: 'custom-x', checked: true, type: 'custom', apiProvider: 'openai' }
       ]
 
@@ -339,7 +344,7 @@ describe('useModelConfiguration', () => {
 
       vi.mocked(getUser).mockResolvedValue({
         data: {
-          models: ['gpt-4', 'claude-3'],
+          models: ['gpt-5', 'claude-4'],
           llmGatewayAddr: 'https://api.example.com',
           key: 'server-key'
         }
@@ -350,14 +355,14 @@ describe('useModelConfiguration', () => {
 
       // Verify order: retained standard, new standard, then custom
       expect(stateModule.updateGlobalState).toHaveBeenCalledWith('modelOptions', [
-        { id: 's1', name: 'gpt-4', checked: false, type: 'standard', apiProvider: 'default' },
-        { id: 'claude-3', name: 'claude-3', checked: true, type: 'standard', apiProvider: 'default' },
+        { id: 's1', name: 'gpt-5', checked: false, type: 'standard', apiProvider: 'default' },
+        { id: 'claude-4', name: 'claude-4', checked: true, type: 'standard', apiProvider: 'default' },
         { id: 'c1', name: 'custom-x', checked: true, type: 'custom', apiProvider: 'openai' }
       ])
       expect(stateModule.updateGlobalState).toHaveBeenCalledWith('defaultBaseUrl', 'https://api.example.com')
       expect(stateModule.storeSecret).toHaveBeenCalledWith('defaultApiKey', 'server-key')
       // Verify UI options are updated (initModel was called)
-      expect(AgentAiModelsOptions.value.map((o) => o.label)).toEqual(['claude-3', 'custom-x'])
+      expect(AgentAiModelsOptions.value.map((o) => o.label)).toEqual(['claude-4', 'custom-x'])
     })
 
     it('does not update modelOptions when request fails', async () => {
@@ -379,7 +384,7 @@ describe('useModelConfiguration', () => {
     it('does not update modelOptions when server returns empty list', async () => {
       localStorage.removeItem('login-skipped')
 
-      const existing = [{ id: 's1', name: 'gpt-4', checked: true, type: 'standard', apiProvider: 'default' }]
+      const existing = [{ id: 's1', name: 'gpt-5', checked: true, type: 'standard', apiProvider: 'default' }]
 
       vi.mocked(stateModule.getGlobalState).mockImplementation(async (key) => {
         if (key === 'modelOptions') return existing


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases and mock data for AI model configuration to reflect support for new AI model versions (claude-4-5-sonnet, gpt-5, claude-4-opus). Revised provider-specific model ID configurations and adjusted test expectations across multiple scenarios to maintain accuracy with current model selections and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->