### PR TITLE
feat(knowledgebase): add cloud storage and sync last results handlers…

### DIFF
--- a/src/main/services/knowledgebase/index.ts
+++ b/src/main/services/knowledgebase/index.ts
@@ -9,6 +9,7 @@ import { getDefaultLanguage } from '../../config/edition'
 import { getUserConfig } from '../../agent/core/storage/state'
 import { KB_DEFAULT_SEEDS, KB_DEFAULT_SEEDS_VERSION } from './default-seeds'
 import type { KnowledgeBaseDefaultSeed } from './default-seeds'
+import { getKbCloudUsedBytes, KB_CLOUD_TOTAL_BYTES, getKbSyncLastResults } from './sync'
 
 export interface KnowledgeBaseEntry {
   name: string
@@ -479,6 +480,13 @@ export function registerKnowledgeBaseHandlers(): void {
     await initKbDefaultSeedFiles()
     return { root }
   })
+
+  ipcMain.handle('kb:get-cloud-storage', async () => {
+    const usedBytes = await getKbCloudUsedBytes()
+    return { usedBytes, totalBytes: KB_CLOUD_TOTAL_BYTES }
+  })
+
+  ipcMain.handle('kb:sync-last-results', async () => getKbSyncLastResults())
 
   ipcMain.handle('kb:list-dir', async (_evt, payload: { relDir: string }) => {
     const relDir = payload?.relDir ?? ''

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -360,6 +360,12 @@ interface ApiType {
   onKbTransferProgress: (callback: (data: { jobId: string; transferred: number; total: number; destRelPath: string }) => void) => () => void
   kbSyncGetStatus: () => Promise<{ status: 'idle' | 'syncing' }>
   kbSyncLastTime: () => Promise<number | null>
+  kbSyncLastResults: () => Promise<{
+    finishedAt: number
+    uploads: Array<{ relPath: string; kind: 'upload' | 'delete'; status: string; message: string }>
+    deletes: Array<{ relPath: string; kind: 'upload' | 'delete'; status: string; message: string }>
+  }>
+  getKbCloudStorage: () => Promise<{ usedBytes: number; totalBytes: number }>
   getLocalWorkingDirectory: () => Promise<{ success: boolean; cwd: string }>
   getShellsLocal: () => Promise<any>
   agentEnableAndConfigure: (opts: { enabled: boolean }) => Promise<any>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1007,6 +1007,8 @@ const api = {
   },
   kbSyncGetStatus: () => ipcRenderer.invoke('kb:sync-get-status'),
   kbSyncLastTime: () => ipcRenderer.invoke('kb:sync-last-time'),
+  kbSyncLastResults: () => ipcRenderer.invoke('kb:sync-last-results'),
+  getKbCloudStorage: () => ipcRenderer.invoke('kb:get-cloud-storage'),
 
   agentEnableAndConfigure: (opts: { enabled: boolean }) => ipcRenderer.invoke('ssh:agent:enable-and-configure', opts),
   addKey: (opts: { keyData: string; passphrase?: string; comment?: string }) => ipcRenderer.invoke('ssh:agent:add-key', opts),

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1420,7 +1420,18 @@ export default {
     importErrorFileTypeNotAllowed: 'نوع الملف هذا لا يمكن استيراده',
     importErrorFileTooLarge: 'الملف كبير جداً ولا يمكن استيراده',
     importErrorFileFailed: 'فشل استيراد الملف',
-    importErrorFolderFailed: 'فشل استيراد المجلد'
+    importErrorFolderFailed: 'فشل استيراد المجلد',
+    myCapacity: 'سعتي',
+    capacityDetail: 'التفاصيل',
+    capacitySourceDetail: 'تفاصيل مصدر السعة',
+    serviceItem: 'الخدمة',
+    expireAt: 'ينتهي',
+    capacity: 'السعة',
+    total: 'المجموع',
+    freeTierName: 'خطة شخصية مجانية',
+    proTierName: 'خطة شخصية Pro',
+    ultraTierName: 'خطة شخصية Ultra',
+    expireNever: 'لا ينتهي'
   },
   interaction: {
     waiting: 'جاري الانتظار للإدخال...',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1440,7 +1440,18 @@ export default {
     importErrorFileTypeNotAllowed: 'Dieser Dateityp kann nicht importiert werden',
     importErrorFileTooLarge: 'Datei ist zu groß zum Importieren',
     importErrorFileFailed: 'Datei konnte nicht importiert werden',
-    importErrorFolderFailed: 'Ordner konnte nicht importiert werden'
+    importErrorFolderFailed: 'Ordner konnte nicht importiert werden',
+    myCapacity: 'Mein Speicher',
+    capacityDetail: 'Details',
+    capacitySourceDetail: 'Speicherquellen-Details',
+    serviceItem: 'Service',
+    expireAt: 'Läuft ab',
+    capacity: 'Kapazität',
+    total: 'Gesamt',
+    freeTierName: 'Persönlicher Gratis-Tarif',
+    proTierName: 'Persönlicher Pro-Tarif',
+    ultraTierName: 'Persönlicher Ultra-Tarif',
+    expireNever: 'Unbegrenzt gültig'
   },
   interaction: {
     waiting: 'Warten auf Eingabe...',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -1443,7 +1443,18 @@ export default {
     importErrorFileTypeNotAllowed: 'This file type cannot be imported',
     importErrorFileTooLarge: 'File is too large to import',
     importErrorFileFailed: 'Failed to import file',
-    importErrorFolderFailed: 'Failed to import folder'
+    importErrorFolderFailed: 'Failed to import folder',
+    myCapacity: 'My Capacity',
+    capacityDetail: 'Details',
+    capacitySourceDetail: 'Capacity Source Details',
+    serviceItem: 'Service',
+    expireAt: 'Expires',
+    capacity: 'Capacity',
+    total: 'Total',
+    freeTierName: 'Personal Free Plan',
+    proTierName: 'Personal Pro Plan',
+    ultraTierName: 'Personal Ultra Plan',
+    expireNever: 'Never expires'
   },
   interaction: {
     waiting: 'Waiting for input...',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1444,7 +1444,18 @@ export default {
     importErrorFileTypeNotAllowed: 'Ce type de fichier ne peut pas être importé',
     importErrorFileTooLarge: 'Fichier trop volumineux pour être importé',
     importErrorFileFailed: "Échec de l'import du fichier",
-    importErrorFolderFailed: "Échec de l'import du dossier"
+    importErrorFolderFailed: "Échec de l'import du dossier",
+    myCapacity: 'Mon espace',
+    capacityDetail: 'Détails',
+    capacitySourceDetail: 'Détail des sources de capacité',
+    serviceItem: 'Service',
+    expireAt: 'Expiration',
+    capacity: 'Capacité',
+    total: 'Total',
+    freeTierName: 'Forfait personnel gratuit',
+    proTierName: 'Forfait personnel Pro',
+    ultraTierName: 'Forfait personnel Ultra',
+    expireNever: 'Jamais expiré'
   },
   interaction: {
     title: 'Interaction de commande requise',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1442,7 +1442,18 @@ export default {
     importErrorFileTypeNotAllowed: 'Questo tipo di file non può essere importato',
     importErrorFileTooLarge: 'File troppo grande per essere importato',
     importErrorFileFailed: 'Importazione file non riuscita',
-    importErrorFolderFailed: 'Importazione cartella non riuscita'
+    importErrorFolderFailed: 'Importazione cartella non riuscita',
+    myCapacity: 'La mia capacità',
+    capacityDetail: 'Dettagli',
+    capacitySourceDetail: 'Dettaglio fonti capacità',
+    serviceItem: 'Servizio',
+    expireAt: 'Scadenza',
+    capacity: 'Capacità',
+    total: 'Totale',
+    freeTierName: 'Piano personale gratuito',
+    proTierName: 'Piano personale Pro',
+    ultraTierName: 'Piano personale Ultra',
+    expireNever: 'Mai in scadenza'
   },
   interaction: {
     title: 'Interazione comando richiesta',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1438,7 +1438,18 @@ export default {
     importErrorFileTypeNotAllowed: 'このファイル形式はインポートできません',
     importErrorFileTooLarge: 'ファイルが大きすぎてインポートできません',
     importErrorFileFailed: 'ファイルのインポートに失敗しました',
-    importErrorFolderFailed: 'フォルダのインポートに失敗しました'
+    importErrorFolderFailed: 'フォルダのインポートに失敗しました',
+    myCapacity: 'マイ容量',
+    capacityDetail: '明細',
+    capacitySourceDetail: '容量の内訳',
+    serviceItem: 'サービス',
+    expireAt: '有効期限',
+    capacity: '容量',
+    total: '合計',
+    freeTierName: '個人無料版',
+    proTierName: '個人Proプラン',
+    ultraTierName: '個人Ultraプラン',
+    expireNever: '無期限'
   },
   interaction: {
     waiting: '入力待機中...',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1434,7 +1434,18 @@ export default {
     importErrorFileTypeNotAllowed: '이 파일 형식은 가져올 수 없습니다',
     importErrorFileTooLarge: '파일이 너무 커서 가져올 수 없습니다',
     importErrorFileFailed: '파일 가져오기 실패',
-    importErrorFolderFailed: '폴더 가져오기 실패'
+    importErrorFolderFailed: '폴더 가져오기 실패',
+    myCapacity: '내 용량',
+    capacityDetail: '세부정보',
+    capacitySourceDetail: '용량 출처 세부정보',
+    serviceItem: '서비스',
+    expireAt: '만료일',
+    capacity: '용량',
+    total: '합계',
+    freeTierName: '개인 무료 요금제',
+    proTierName: '개인 Pro 요금제',
+    ultraTierName: '개인 Ultra 요금제',
+    expireNever: '만료 없음'
   },
   interaction: {
     waiting: '입력 대기 중...',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1438,7 +1438,18 @@ export default {
     importErrorFileTypeNotAllowed: 'Este tipo de ficheiro não pode ser importado',
     importErrorFileTooLarge: 'Ficheiro demasiado grande para importar',
     importErrorFileFailed: 'Falha ao importar ficheiro',
-    importErrorFolderFailed: 'Falha ao importar pasta'
+    importErrorFolderFailed: 'Falha ao importar pasta',
+    myCapacity: 'A minha capacidade',
+    capacityDetail: 'Detalhes',
+    capacitySourceDetail: 'Detalhe das fontes de capacidade',
+    serviceItem: 'Serviço',
+    expireAt: 'Expira em',
+    capacity: 'Capacidade',
+    total: 'Total',
+    freeTierName: 'Plano pessoal gratuito',
+    proTierName: 'Plano pessoal Pro',
+    ultraTierName: 'Plano pessoal Ultra',
+    expireNever: 'Nunca expira'
   },
   interaction: {
     title: 'Interacao de comando necessaria',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1437,7 +1437,18 @@ export default {
     importErrorFileTypeNotAllowed: 'Этот тип файла нельзя импортировать',
     importErrorFileTooLarge: 'Файл слишком большой для импорта',
     importErrorFileFailed: 'Не удалось импортировать файл',
-    importErrorFolderFailed: 'Не удалось импортировать папку'
+    importErrorFolderFailed: 'Не удалось импортировать папку',
+    myCapacity: 'Мой объём',
+    capacityDetail: 'Подробнее',
+    capacitySourceDetail: 'Источники объёма',
+    serviceItem: 'Услуга',
+    expireAt: 'Истекает',
+    capacity: 'Объём',
+    total: 'Итого',
+    freeTierName: 'Персональный бесплатный тариф',
+    proTierName: 'Персональный тариф Pro',
+    ultraTierName: 'Персональный тариф Ultra',
+    expireNever: 'Без срока'
   },
   interaction: {
     title: 'Требуется взаимодействие с командой',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -1429,7 +1429,18 @@ export default {
     importErrorFileTypeNotAllowed: '该文件类型不支持导入',
     importErrorFileTooLarge: '文件过大，无法导入',
     importErrorFileFailed: '文件导入失败',
-    importErrorFolderFailed: '文件夹导入失败'
+    importErrorFolderFailed: '文件夹导入失败',
+    myCapacity: '我的容量',
+    capacityDetail: '明细',
+    capacitySourceDetail: '容量来源明细',
+    serviceItem: '服务项',
+    expireAt: '到期时间',
+    capacity: '容量',
+    total: '总计',
+    freeTierName: '个人免费版',
+    proTierName: '个人pro套餐',
+    ultraTierName: '个人ultra套餐',
+    expireNever: '长期有效'
   },
   interaction: {
     waiting: '等待输入...',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -1421,7 +1421,18 @@ export default {
     importErrorFileTypeNotAllowed: '該檔案類型不支援匯入',
     importErrorFileTooLarge: '檔案過大，無法匯入',
     importErrorFileFailed: '檔案匯入失敗',
-    importErrorFolderFailed: '資料夾匯入失敗'
+    importErrorFolderFailed: '資料夾匯入失敗',
+    myCapacity: '我的容量',
+    capacityDetail: '明細',
+    capacitySourceDetail: '容量來源明細',
+    serviceItem: '服務項',
+    expireAt: '到期時間',
+    capacity: '容量',
+    total: '總計',
+    freeTierName: '個人免費版',
+    proTierName: '個人pro套餐',
+    ultraTierName: '個人ultra套餐',
+    expireNever: '長期有效'
   },
   interaction: {
     waiting: '等待輸入...',

--- a/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
+++ b/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
@@ -54,151 +54,165 @@
     >
       <div
         class="kb-tree-wrapper"
-        :class="{
-          'scrollbar-visible': isTreeScrolling,
-          'has-context-menu': isContextMenuOpen
-        }"
+        :class="{ 'has-context-menu': isContextMenuOpen }"
         @click="handleTreeBlankClick"
-        @scroll="handleTreeScroll"
         @contextmenu="handleWrapperContextMenu"
       >
-        <a-directory-tree
-          v-model:expanded-keys="expandedKeys"
-          v-model:selected-keys="selectedKeys"
-          multiple
-          class="kb-tree"
-          block-node
-          draggable
-          :tree-data="filteredTreeData"
-          @select="onSelect"
-          @drop="onDrop"
+        <div
+          class="kb-tree-scroll"
+          :class="{ 'scrollbar-visible': isTreeScrolling }"
+          @scroll="handleTreeScroll"
         >
-          <template #title="{ dataRef }">
-            <a-dropdown
-              :trigger="['contextmenu']"
-              placement="bottomLeft"
-              transition-name=""
-              @visible-change="
-                (visible) => {
-                  if (visible) {
-                    menuKey = dataRef.key
-                  } else if (menuKey === dataRef.key) {
-                    menuKey = null
+          <a-directory-tree
+            v-model:expanded-keys="expandedKeys"
+            v-model:selected-keys="selectedKeys"
+            multiple
+            class="kb-tree"
+            block-node
+            draggable
+            :tree-data="filteredTreeData"
+            @select="onSelect"
+            @drop="onDrop"
+          >
+            <template #title="{ dataRef }">
+              <a-dropdown
+                :trigger="['contextmenu']"
+                placement="bottomLeft"
+                transition-name=""
+                @visible-change="
+                  (visible) => {
+                    if (visible) {
+                      menuKey = dataRef.key
+                    } else if (menuKey === dataRef.key) {
+                      menuKey = null
+                    }
                   }
-                }
-              "
-            >
-              <div
-                class="kb-tree-title"
-                :class="{ 'context-menu-active': menuKey === dataRef.key }"
-                @contextmenu.stop="(event) => handleNodeContextMenu(event, dataRef)"
+                "
               >
-                <span
-                  v-if="editingKey !== dataRef.key"
-                  class="kb-title-text"
-                  >{{ dataRef.title }}</span
+                <div
+                  class="kb-tree-title"
+                  :class="{ 'context-menu-active': menuKey === dataRef.key }"
+                  @contextmenu.stop="(event) => handleNodeContextMenu(event, dataRef)"
                 >
-                <a-input
-                  v-else
-                  ref="inputRef"
-                  v-model:value="editingName"
-                  size="small"
-                  class="kb-rename-input"
-                  @keydown.enter="confirmRename"
-                  @keydown.esc="cancelRename"
-                  @keydown.stop
-                  @blur="handleBlur"
-                  @contextmenu.stop
-                />
-              </div>
-              <template #overlay>
-                <a-menu @click="({ key }) => onContextAction(String(key), dataRef)">
-                  <template v-if="selectedKeys.length > 1 && selectedKeys.includes(dataRef.relPath)">
-                    <a-menu-item
-                      v-if="hasSelectedFile"
-                      key="addToChat"
-                    >
-                      {{ $t('knowledgeCenter.addToChat') }}
-                    </a-menu-item>
-                    <a-menu-item
-                      v-if="hasSelectedFile"
-                      key="copyPath"
-                    >
-                      {{ $t('knowledgeCenter.copyPath') }}
-                    </a-menu-item>
-                    <a-menu-item
-                      key="copy"
-                      class="kb-menu-item-with-shortcut"
-                    >
-                      <span>{{ $t('common.copy') }}</span>
-                      <span class="shortcut-hint">{{ modifierKey }}C</span>
-                    </a-menu-item>
-                    <a-menu-item
-                      key="cut"
-                      class="kb-menu-item-with-shortcut"
-                    >
-                      <span>{{ $t('knowledgeCenter.cut') }}</span>
-                      <span class="shortcut-hint">{{ modifierKey }}X</span>
-                    </a-menu-item>
-                    <a-menu-item key="delete">{{ $t('common.delete') }}</a-menu-item>
-                  </template>
-                  <template v-else>
-                    <a-menu-item
-                      v-if="dataRef.type === 'file'"
-                      key="addToChat"
-                    >
-                      {{ $t('knowledgeCenter.addToChat') }}
-                    </a-menu-item>
-                    <a-menu-item
-                      v-if="dataRef.type === 'dir'"
-                      key="newFile"
-                    >
-                      {{ $t('knowledgeCenter.newFile') }}
-                    </a-menu-item>
-                    <a-menu-item
-                      v-if="dataRef.type === 'dir'"
-                      key="newFolder"
-                    >
-                      {{ $t('knowledgeCenter.newFolder') }}
-                    </a-menu-item>
-                    <a-menu-divider v-if="dataRef.type === 'dir'" />
-                    <a-menu-item key="rename">{{ $t('common.rename') }}</a-menu-item>
-                    <a-menu-item key="delete">{{ $t('common.delete') }}</a-menu-item>
-                    <a-menu-divider />
-                    <a-menu-item
-                      v-if="dataRef.type === 'file'"
-                      key="copyPath"
-                    >
-                      {{ $t('knowledgeCenter.copyPath') }}
-                    </a-menu-item>
-                    <a-menu-item
-                      key="copy"
-                      class="kb-menu-item-with-shortcut"
-                    >
-                      <span>{{ $t('common.copy') }}</span>
-                      <span class="shortcut-hint">{{ modifierKey }}C</span>
-                    </a-menu-item>
-                    <a-menu-item
-                      key="cut"
-                      class="kb-menu-item-with-shortcut"
-                    >
-                      <span>{{ $t('knowledgeCenter.cut') }}</span>
-                      <span class="shortcut-hint">{{ modifierKey }}X</span>
-                    </a-menu-item>
-                    <a-menu-item
-                      v-if="clipboard"
-                      key="paste"
-                      class="kb-menu-item-with-shortcut"
-                    >
-                      <span>{{ $t('common.paste') }}</span>
-                      <span class="shortcut-hint">{{ modifierKey }}V</span>
-                    </a-menu-item>
-                  </template>
-                </a-menu>
-              </template>
-            </a-dropdown>
-          </template>
-        </a-directory-tree>
+                  <span
+                    v-if="editingKey !== dataRef.key"
+                    class="kb-title-text"
+                    >{{ dataRef.title }}</span
+                  >
+                  <a-input
+                    v-else
+                    ref="inputRef"
+                    v-model:value="editingName"
+                    size="small"
+                    class="kb-rename-input"
+                    @keydown.enter="confirmRename"
+                    @keydown.esc="cancelRename"
+                    @keydown.stop
+                    @blur="handleBlur"
+                    @contextmenu.stop
+                  />
+                </div>
+                <template #overlay>
+                  <a-menu @click="({ key }) => onContextAction(String(key), dataRef)">
+                    <template v-if="selectedKeys.length > 1 && selectedKeys.includes(dataRef.relPath)">
+                      <a-menu-item
+                        v-if="hasSelectedFile"
+                        key="addToChat"
+                      >
+                        {{ $t('knowledgeCenter.addToChat') }}
+                      </a-menu-item>
+                      <a-menu-item
+                        v-if="hasSelectedFile"
+                        key="copyPath"
+                      >
+                        {{ $t('knowledgeCenter.copyPath') }}
+                      </a-menu-item>
+                      <a-menu-item
+                        key="copy"
+                        class="kb-menu-item-with-shortcut"
+                      >
+                        <span>{{ $t('common.copy') }}</span>
+                        <span class="shortcut-hint">{{ modifierKey }}C</span>
+                      </a-menu-item>
+                      <a-menu-item
+                        key="cut"
+                        class="kb-menu-item-with-shortcut"
+                      >
+                        <span>{{ $t('knowledgeCenter.cut') }}</span>
+                        <span class="shortcut-hint">{{ modifierKey }}X</span>
+                      </a-menu-item>
+                      <a-menu-item key="delete">{{ $t('common.delete') }}</a-menu-item>
+                    </template>
+                    <template v-else>
+                      <a-menu-item
+                        v-if="dataRef.type === 'file'"
+                        key="addToChat"
+                      >
+                        {{ $t('knowledgeCenter.addToChat') }}
+                      </a-menu-item>
+                      <a-menu-item
+                        v-if="dataRef.type === 'dir'"
+                        key="newFile"
+                      >
+                        {{ $t('knowledgeCenter.newFile') }}
+                      </a-menu-item>
+                      <a-menu-item
+                        v-if="dataRef.type === 'dir'"
+                        key="newFolder"
+                      >
+                        {{ $t('knowledgeCenter.newFolder') }}
+                      </a-menu-item>
+                      <a-menu-divider v-if="dataRef.type === 'dir'" />
+                      <a-menu-item key="rename">{{ $t('common.rename') }}</a-menu-item>
+                      <a-menu-item key="delete">{{ $t('common.delete') }}</a-menu-item>
+                      <a-menu-divider />
+                      <a-menu-item
+                        v-if="dataRef.type === 'file'"
+                        key="copyPath"
+                      >
+                        {{ $t('knowledgeCenter.copyPath') }}
+                      </a-menu-item>
+                      <a-menu-item
+                        key="copy"
+                        class="kb-menu-item-with-shortcut"
+                      >
+                        <span>{{ $t('common.copy') }}</span>
+                        <span class="shortcut-hint">{{ modifierKey }}C</span>
+                      </a-menu-item>
+                      <a-menu-item
+                        key="cut"
+                        class="kb-menu-item-with-shortcut"
+                      >
+                        <span>{{ $t('knowledgeCenter.cut') }}</span>
+                        <span class="shortcut-hint">{{ modifierKey }}X</span>
+                      </a-menu-item>
+                      <a-menu-item
+                        v-if="clipboard"
+                        key="paste"
+                        class="kb-menu-item-with-shortcut"
+                      >
+                        <span>{{ $t('common.paste') }}</span>
+                        <span class="shortcut-hint">{{ modifierKey }}V</span>
+                      </a-menu-item>
+                    </template>
+                  </a-menu>
+                </template>
+              </a-dropdown>
+            </template>
+          </a-directory-tree>
+        </div>
+        <div class="kb-capacity-bar">
+          <CloudOutlined :class="['kb-capacity-icon', { 'kb-capacity-icon-syncing': isSyncing }]" />
+          <div class="kb-capacity-info">
+            <div class="kb-capacity-label">{{ $t('knowledgeCenter.myCapacity') }}</div>
+            <div class="kb-capacity-value">{{ formatCapacity(cloudStorage.usedBytes) }} / {{ formatCapacity(displayTotalBytes) }}</div>
+          </div>
+          <a
+            class="kb-capacity-detail-link"
+            @click.prevent="showCapacityDetail = true"
+            >{{ $t('knowledgeCenter.capacityDetail') }}</a
+          >
+        </div>
       </div>
       <template #overlay>
         <a-menu @click="({ key }) => onBlankContextAction(String(key))">
@@ -216,6 +230,24 @@
         </a-menu>
       </template>
     </a-dropdown>
+
+    <a-modal
+      v-model:open="showCapacityDetail"
+      :title="$t('knowledgeCenter.capacitySourceDetail')"
+      :footer="null"
+      width="480px"
+      class="kb-capacity-detail-modal"
+      @cancel="showCapacityDetail = false"
+    >
+      <a-table
+        :columns="capacityDetailColumns"
+        :data-source="capacityDetailData"
+        :pagination="false"
+        size="small"
+        row-key="key"
+      />
+      <div class="kb-capacity-total"> {{ $t('knowledgeCenter.total') }}: {{ formatCapacity(displayTotalBytes) }} </div>
+    </a-modal>
 
     <div
       v-if="Object.keys(importJobs).length"
@@ -241,8 +273,18 @@ import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'v
 import { useI18n } from 'vue-i18n'
 import { message, Modal } from 'ant-design-vue'
 import eventBus from '@/utils/eventBus'
-import { CloudUploadOutlined, FileAddOutlined, FolderAddOutlined, PlusOutlined, RedoOutlined, SearchOutlined } from '@ant-design/icons-vue'
+import { getUser } from '@/api/user/user'
+import {
+  CloudOutlined,
+  CloudUploadOutlined,
+  FileAddOutlined,
+  FolderAddOutlined,
+  PlusOutlined,
+  RedoOutlined,
+  SearchOutlined
+} from '@ant-design/icons-vue'
 import { getModifierSymbol, hasPreviewTextSelection, isShortcutEvent } from './utils/kbShortcuts'
+import { resolveKbCapacityDisplay } from './utils/kbCapacity'
 import { getImageMediaType, isImageFile } from '../AiTab/utils'
 
 type KbNodeType = 'file' | 'dir'
@@ -257,6 +299,68 @@ type TreeNode = {
 
 const { t } = useI18n()
 const api = window.api
+
+const cloudStorage = ref({ usedBytes: 0, totalBytes: 1024 * 1024 * 1024 })
+const showCapacityDetail = ref(false)
+const isDeletingCount = ref(0)
+const subscription = ref<string | undefined>(undefined)
+
+const capacityDetailColumns = [
+  { title: () => t('knowledgeCenter.serviceItem'), dataIndex: 'name', key: 'name' },
+  { title: () => t('knowledgeCenter.expireAt'), dataIndex: 'expireAt', key: 'expireAt' },
+  { title: () => t('knowledgeCenter.capacity'), dataIndex: 'capacity', key: 'capacity' }
+]
+const capacityDisplay = computed(() => resolveKbCapacityDisplay(subscription.value))
+const displayTotalBytes = computed(() => capacityDisplay.value.totalBytes)
+const capacityDetailData = computed(() => {
+  const tier = capacityDisplay.value.tier
+  const nameKey = tier === 'pro' ? 'knowledgeCenter.proTierName' : tier === 'ultra' ? 'knowledgeCenter.ultraTierName' : 'knowledgeCenter.freeTierName'
+  return [
+    {
+      key: tier === 'pro' || tier === 'ultra' ? tier : 'free',
+      name: t(nameKey),
+      expireAt: t('knowledgeCenter.expireNever'),
+      capacity: formatCapacity(displayTotalBytes.value)
+    }
+  ]
+})
+
+function formatCapacity(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(2)} KB`
+  }
+  return `${bytes} B`
+}
+
+async function loadCloudStorage(): Promise<void> {
+  try {
+    if (api?.getKbCloudStorage) {
+      const res = await api.getKbCloudStorage()
+      cloudStorage.value = { usedBytes: res.usedBytes ?? 0, totalBytes: res.totalBytes ?? 1024 * 1024 * 1024 }
+    }
+  } catch {
+    // keep default
+  }
+}
+
+async function loadUserSubscription(): Promise<void> {
+  if (localStorage.getItem('login-skipped') === 'true') {
+    subscription.value = undefined
+    return
+  }
+  try {
+    const res: any = await getUser({})
+    subscription.value = typeof res?.data?.subscription === 'string' ? res.data.subscription : undefined
+  } catch {
+    subscription.value = undefined
+  }
+}
 
 function importErrorMessage(err: unknown, forFolder: boolean): string {
   const msg = err instanceof Error ? err.message : String(err)
@@ -629,6 +733,7 @@ async function removeNode(node: TreeNode) {
     content: node.type === 'dir' ? 'Delete folder and its contents?' : 'Delete file?',
     okType: 'danger',
     onOk: async () => {
+      isDeletingCount.value += 1
       try {
         await api.kbDelete(node.relPath, node.type === 'dir')
         await refreshDir(getDirOf(node.relPath))
@@ -636,6 +741,9 @@ async function removeNode(node: TreeNode) {
       } catch (e: unknown) {
         const error = e as Error
         message.error(error?.message || String(e))
+      } finally {
+        isDeletingCount.value -= 1
+        void loadCloudStorage()
       }
     }
   })
@@ -932,6 +1040,7 @@ async function onContextAction(action: string, node: TreeNode) {
         content: `Delete ${targets.length} items?`,
         okType: 'danger',
         onOk: async () => {
+          isDeletingCount.value += 1
           try {
             // Delete deeper paths first to reduce parent/child conflicts
             const sortedTargets = targets.slice().sort((a, b) => b.split('/').filter(Boolean).length - a.split('/').filter(Boolean).length)
@@ -952,6 +1061,9 @@ async function onContextAction(action: string, node: TreeNode) {
           } catch (e: unknown) {
             const error = e as Error
             message.error(error?.message || String(e))
+          } finally {
+            isDeletingCount.value -= 1
+            void loadCloudStorage()
           }
         }
       })
@@ -1023,6 +1135,8 @@ const importJobList = computed(() => {
     percent: j.total ? Math.floor((j.transferred / j.total) * 100) : 0
   }))
 })
+
+const isSyncing = computed(() => Object.keys(importJobs).length > 0 || isDeletingCount.value > 0)
 
 const unsubscribeProgress = ref<(() => void) | null>(null)
 
@@ -1106,6 +1220,8 @@ async function handleDropImport(e: DragEvent) {
 onMounted(async () => {
   await api.kbEnsureRoot()
   await refreshDir('')
+  await loadCloudStorage()
+  await loadUserSubscription()
   eventBus.on('kbActiveFileChanged', handleActiveKbTab)
   eventBus.on('kbRefresh', handleRefresh)
   eventBus.on('kbRefreshAndOpen', handleRefreshAndOpen)
@@ -1116,6 +1232,7 @@ onMounted(async () => {
       importJobs[data.jobId] = { jobId: data.jobId, destRelPath: data.destRelPath, transferred: data.transferred, total: data.total }
       if (data.total === 0) {
         window.setTimeout(() => {
+          void loadCloudStorage()
           delete importJobs[data.jobId]
         }, 1500)
       }
@@ -1125,6 +1242,7 @@ onMounted(async () => {
     job.total = data.total
     if (data.total > 0 && data.transferred >= data.total) {
       window.setTimeout(() => {
+        void loadCloudStorage()
         delete importJobs[data.jobId]
       }, 1500)
     }
@@ -1231,10 +1349,17 @@ onBeforeUnmount(() => {
 
 .kb-tree-wrapper {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  margin-top: 4px;
+}
+
+.kb-tree-scroll {
+  flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  margin-top: 4px;
-  padding-bottom: 25px;
+  padding-bottom: 8px;
 
   /* Scrollbar styles - align with Workspace */
   &::-webkit-scrollbar {
@@ -1267,6 +1392,74 @@ onBeforeUnmount(() => {
   &.scrollbar-visible {
     scrollbar-color: var(--border-color-light) transparent;
   }
+}
+
+.kb-capacity-bar {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  margin: 0 8px 8px;
+  background: var(--hover-bg-color, rgba(0, 0, 0, 0.04));
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.kb-capacity-icon {
+  color: var(--text-color-secondary);
+  font-size: 18px;
+  margin-top: 2px;
+}
+
+@keyframes kb-cloud-sync {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-3px);
+    opacity: 0.7;
+  }
+}
+
+.kb-capacity-icon-syncing {
+  animation: kb-cloud-sync 1.2s ease-in-out infinite;
+  color: @kb-primary-color;
+}
+
+.kb-capacity-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.kb-capacity-label {
+  font-size: 12px;
+  color: var(--text-color);
+  font-weight: 500;
+}
+
+.kb-capacity-value {
+  font-size: 12px;
+  color: var(--text-color-secondary);
+  margin-top: 2px;
+}
+
+.kb-capacity-detail-link {
+  font-size: 12px;
+  color: var(--kb-primary-color);
+  flex-shrink: 0;
+  &:hover {
+    color: var(--kb-primary-color);
+    opacity: 0.85;
+  }
+}
+
+.kb-capacity-total {
+  margin-top: 12px;
+  text-align: right;
+  font-size: 13px;
+  color: var(--text-color);
 }
 
 .kb-tree {
@@ -1418,5 +1611,48 @@ onBeforeUnmount(() => {
     font-size: 12px;
     flex-shrink: 0;
   }
+}
+</style>
+
+<style>
+/* AntD modal/table are teleported to body; keep this non-scoped. */
+.kb-capacity-detail-modal .ant-modal-content,
+.kb-capacity-detail-modal .ant-modal-header,
+.kb-capacity-detail-modal .ant-modal-body {
+  background-color: var(--bg-color-secondary) !important;
+  color: var(--text-color) !important;
+}
+
+.kb-capacity-detail-modal .ant-modal-header {
+  border-bottom: 1px solid var(--border-color-light) !important;
+}
+
+.kb-capacity-detail-modal .ant-modal-title,
+.kb-capacity-detail-modal .ant-modal-close,
+.kb-capacity-detail-modal .ant-modal-close-x {
+  color: var(--text-color) !important;
+}
+
+.kb-capacity-detail-modal .ant-table,
+.kb-capacity-detail-modal .ant-table-container,
+.kb-capacity-detail-modal .ant-table-content {
+  background: transparent !important;
+  color: var(--text-color) !important;
+}
+
+.kb-capacity-detail-modal .ant-table-thead > tr > th {
+  background-color: var(--bg-color-tertiary) !important;
+  color: var(--text-color) !important;
+  border-bottom: 1px solid var(--border-color-light) !important;
+}
+
+.kb-capacity-detail-modal .ant-table-tbody > tr > td {
+  background-color: transparent !important;
+  color: var(--text-color-secondary) !important;
+  border-bottom: 1px solid var(--border-color-light) !important;
+}
+
+.kb-capacity-detail-modal .ant-table-tbody > tr:hover > td {
+  background-color: var(--hover-bg-color) !important;
 }
 </style>

--- a/src/renderer/src/views/components/KnowledgeCenter/utils/kbCapacity.ts
+++ b/src/renderer/src/views/components/KnowledgeCenter/utils/kbCapacity.ts
@@ -1,0 +1,17 @@
+export type SubscriptionTier = 'free' | 'lite' | 'pro' | 'ultra' | 'unknown'
+
+export interface KbCapacityDisplay {
+  tier: SubscriptionTier
+  totalBytes: number
+}
+
+const GIB = 1024 * 1024 * 1024
+
+export function resolveKbCapacityDisplay(subscription?: string): KbCapacityDisplay {
+  const raw = (subscription ?? '').trim().toLowerCase()
+  const tier: SubscriptionTier =
+    raw === 'pro' ? 'pro' : raw === 'ultra' ? 'ultra' : raw === 'lite' ? 'lite' : raw === 'free' || raw === '' ? 'free' : 'unknown'
+
+  const totalBytes = tier === 'pro' || tier === 'ultra' ? 50 * GIB : 1 * GIB
+  return { tier, totalBytes }
+}


### PR DESCRIPTION
…, enhance UI with capacity details

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "My Capacity" section in Knowledge Center displaying cloud storage usage with a syncing animation and capacity details modal.

* **Documentation**
  * Added multilingual translations for capacity-related UI labels across 11 language versions (English, German, French, Italian, Japanese, Korean, Portuguese, Russian, Arabic, and Simplified/Traditional Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->