### PR TITLE
fix: change default theme from 'auto' to 'dark' across user configura…

### DIFF
--- a/src/renderer/src/services/userConfigStoreService.ts
+++ b/src/renderer/src/services/userConfigStoreService.ts
@@ -111,7 +111,7 @@ export class UserConfigStoreService {
       watermark: 'open' as 'open' | 'close',
       secretRedaction: 'disabled' as 'enabled' | 'disabled',
       dataSync: 'disabled' as 'enabled' | 'disabled',
-      theme: 'auto' as 'dark' | 'light' | 'auto',
+      theme: 'dark' as 'dark' | 'light' | 'auto',
       defaultLayout: 'terminal' as 'terminal' | 'agents',
       feature: 0.0,
       quickComand: false,

--- a/src/renderer/src/store/userConfigStore.ts
+++ b/src/renderer/src/store/userConfigStore.ts
@@ -19,7 +19,7 @@ export const userConfigStore = defineStore('userConfig', {
         dataSync: 'disabled',
         feature: 0.0,
         terminalType: 'xterm',
-        theme: 'auto',
+        theme: 'dark',
         background: {
           image: '',
           opacity: 0.15,
@@ -73,7 +73,7 @@ export const userConfigStore = defineStore('userConfig', {
           dataSync: 'disabled',
           feature: 0.0,
           terminalType: 'xterm',
-          theme: 'auto',
+          theme: 'dark',
           background: {
             image: '',
             opacity: 0.15,

--- a/src/renderer/src/utils/themeUtils.js
+++ b/src/renderer/src/utils/themeUtils.js
@@ -15,7 +15,7 @@ export function prefersDarkMode() {
 export async function initializeThemeFromDatabase() {
   const { userConfigStore } = await import('../services/userConfigStoreService')
   const config = await userConfigStore.getConfig()
-  const dbTheme = config.theme || 'auto'
+  const dbTheme = config.theme || 'dark'
   const actualTheme = getActualTheme(dbTheme)
 
   // Set document theme class

--- a/src/renderer/src/views/components/LeftTab/setting/__tests__/general.test.ts
+++ b/src/renderer/src/views/components/LeftTab/setting/__tests__/general.test.ts
@@ -180,7 +180,7 @@ describe('General Component', () => {
     ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
       language: 'zh-CN',
       watermark: 'open',
-      theme: 'auto',
+      theme: 'dark',
       defaultLayout: 'terminal',
       lastCustomImage: '',
       background: {
@@ -266,6 +266,9 @@ describe('General Component', () => {
         message: 'Failed to load config',
         description: 'Failed to load configuration'
       })
+      const vm = wrapper.vm as any
+      expect(vm.userConfig.theme).toBe('dark')
+      expect(document.documentElement.className).toBe('theme-dark')
     })
   })
 

--- a/src/renderer/src/views/components/LeftTab/setting/general.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/general.vue
@@ -311,7 +311,7 @@ const editorConfigStore = useEditorConfigStore()
 const userConfig = ref({
   language: 'zh-CN',
   watermark: 'open',
-  theme: 'auto',
+  theme: 'dark',
   defaultLayout: 'terminal',
   lastCustomImage: '',
   background: {
@@ -382,9 +382,9 @@ const loadSavedConfig = async () => {
       message: t('user.loadConfigFailed'),
       description: t('user.loadConfigFailedDescription')
     })
-    const actualTheme = getActualTheme('auto')
+    const actualTheme = getActualTheme('dark')
     document.documentElement.className = `theme-${actualTheme}`
-    userConfig.value.theme = 'auto'
+    userConfig.value.theme = 'dark'
   }
 }
 

--- a/src/renderer/src/views/layouts/TerminalLayout.vue
+++ b/src/renderer/src/views/layouts/TerminalLayout.vue
@@ -793,7 +793,7 @@ onMounted(async () => {
     }
     store.setUserConfig(config)
     configLoaded.value = true
-    currentTheme.value = getActualTheme(config.theme || 'auto')
+    currentTheme.value = getActualTheme(config.theme || 'dark')
 
     // Delay of 2 seconds to wait for the main thread to complete initializeTelemetrySetting
     setTimeout(async () => {
@@ -814,7 +814,7 @@ onMounted(async () => {
       showWatermark.value = config.watermark !== 'close'
     })
   } catch (e) {
-    currentTheme.value = getActualTheme('auto')
+    currentTheme.value = getActualTheme('dark')
     nextTick(() => {
       showWatermark.value = true
     })


### PR DESCRIPTION
…tion and related components

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Changed default application theme from auto-detection to dark mode. The application now launches with dark theme enabled by default and maintains dark theme as the fallback in configuration error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->