### PR TITLE
fix: treat missing IndexedDB stores as empty during migration

### DIFF
--- a/src/renderer/src/services/indexdb-migration-listener.ts
+++ b/src/renderer/src/services/indexdb-migration-listener.ts
@@ -13,45 +13,45 @@ async function openIndexedDb(name: string): Promise<IDBDatabase> {
 async function readAllFromStore(dbName: string, storeName: string): Promise<any[]> {
   const db = await openIndexedDb(dbName)
 
-  if (!db.objectStoreNames.contains(storeName)) {
-    logger.info('IndexedDB store not found, treating as empty', { dbName, storeName, stores: Array.from(db.objectStoreNames) })
+  try {
+    if (!db.objectStoreNames.contains(storeName)) {
+      logger.info('IndexedDB store not found, treating as empty', { dbName, storeName, stores: Array.from(db.objectStoreNames) })
+      return []
+    }
+
+    const transaction = db.transaction([storeName], 'readonly')
+    const store = transaction.objectStore(storeName)
+    const getAllRequest = store.getAll()
+
+    return await new Promise<any[]>((resolve, reject) => {
+      getAllRequest.onsuccess = () => resolve(getAllRequest.result || [])
+      getAllRequest.onerror = () => reject(getAllRequest.error)
+    })
+  } finally {
     db.close()
-    return []
   }
-
-  const transaction = db.transaction([storeName], 'readonly')
-  const store = transaction.objectStore(storeName)
-  const getAllRequest = store.getAll()
-
-  const data = await new Promise<any[]>((resolve, reject) => {
-    getAllRequest.onsuccess = () => resolve(getAllRequest.result || [])
-    getAllRequest.onerror = () => reject(getAllRequest.error)
-  })
-
-  db.close()
-  return data
 }
 
 async function readOneFromStore(dbName: string, storeName: string, key: string): Promise<any | null> {
   const db = await openIndexedDb(dbName)
 
-  if (!db.objectStoreNames.contains(storeName)) {
-    logger.info('IndexedDB store not found, treating as empty', { dbName, storeName, stores: Array.from(db.objectStoreNames) })
+  try {
+    if (!db.objectStoreNames.contains(storeName)) {
+      logger.info('IndexedDB store not found, treating as empty', { dbName, storeName, stores: Array.from(db.objectStoreNames) })
+      return null
+    }
+
+    const transaction = db.transaction([storeName], 'readonly')
+    const store = transaction.objectStore(storeName)
+    const getRequest = store.get(key)
+
+    return await new Promise<any>((resolve, reject) => {
+      getRequest.onsuccess = () => resolve(getRequest.result || null)
+      getRequest.onerror = () => reject(getRequest.error)
+    })
+  } finally {
     db.close()
-    return null
   }
-
-  const transaction = db.transaction([storeName], 'readonly')
-  const store = transaction.objectStore(storeName)
-  const getRequest = store.get(key)
-
-  const data = await new Promise<any>((resolve, reject) => {
-    getRequest.onsuccess = () => resolve(getRequest.result || null)
-    getRequest.onerror = () => reject(getRequest.error)
-  })
-
-  db.close()
-  return data
 }
 
 /**


### PR DESCRIPTION
## Summary\n- avoid migration failure when the legacy IndexedDB store does not exist\n- treat missing `aliases` and `userConfig` stores as empty data\n- preserve the current migration flow for real data when stores are present\n\n## Why\nOn a fresh environment, `chatermDB` can exist without the expected legacy stores. The renderer migration listener currently opens a transaction against `aliases` / `userConfig` unconditionally, which throws:\n\n`Failed to execute 'transaction' on 'IDBDatabase': One of the specified object stores was not found.`\n\nThat makes the migration retry and eventually fall back, even though the correct behavior for a missing legacy store is simply "no data to migrate".\n\n## Validation\n- reproduced the startup migration failure locally in dev mode\n- patched the renderer migration listener to check `db.objectStoreNames.contains(storeName)` before opening the transaction\n- re-ran `npm run dev:global` and confirmed migration completes successfully instead of erroring/retrying\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to centralize IndexedDB access and standardize data reads, improving consistency and maintainability without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist
- [x] Reproduced locally
- [x] Verified the fix locally
- [x] No breaking API changes
