### PR TITLE
feat: add terminal refocus after starting and stopping macro recording

### DIFF
--- a/src/renderer/src/views/components/LeftTab/config/snippets.vue
+++ b/src/renderer/src/views/components/LeftTab/config/snippets.vue
@@ -1010,6 +1010,10 @@ const startMacroRecording = () => {
   if (success) {
     message.success(t('macro.recordingStarted'))
   }
+  // Refocus terminal after clicking the macro button
+  nextTick(() => {
+    eventBus.emit('focusActiveTerminal')
+  })
 }
 
 const stopMacroRecording = async () => {
@@ -1034,6 +1038,10 @@ const stopMacroRecording = async () => {
   } else {
     message.info(t('macro.noCommandsRecorded'))
   }
+  // Refocus terminal after clicking the stop button
+  nextTick(() => {
+    eventBus.emit('focusActiveTerminal')
+  })
 }
 
 const handleMacroLimitReached = async (payload: { reason: string; result?: { content: string; name: string; groupUuid: string | null } }) => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal focus behavior when recording macros. The active terminal now automatically refocuses after starting and stopping macro recordings for improved workflow continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->