### PR TITLE
feat: Enhance suggestion handling by clearing timers and skipping queries when terminal is not focused

### DIFF
--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -260,6 +260,11 @@ const clearAllSuggestions = (options: { resetActive?: boolean } = {}) => {
     clearTimeout(aiSuggestTimer.value)
     aiSuggestTimer.value = null
   }
+  // Cancel pending local query debounce timer to prevent stale suggestions after clear
+  if (queryCommandDebounceTimer) {
+    clearTimeout(queryCommandDebounceTimer)
+    queryCommandDebounceTimer = null
+  }
   suggestionSelectionMode.value = false
   if (resetActive) {
     activeSuggestion.value = -1
@@ -617,7 +622,7 @@ onMounted(async () => {
     if (currentIsUserCall) {
       highLightFlag = false
     }
-    if (pasteFlag.value) {
+    if (pasteFlag.value && !enterPress.value) {
       highLightFlag = true
     }
     if (highLightFlag) {
@@ -864,6 +869,7 @@ onMounted(async () => {
     }
     const handleTextareaBlur = () => {
       hideSelectionButton()
+      clearAllSuggestions()
       window.electron?.ipcRenderer?.send('terminal:focus-changed', false)
     }
     terminal.value.textarea.addEventListener('focus', handleTextareaFocus)
@@ -4142,6 +4148,10 @@ const triggerAiSuggest = () => {
   if (suggestionSelectionMode.value) {
     return
   }
+  // Skip if the terminal is not focused
+  if (terminal.value?.textarea && document.activeElement !== terminal.value.textarea) {
+    return
+  }
 
   const isAtEndOfLine = terminalState.value.beforeCursor.length === terminalState.value.content.length
   if (!isAtEndOfLine) {
@@ -4170,6 +4180,11 @@ const queryCommand = async (cmd = '') => {
   // Check if it is in the Vim editing mode. If so, do not trigger the automatic completion.
   if (terminalMode.value === 'alternate') {
     clearAllSuggestions({ resetActive: false })
+    return
+  }
+
+  // Skip if the terminal is not focused
+  if (terminal.value?.textarea && document.activeElement !== terminal.value.textarea) {
     return
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale command suggestions persisting after clearing the terminal input
  * Command and AI suggestions now only display when the terminal is actively in use
  * Suggestions are automatically cleared when exiting the input field, improving recommendation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->