### PR TITLE
feat(skills): add skill content reading and updating functionality

### DIFF
--- a/src/main/agent/services/skills/SkillsManager.ts
+++ b/src/main/agent/services/skills/SkillsManager.ts
@@ -614,7 +614,8 @@ export class SkillsManager {
         skills: this.getAllSkills().map((skill) => ({
           name: skill.metadata.name,
           description: skill.metadata.description,
-          enabled: skill.enabled
+          enabled: skill.enabled,
+          path: skill.path
         }))
       })
     }
@@ -707,6 +708,49 @@ export class SkillsManager {
 
     // Notify webview
     await this.notifySkillsUpdate()
+  }
+
+  /**
+   * Read the full content of a skill (metadata + body)
+   */
+  async readSkillContent(skillName: string): Promise<{ metadata: Partial<SkillMetadata>; content: string }> {
+    const skill = this.skills.get(skillName)
+    if (!skill) {
+      throw new Error(`Skill not found: ${skillName}`)
+    }
+
+    const result = await this.parseSkillFile(skill.path)
+    if (!result.success || !result.skill) {
+      throw new Error(result.error || 'Failed to parse skill file')
+    }
+
+    return {
+      metadata: result.skill.metadata,
+      content: result.skill.content
+    }
+  }
+
+  /**
+   * Update a user skill's SKILL.md file
+   */
+  async updateUserSkill(skillName: string, metadata: SkillMetadata, content: string): Promise<void> {
+    const skill = this.skills.get(skillName)
+    if (!skill) {
+      throw new Error(`Skill not found: ${skillName}`)
+    }
+
+    // Check if skill is in user skills directory
+    const userSkillsPath = this.getUserSkillsPath()
+    if (!skill.path.startsWith(userSkillsPath)) {
+      throw new Error('Can only update user-created skills')
+    }
+
+    // Build and write updated SKILL.md content
+    const skillContent = this.buildSkillFile(metadata, content)
+    await fs.writeFile(skill.path, skillContent, 'utf-8')
+
+    // Reload skills to pick up changes
+    await this.loadAllSkills()
   }
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -767,6 +767,30 @@ ipcMain.handle('skills:import-zip', async (_event, zipPath: string, overwrite?: 
   }
 })
 
+ipcMain.handle('skills:read-content', async (_event, skillName: string) => {
+  try {
+    if (controller && controller.skillsManager) {
+      return await controller.skillsManager.readSkillContent(skillName)
+    }
+    throw new Error('Skills manager not initialized')
+  } catch (error) {
+    logger.error('Failed to read skill content', { error: error })
+    throw error
+  }
+})
+
+ipcMain.handle('skills:update', async (_event, skillName: string, metadata: any, content: string) => {
+  try {
+    if (controller && controller.skillsManager) {
+      return await controller.skillsManager.updateUserSkill(skillName, metadata, content)
+    }
+    throw new Error('Skills manager not initialized')
+  } catch (error) {
+    logger.error('Failed to update skill', { error: error })
+    throw error
+  }
+})
+
 // ==================== End Skills IPC Handlers ====================
 
 // Get all Cookies

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -283,6 +283,8 @@ interface ApiType {
     error?: string
     errorCode?: 'INVALID_ZIP' | 'NO_SKILL_MD' | 'INVALID_METADATA' | 'DIR_EXISTS' | 'EXTRACT_FAILED' | 'UNKNOWN'
   }>
+  readSkillContent: (skillName: string) => Promise<{ metadata: any; content: string }>
+  updateSkill: (skillName: string, metadata: any, content: string) => Promise<void>
   onSkillsUpdate: (callback: (skills: any[]) => void) => () => void
 
   // IndexedDB migration related API

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -769,6 +769,8 @@ const api = {
   deleteSkill: (skillId: string) => ipcRenderer.invoke('skills:delete', skillId),
   openSkillsFolder: () => ipcRenderer.invoke('skills:open-folder'),
   importSkillZip: (zipPath: string, overwrite?: boolean) => ipcRenderer.invoke('skills:import-zip', zipPath, overwrite),
+  readSkillContent: (skillName: string) => ipcRenderer.invoke('skills:read-content', skillName),
+  updateSkill: (skillName: string, metadata: any, content: string) => ipcRenderer.invoke('skills:update', skillName, metadata, content),
   onSkillsUpdate: (callback: (skills: any[]) => void) => {
     const listener = (_event, data) => callback(data.skills)
     ipcRenderer.on('skillsUpdate', listener)

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1398,7 +1398,11 @@ export default {
     importInvalidMetadata: 'SKILL.md يفتقد حقول مطلوبة',
     importOverwriteTitle: 'المهارة موجودة بالفعل',
     importOverwriteContent: 'هل أنت متأكد من رغبتك في استبدال المهارة الموجودة؟',
-    importOverwrite: 'استبدال'
+    importOverwrite: 'استبدال',
+    editSkill: 'تعديل المهارة',
+    readContentError: 'فشل في قراءة محتوى المهارة',
+    updateSuccess: 'تم تحديث المهارة بنجاح',
+    updateError: 'فشل في تحديث المهارة'
   },
   knowledgeCenter: {
     title: 'قاعدة المعرفة',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1418,7 +1418,11 @@ export default {
     importInvalidMetadata: 'SKILL.md fehlt erforderliche Felder',
     importOverwriteTitle: 'Skill bereits vorhanden',
     importOverwriteContent: 'Möchten Sie den bestehenden Skill überschreiben?',
-    importOverwrite: 'Überschreiben'
+    importOverwrite: 'Überschreiben',
+    editSkill: 'Skill bearbeiten',
+    readContentError: 'Skill-Inhalt konnte nicht gelesen werden',
+    updateSuccess: 'Skill erfolgreich aktualisiert',
+    updateError: 'Skill konnte nicht aktualisiert werden'
   },
   knowledgeCenter: {
     title: 'Wissensdatenbank',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -1421,7 +1421,11 @@ export default {
     importInvalidMetadata: 'SKILL.md missing required fields',
     importOverwriteTitle: 'Skill Already Exists',
     importOverwriteContent: 'Overwrite existing skill?',
-    importOverwrite: 'Overwrite'
+    importOverwrite: 'Overwrite',
+    editSkill: 'Edit Skill',
+    readContentError: 'Failed to read skill content',
+    updateSuccess: 'Skill updated successfully',
+    updateError: 'Failed to update skill'
   },
   knowledgeCenter: {
     title: 'Knowledge Base',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1422,7 +1422,11 @@ export default {
     importInvalidMetadata: 'Fichier SKILL.md manquant des champs requis',
     importOverwriteTitle: 'Compétence déjà existante',
     importOverwriteContent: 'Voulez-vous remplacer la compétence existante ?',
-    importOverwrite: 'Remplacer'
+    importOverwrite: 'Remplacer',
+    editSkill: 'Modifier la compétence',
+    readContentError: 'Impossible de lire le contenu de la compétence',
+    updateSuccess: 'Compétence mise à jour avec succès',
+    updateError: 'Impossible de mettre à jour la compétence'
   },
   knowledgeCenter: {
     title: 'Base de connaissances',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1420,7 +1420,11 @@ export default {
     importInvalidMetadata: 'File SKILL.md manca campi obbligatori',
     importOverwriteTitle: 'Competenza già esistente',
     importOverwriteContent: 'Vuoi sovrascrivere la competenza esistente?',
-    importOverwrite: 'Sovrascrivi'
+    importOverwrite: 'Sovrascrivi',
+    editSkill: 'Modifica competenza',
+    readContentError: 'Impossibile leggere il contenuto della competenza',
+    updateSuccess: 'Competenza aggiornata con successo',
+    updateError: 'Impossibile aggiornare la competenza'
   },
   knowledgeCenter: {
     title: 'Base di conoscenza',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1416,7 +1416,11 @@ export default {
     importInvalidMetadata: 'SKILL.mdに必須フィールドがありません',
     importOverwriteTitle: 'スキルが既に存在します',
     importOverwriteContent: '既存のスキルを上書きしますか？',
-    importOverwrite: '上書き'
+    importOverwrite: '上書き',
+    editSkill: 'スキルを編集',
+    readContentError: 'スキルの内容の読み込みに失敗しました',
+    updateSuccess: 'スキルが正常に更新されました',
+    updateError: 'スキルの更新に失敗しました'
   },
   knowledgeCenter: {
     title: '知識ベース',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1412,7 +1412,11 @@ export default {
     importInvalidMetadata: 'SKILL.md에 필수 필드가 없습니다',
     importOverwriteTitle: '스킬이 이미 존재합니다',
     importOverwriteContent: '기존 스킬을 덮어쓰시겠습니까?',
-    importOverwrite: '덮어쓰기'
+    importOverwrite: '덮어쓰기',
+    editSkill: '스킬 편집',
+    readContentError: '스킬 내용을 읽지 못했습니다',
+    updateSuccess: '스킬이 성공적으로 업데이트되었습니다',
+    updateError: '스킬 업데이트에 실패했습니다'
   },
   knowledgeCenter: {
     title: '지식 베이스',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1416,7 +1416,11 @@ export default {
     importInvalidMetadata: 'Arquivo SKILL.md está faltando campos obrigatórios',
     importOverwriteTitle: 'Competência já existe',
     importOverwriteContent: 'Deseja sobrescrever a competência existente?',
-    importOverwrite: 'Sobrescrever'
+    importOverwrite: 'Sobrescrever',
+    editSkill: 'Editar competência',
+    readContentError: 'Falha ao ler o conteúdo da competência',
+    updateSuccess: 'Competência atualizada com sucesso',
+    updateError: 'Falha ao atualizar a competência'
   },
   knowledgeCenter: {
     title: 'Base de Conhecimento',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1415,7 +1415,11 @@ export default {
     importInvalidMetadata: 'Файл SKILL.md отсутствует обязательные поля',
     importOverwriteTitle: 'Навык уже существует',
     importOverwriteContent: 'Хотите заменить существующий навык?',
-    importOverwrite: 'Заменить'
+    importOverwrite: 'Заменить',
+    editSkill: 'Редактировать навык',
+    readContentError: 'Не удалось прочитать содержимое навыка',
+    updateSuccess: 'Навык успешно обновлен',
+    updateError: 'Не удалось обновить навык'
   },
   knowledgeCenter: {
     title: 'База знаний',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -1407,7 +1407,11 @@ export default {
     importInvalidMetadata: 'SKILL.md 缺少必填字段',
     importOverwriteTitle: '技能已存在',
     importOverwriteContent: '是否覆盖已存在的技能？',
-    importOverwrite: '覆盖'
+    importOverwrite: '覆盖',
+    editSkill: '编辑技能',
+    readContentError: '读取技能内容失败',
+    updateSuccess: '技能更新成功',
+    updateError: '更新技能失败'
   },
   knowledgeCenter: {
     title: '知识库',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -1399,7 +1399,11 @@ export default {
     importInvalidMetadata: 'SKILL.md 文件缺少必需的字段',
     importOverwriteTitle: '技能已存在',
     importOverwriteContent: '是否要覆蓋現有技能？',
-    importOverwrite: '覆蓋'
+    importOverwrite: '覆蓋',
+    editSkill: '編輯技能',
+    readContentError: '讀取技能內容失敗',
+    updateSuccess: '技能更新成功',
+    updateError: '更新技能失敗'
   },
   knowledgeCenter: {
     title: '知識庫',

--- a/src/renderer/src/views/components/LeftTab/setting/__tests__/skills.test.ts
+++ b/src/renderer/src/views/components/LeftTab/setting/__tests__/skills.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import SkillsComponent from '../skills.vue'
@@ -69,9 +69,14 @@ const mockTranslations: Record<string, string> = {
   'skills.importOverwriteTitle': 'Skill Already Exists',
   'skills.importOverwriteContent': 'Do you want to overwrite the existing skill?',
   'skills.importOverwrite': 'Overwrite',
+  'skills.editSkill': 'Edit Skill',
+  'skills.readContentError': 'Failed to read skill content',
+  'skills.updateSuccess': 'Skill updated successfully',
+  'skills.updateError': 'Failed to update skill',
   'common.delete': 'Delete',
   'common.cancel': 'Cancel',
-  'common.create': 'Create'
+  'common.create': 'Create',
+  'common.save': 'Save'
 }
 
 const mockT = (key: string, params?: Record<string, string>) => {
@@ -93,12 +98,15 @@ vi.mock('vue-i18n', () => ({
 // Mock window.api
 const mockWindowApi = {
   getSkills: vi.fn(),
+  getSkillsUserPath: vi.fn(),
   reloadSkills: vi.fn(),
   openSkillsFolder: vi.fn(),
   importSkillZip: vi.fn(),
   createSkill: vi.fn(),
   deleteSkill: vi.fn(),
   setSkillEnabled: vi.fn(),
+  readSkillContent: vi.fn(),
+  updateSkill: vi.fn(),
   onSkillsUpdate: vi.fn(),
   showOpenDialog: vi.fn()
 }
@@ -160,7 +168,8 @@ describe('Skills Component', () => {
           PlusOutlined: { template: '<span class="plus-icon" />' },
           DeleteOutlined: { template: '<span class="delete-icon" />' },
           ThunderboltOutlined: { template: '<span class="thunderbolt-icon" />' },
-          ImportOutlined: { template: '<span class="import-icon" />' }
+          ImportOutlined: { template: '<span class="import-icon" />' },
+          EditOutlined: { template: '<span class="edit-icon" />' }
         },
         mocks: {
           $t: mockT
@@ -179,21 +188,24 @@ describe('Skills Component', () => {
     global.window = global.window || ({} as Window & typeof globalThis)
     ;(global.window as unknown as { api: typeof mockWindowApi }).api = mockWindowApi
 
-    // Setup unsubscribe mock
-    unsubscribeMock = vi.fn()
-    mockWindowApi.onSkillsUpdate.mockReturnValue(unsubscribeMock)
-
     // Reset all mocks
     vi.clearAllMocks()
 
+    // Setup unsubscribe mock (must be after clearAllMocks)
+    unsubscribeMock = vi.fn()
+    mockWindowApi.onSkillsUpdate.mockReturnValue(unsubscribeMock)
+
     // Setup default mock return values
     mockWindowApi.getSkills.mockResolvedValue([])
+    mockWindowApi.getSkillsUserPath.mockResolvedValue('/user/skills')
     mockWindowApi.reloadSkills.mockResolvedValue(undefined)
     mockWindowApi.openSkillsFolder.mockResolvedValue(undefined)
     mockWindowApi.importSkillZip.mockResolvedValue({ success: true, skillName: 'Test Skill' })
     mockWindowApi.createSkill.mockResolvedValue({ success: true })
     mockWindowApi.deleteSkill.mockResolvedValue(undefined)
     mockWindowApi.setSkillEnabled.mockResolvedValue(undefined)
+    mockWindowApi.readSkillContent.mockResolvedValue({ metadata: { name: 'test', description: 'desc' }, content: 'body' })
+    mockWindowApi.updateSkill.mockResolvedValue(undefined)
     mockWindowApi.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
 
     // Clear console output for cleaner test results
@@ -253,8 +265,7 @@ describe('Skills Component', () => {
 
     it('should subscribe to skills updates on mount', async () => {
       wrapper = createWrapper()
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(mockWindowApi.onSkillsUpdate).toHaveBeenCalled()
     })
@@ -264,16 +275,14 @@ describe('Skills Component', () => {
       mockWindowApi.getSkills.mockRejectedValue(error)
 
       wrapper = createWrapper()
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(message.error).toHaveBeenCalledWith('Failed to load skills')
     })
 
     it('should update skills when onSkillsUpdate callback is called', async () => {
       wrapper = createWrapper()
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       const updateCallback = mockWindowApi.onSkillsUpdate.mock.calls[0][0] as (skills: any[]) => void
       const updatedSkills = [
@@ -293,8 +302,7 @@ describe('Skills Component', () => {
 
     it('should cleanup subscription on unmount', async () => {
       wrapper = createWrapper()
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       wrapper.unmount()
 
@@ -1473,6 +1481,382 @@ describe('Skills Component', () => {
     it('should have delete button with title attribute', () => {
       const deleteButton = wrapper.find('.delete-btn')
       expect(deleteButton.attributes('title')).toBe('Delete')
+    })
+
+    it('should have edit button with title attribute for editable skills', async () => {
+      const editableSkills = [
+        {
+          name: 'Test Skill',
+          description: 'Test description',
+          enabled: true,
+          path: '/user/skills/test-skill/SKILL.md'
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(editableSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButton = wrapper.find('.edit-btn')
+      expect(editButton.exists()).toBe(true)
+      expect(editButton.attributes('title')).toBe('Edit Skill')
+    })
+  })
+
+  describe('Edit Skill - isEditable', () => {
+    it('should show edit button for user-created skills', async () => {
+      const mockSkills = [
+        {
+          name: 'user-skill',
+          description: 'User skill',
+          enabled: true,
+          path: '/user/skills/user-skill/SKILL.md'
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(mockSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButton = wrapper.find('.edit-btn')
+      expect(editButton.exists()).toBe(true)
+    })
+
+    it('should not show edit button for built-in skills', async () => {
+      const mockSkills = [
+        {
+          name: 'builtin-skill',
+          description: 'Built-in skill',
+          enabled: true,
+          path: '/app/resources/skills/builtin-skill/SKILL.md'
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(mockSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButton = wrapper.find('.edit-btn')
+      expect(editButton.exists()).toBe(false)
+    })
+
+    it('should not show edit button for skills without path', async () => {
+      const mockSkills = [
+        {
+          name: 'no-path-skill',
+          description: 'No path skill',
+          enabled: true
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(mockSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButton = wrapper.find('.edit-btn')
+      expect(editButton.exists()).toBe(false)
+    })
+
+    it('should correctly determine editability via isEditable method', async () => {
+      mockWindowApi.getSkills.mockResolvedValue([])
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+
+      expect(vm.isEditable({ name: 'test', path: '/user/skills/test/SKILL.md' })).toBe(true)
+      expect(vm.isEditable({ name: 'test', path: '/app/resources/skills/test/SKILL.md' })).toBe(false)
+      expect(vm.isEditable({ name: 'test' })).toBe(false)
+      expect(vm.isEditable({ name: 'test', path: '' })).toBe(false)
+    })
+
+    it('should show edit button only for user skills in mixed list', async () => {
+      const mockSkills = [
+        {
+          name: 'user-skill',
+          description: 'User skill',
+          enabled: true,
+          path: '/user/skills/user-skill/SKILL.md'
+        },
+        {
+          name: 'builtin-skill',
+          description: 'Built-in skill',
+          enabled: true,
+          path: '/app/resources/skills/builtin-skill/SKILL.md'
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(mockSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButtons = wrapper.findAll('.edit-btn')
+      expect(editButtons.length).toBe(1)
+    })
+  })
+
+  describe('Edit Skill - Open Edit Modal', () => {
+    const editableSkill = {
+      name: 'my-skill',
+      description: 'My skill description',
+      enabled: true,
+      path: '/user/skills/my-skill/SKILL.md'
+    }
+
+    beforeEach(async () => {
+      mockWindowApi.getSkills.mockResolvedValue([editableSkill])
+      mockWindowApi.readSkillContent.mockResolvedValue({
+        metadata: { name: 'my-skill', description: 'My skill description' },
+        content: '# My Skill\n\nSkill instructions here.'
+      })
+      wrapper = createWrapper()
+      await flushPromises()
+    })
+
+    it('should open edit modal when edit button is clicked', async () => {
+      const editButton = wrapper.find('.edit-btn')
+      await editButton.trigger('click')
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.editModalVisible).toBe(true)
+    })
+
+    it('should call readSkillContent when opening edit modal', async () => {
+      const vm = wrapper.vm as any
+      await vm.openEditModal(editableSkill)
+      await nextTick()
+
+      expect(mockWindowApi.readSkillContent).toHaveBeenCalledWith('my-skill')
+    })
+
+    it('should populate edit form with skill content', async () => {
+      const vm = wrapper.vm as any
+      await vm.openEditModal(editableSkill)
+      await nextTick()
+
+      expect(vm.editSkill.name).toBe('my-skill')
+      expect(vm.editSkill.description).toBe('My skill description')
+      expect(vm.editSkill.content).toBe('# My Skill\n\nSkill instructions here.')
+    })
+
+    it('should show error message when readSkillContent fails', async () => {
+      mockWindowApi.readSkillContent.mockRejectedValue(new Error('Read failed'))
+
+      const vm = wrapper.vm as any
+      await vm.openEditModal(editableSkill)
+      await nextTick()
+
+      expect(message.error).toHaveBeenCalledWith('Failed to read skill content')
+      expect(vm.editModalVisible).toBe(false)
+    })
+
+    it('should not open modal when readSkillContent fails', async () => {
+      mockWindowApi.readSkillContent.mockRejectedValue(new Error('Read failed'))
+
+      const vm = wrapper.vm as any
+      await vm.openEditModal(editableSkill)
+      await nextTick()
+
+      expect(vm.editModalVisible).toBe(false)
+    })
+
+    it('should handle empty content from readSkillContent', async () => {
+      mockWindowApi.readSkillContent.mockResolvedValue({
+        metadata: { name: 'my-skill', description: '' },
+        content: ''
+      })
+
+      const vm = wrapper.vm as any
+      await vm.openEditModal(editableSkill)
+      await nextTick()
+
+      expect(vm.editSkill.name).toBe('my-skill')
+      expect(vm.editSkill.description).toBe('')
+      expect(vm.editSkill.content).toBe('')
+      expect(vm.editModalVisible).toBe(true)
+    })
+  })
+
+  describe('Edit Skill - Update Skill', () => {
+    beforeEach(async () => {
+      mockWindowApi.getSkills.mockResolvedValue([])
+      wrapper = createWrapper()
+      await flushPromises()
+    })
+
+    it('should call updateSkill API with correct parameters', async () => {
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated description'
+      vm.editSkill.content = 'Updated content'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(mockWindowApi.updateSkill).toHaveBeenCalledWith(
+        'test-skill',
+        { name: 'test-skill', description: 'Updated description' },
+        'Updated content'
+      )
+    })
+
+    it('should show success message after successful update', async () => {
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(message.success).toHaveBeenCalledWith('Skill updated successfully')
+    })
+
+    it('should close modal after successful update', async () => {
+      const vm = wrapper.vm as any
+      vm.editModalVisible = true
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(vm.editModalVisible).toBe(false)
+    })
+
+    it('should show error message on update failure', async () => {
+      mockWindowApi.updateSkill.mockRejectedValue(new Error('Update failed'))
+
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(message.error).toHaveBeenCalledWith('Failed to update skill')
+    })
+
+    it('should not close modal on update failure', async () => {
+      mockWindowApi.updateSkill.mockRejectedValue(new Error('Update failed'))
+
+      const vm = wrapper.vm as any
+      vm.editModalVisible = true
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(vm.editModalVisible).toBe(true)
+    })
+
+    it('should validate description is required', async () => {
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = ''
+      vm.editSkill.content = 'Some content'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(message.warning).toHaveBeenCalledWith('Please fill all required fields')
+      expect(mockWindowApi.updateSkill).not.toHaveBeenCalled()
+    })
+
+    it('should validate content is required', async () => {
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Some description'
+      vm.editSkill.content = ''
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(message.warning).toHaveBeenCalledWith('Please fill all required fields')
+      expect(mockWindowApi.updateSkill).not.toHaveBeenCalled()
+    })
+
+    it('should set loading state during update', async () => {
+      let resolveUpdate: () => void
+      const updatePromise = new Promise<void>((resolve) => {
+        resolveUpdate = resolve
+      })
+      mockWindowApi.updateSkill.mockReturnValue(updatePromise)
+
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      const updatePromise2 = vm.updateSkill()
+
+      await nextTick()
+      expect(vm.isUpdating).toBe(true)
+
+      resolveUpdate!()
+      await updatePromise2
+      await nextTick()
+
+      expect(vm.isUpdating).toBe(false)
+    })
+
+    it('should reset loading state after update error', async () => {
+      mockWindowApi.updateSkill.mockRejectedValue(new Error('Failed'))
+
+      const vm = wrapper.vm as any
+      vm.editSkill.name = 'test-skill'
+      vm.editSkill.description = 'Updated'
+      vm.editSkill.content = 'Updated'
+
+      await vm.updateSkill()
+      await nextTick()
+
+      expect(vm.isUpdating).toBe(false)
+    })
+  })
+
+  describe('Edit Skill - Initialization', () => {
+    it('should fetch user skills path on mount', async () => {
+      wrapper = createWrapper()
+      await flushPromises()
+
+      expect(mockWindowApi.getSkillsUserPath).toHaveBeenCalled()
+    })
+
+    it('should store user skills path', async () => {
+      mockWindowApi.getSkillsUserPath.mockResolvedValue('/custom/user/skills')
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.userSkillsPath).toBe('/custom/user/skills')
+    })
+
+    it('should handle getSkillsUserPath failure gracefully', async () => {
+      mockWindowApi.getSkillsUserPath.mockRejectedValue(new Error('Failed'))
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.userSkillsPath).toBe('')
+    })
+
+    it('should not show edit buttons when userSkillsPath is empty', async () => {
+      mockWindowApi.getSkillsUserPath.mockRejectedValue(new Error('Failed'))
+      const mockSkills = [
+        {
+          name: 'test-skill',
+          description: 'Test',
+          enabled: true,
+          path: '/user/skills/test-skill/SKILL.md'
+        }
+      ]
+      mockWindowApi.getSkills.mockResolvedValue(mockSkills)
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const editButton = wrapper.find('.edit-btn')
+      expect(editButton.exists()).toBe(false)
     })
   })
 })

--- a/src/renderer/src/views/components/LeftTab/setting/skills.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/skills.vue
@@ -93,6 +93,16 @@
                 @change="toggleSkill(skill)"
               />
               <a-button
+                v-if="isEditable(skill)"
+                type="text"
+                size="small"
+                class="edit-btn"
+                :title="$t('skills.editSkill')"
+                @click="openEditModal(skill)"
+              >
+                <EditOutlined />
+              </a-button>
+              <a-button
                 type="text"
                 size="small"
                 class="delete-btn"
@@ -158,6 +168,53 @@
         </a-form-item>
       </a-form>
     </a-modal>
+
+    <!-- Edit Skill Modal -->
+    <a-modal
+      v-model:open="editModalVisible"
+      :title="$t('skills.editSkill')"
+      :ok-text="$t('common.save')"
+      :cancel-text="$t('common.cancel')"
+      :confirm-loading="isUpdating"
+      width="600px"
+      class="skill-modal"
+      @ok="updateSkill"
+    >
+      <a-form
+        ref="editFormRef"
+        :model="editSkill"
+        layout="vertical"
+        class="skill-form"
+      >
+        <a-form-item :label="$t('skills.skillName')">
+          <a-input
+            v-model:value="editSkill.name"
+            disabled
+          />
+        </a-form-item>
+        <a-form-item
+          :label="$t('skills.skillDescription')"
+          required
+        >
+          <a-textarea
+            v-model:value="editSkill.description"
+            :placeholder="$t('skills.skillDescriptionPlaceholder')"
+            :rows="2"
+          />
+        </a-form-item>
+        <a-form-item
+          :label="$t('skills.skillContent')"
+          required
+        >
+          <a-textarea
+            v-model:value="editSkill.content"
+            :placeholder="$t('skills.skillContentPlaceholder')"
+            :rows="10"
+            class="skill-content-textarea"
+          />
+        </a-form-item>
+      </a-form>
+    </a-modal>
   </div>
 </template>
 
@@ -165,7 +222,15 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { message, Modal } from 'ant-design-vue'
-import { FolderOpenOutlined, ReloadOutlined, PlusOutlined, DeleteOutlined, ThunderboltOutlined, ImportOutlined } from '@ant-design/icons-vue'
+import {
+  FolderOpenOutlined,
+  ReloadOutlined,
+  PlusOutlined,
+  DeleteOutlined,
+  ThunderboltOutlined,
+  ImportOutlined,
+  EditOutlined
+} from '@ant-design/icons-vue'
 
 const logger = createRendererLogger('settings.skills')
 const { t } = useI18n()
@@ -181,10 +246,19 @@ const skills = ref<Skill[]>([])
 const isReloading = ref(false)
 const isCreating = ref(false)
 const isImporting = ref(false)
+const isUpdating = ref(false)
 const createModalVisible = ref(false)
+const editModalVisible = ref(false)
 const skillFormRef = ref()
+const userSkillsPath = ref('')
 
 const newSkill = ref({
+  name: '',
+  description: '',
+  content: ''
+})
+
+const editSkill = ref({
   name: '',
   description: '',
   content: ''
@@ -206,6 +280,13 @@ let unsubscribeSkillsUpdate: (() => void) | null = null
 
 onMounted(async () => {
   await loadSkills()
+
+  // Get user skills path for determining editability
+  try {
+    userSkillsPath.value = await window.api.getSkillsUserPath()
+  } catch (error) {
+    logger.error('Failed to get user skills path', { error: error })
+  }
 
   // Subscribe to skills updates
   unsubscribeSkillsUpdate = window.api.onSkillsUpdate((updatedSkills) => {
@@ -403,6 +484,48 @@ const confirmDeleteSkill = (skill: Skill) => {
     }
   })
 }
+
+const isEditable = (skill: Skill): boolean => {
+  return !!skill.path && !!userSkillsPath.value && skill.path.startsWith(userSkillsPath.value)
+}
+
+const openEditModal = async (skill: Skill) => {
+  try {
+    const result = await window.api.readSkillContent(skill.name)
+    editSkill.value = {
+      name: skill.name,
+      description: result.metadata.description || '',
+      content: result.content || ''
+    }
+    editModalVisible.value = true
+  } catch (error) {
+    logger.error('Failed to read skill content', { error: error })
+    message.error(t('skills.readContentError'))
+  }
+}
+
+const updateSkill = async () => {
+  if (!editSkill.value.description || !editSkill.value.content) {
+    message.warning(t('skills.fillRequired'))
+    return
+  }
+
+  isUpdating.value = true
+  try {
+    const metadata = {
+      name: editSkill.value.name,
+      description: editSkill.value.description
+    }
+    await window.api.updateSkill(editSkill.value.name, metadata, editSkill.value.content)
+    editModalVisible.value = false
+    message.success(t('skills.updateSuccess'))
+  } catch (error) {
+    logger.error('Failed to update skill', { error: error })
+    message.error(t('skills.updateError'))
+  } finally {
+    isUpdating.value = false
+  }
+}
 </script>
 
 <style lang="less" scoped>
@@ -589,6 +712,23 @@ const confirmDeleteSkill = (skill: Skill) => {
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+
+    .edit-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 22px;
+      color: var(--text-color-tertiary);
+      padding: 0;
+      border-radius: 4px;
+      transition: all 0.2s ease;
+
+      &:hover {
+        color: #1890ff;
+        background-color: rgba(24, 144, 255, 0.1);
+      }
+    }
 
     .delete-btn {
       display: flex;


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #1825 

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill editing capability with a dedicated modal for user-created skills
  * Included edit button for eligible skills with form fields to modify description and content
  * Added validation and error handling with user feedback messages
  
* **Localization**
  * Extended translations across 12 languages to support new skill editing UI labels and status messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->