### PR TITLE
feat: add user config and rules sync services

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1143,10 +1143,17 @@ function setupIPC(): void {
       if (params?.key) {
         const row = db.getKeyValue(params.key)
         if (row && row.value) {
-          // Use safeParse to deserialize superjson formatted data
-          const { safeParse } = await import('./storage/db/json-serializer')
-          const parsedValue = await safeParse(row.value)
-          return { ...row, value: JSON.stringify(parsedValue) }
+          const { deserializeStoredKvValue } = await import('./storage/db/kv-serialization')
+          const deserialized = await deserializeStoredKvValue(row.value)
+          if (deserialized.source !== 'superjson') {
+            logger.warn('db:kv:get used compatibility fallback for stored KV value', {
+              key: params.key,
+              userId,
+              source: deserialized.source,
+              rawPrefix: typeof row.value === 'string' ? row.value.slice(0, 200) : row.value
+            })
+          }
+          return { ...row, value: JSON.stringify(deserialized.value) }
         }
         return row
       } else {
@@ -1209,6 +1216,25 @@ function setupIPC(): void {
     }
   })
 
+  // Handler 6: KV transaction (atomic batch write)
+  ipcMain.handle('db:kv:transaction', async (_event, ops: Array<{ action: 'set' | 'delete'; key: string; value?: string }>) => {
+    try {
+      let userId = getCurrentUserId()
+
+      if (!userId) {
+        userId = getGuestUserId()
+      }
+
+      const db = await ChatermDatabaseService.getInstance(userId)
+      const { serializeKvTransactionOps } = await import('./storage/db/kv-serialization')
+      const serializedOps = await serializeKvTransactionOps(ops)
+      await db.kvTransaction(serializedOps)
+    } catch (error) {
+      logger.error('db:kv:transaction error', { error: error })
+      throw error
+    }
+  })
+
   // Unified version related operation handler
   ipcMain.handle('version:operation', async (_event, operation: string, payload?: any) => {
     try {
@@ -1229,44 +1255,6 @@ function setupIPC(): void {
     } catch (error) {
       logger.error(`version:operation [${operation}] error`, { error: error })
 
-      throw error
-    }
-  })
-
-  // Editor configuration handlers
-  ipcMain.handle('get-editor-config', async () => {
-    try {
-      const configPath = join(app.getPath('userData'), 'setting', 'editor-config.json')
-      try {
-        const configData = await fs.readFile(configPath, 'utf-8')
-        return JSON.parse(configData)
-      } catch (error: any) {
-        // If file doesn't exist, return null to use default config
-        if (error.code === 'ENOENT') {
-          return null
-        }
-        throw error
-      }
-    } catch (error) {
-      logger.error('Failed to get editor config:', { error: error })
-      throw error
-    }
-  })
-
-  ipcMain.handle('save-editor-config', async (_event, config) => {
-    try {
-      const configPath = join(app.getPath('userData'), 'setting', 'editor-config.json')
-      const configDir = join(app.getPath('userData'), 'setting')
-
-      // Ensure directory exists
-      await fs.mkdir(configDir, { recursive: true })
-
-      // Save config
-      await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
-
-      return { success: true }
-    } catch (error) {
-      logger.error('Failed to save editor config:', { error: error })
       throw error
     }
   })

--- a/src/main/storage/db/chaterm.service.ts
+++ b/src/main/storage/db/chaterm.service.ts
@@ -909,6 +909,32 @@ export class ChatermDatabaseService {
     }
   }
 
+  /**
+   * Execute multiple KV operations in a single SQLite transaction.
+   * All operations succeed or all are rolled back.
+   * Usage: Renderer process calls via window.api.kvTransaction(callback)
+   */
+  kvTransaction(ops: Array<{ action: 'set' | 'delete'; key: string; value?: string }>): void {
+    const setStmt = this.db.prepare('INSERT OR REPLACE INTO key_value_store (key, value, updated_at) VALUES (?, ?, ?)')
+    const deleteStmt = this.db.prepare('DELETE FROM key_value_store WHERE key = ?')
+
+    this.db.transaction(() => {
+      const now = Date.now()
+      for (const op of ops) {
+        switch (op.action) {
+          case 'set':
+            setStmt.run(op.key, op.value, now)
+            break
+          case 'delete':
+            deleteStmt.run(op.key)
+            break
+          default:
+            throw new Error(`Invalid KV transaction action: ${(op as any).action}`)
+        }
+      }
+    })()
+  }
+
   // ==================== Chat Sync V2 Methods ====================
 
   /**

--- a/src/main/storage/db/kv-serialization.test.ts
+++ b/src/main/storage/db/kv-serialization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { deserializeStoredKvValue, serializeKvTransactionOps } from './kv-serialization'
+
+describe('kv serialization helpers', () => {
+  it('serializes transaction set values so they round-trip through the KV read path', async () => {
+    const ops = await serializeKvTransactionOps([
+      {
+        action: 'set',
+        key: 'userConfig',
+        value: JSON.stringify({ theme: 'light', watermark: 'open' })
+      }
+    ])
+
+    expect(ops[0]?.action).toBe('set')
+    if (ops[0]?.action !== 'set') {
+      throw new Error('Expected first op to be a set op')
+    }
+    expect(ops[0].value).not.toBe(JSON.stringify({ theme: 'light', watermark: 'open' }))
+
+    const decoded = await deserializeStoredKvValue(ops[0].value)
+
+    expect(decoded.source).toBe('superjson')
+    expect(decoded.value).toEqual({ theme: 'light', watermark: 'open' })
+  })
+
+  it('falls back to plain JSON for legacy transaction-written rows', async () => {
+    const decoded = await deserializeStoredKvValue(JSON.stringify({ theme: 'light', watermark: 'open' }))
+
+    expect(decoded.source).toBe('plain_json')
+    expect(decoded.value).toEqual({ theme: 'light', watermark: 'open' })
+  })
+})

--- a/src/main/storage/db/kv-serialization.ts
+++ b/src/main/storage/db/kv-serialization.ts
@@ -1,0 +1,63 @@
+import { safeParse, safeStringify } from './json-serializer'
+
+export type KvTransactionOp = { action: 'set'; key: string; value: string } | { action: 'delete'; key: string }
+
+export interface DeserializedKvValue {
+  value: unknown
+  source: 'superjson' | 'plain_json' | 'invalid'
+}
+
+export async function serializeKvTransactionOps(ops: Array<{ action: 'set' | 'delete'; key: string; value?: string }>): Promise<KvTransactionOp[]> {
+  const serializedOps: KvTransactionOp[] = []
+
+  for (const op of ops) {
+    if (op.action === 'delete') {
+      serializedOps.push({
+        action: 'delete',
+        key: op.key
+      })
+      continue
+    }
+
+    if (op.value === undefined) {
+      throw new Error(`KV transaction set action requires value for key ${op.key}`)
+    }
+
+    const valueObj = JSON.parse(op.value)
+    const result = await safeStringify(valueObj)
+    if (!result.success || !result.data) {
+      throw new Error(`Failed to serialize KV transaction value for key ${op.key}: ${result.error || 'unknown error'}`)
+    }
+
+    serializedOps.push({
+      action: 'set',
+      key: op.key,
+      value: result.data
+    })
+  }
+
+  return serializedOps
+}
+
+export async function deserializeStoredKvValue(rawValue: string): Promise<DeserializedKvValue> {
+  const parsedValue = await safeParse(rawValue)
+
+  if (parsedValue !== undefined && parsedValue !== null) {
+    return {
+      value: parsedValue,
+      source: 'superjson'
+    }
+  }
+
+  try {
+    return {
+      value: JSON.parse(rawValue),
+      source: 'plain_json'
+    }
+  } catch {
+    return {
+      value: parsedValue,
+      source: 'invalid'
+    }
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -132,6 +132,16 @@ export interface BastionDefinition {
   uiHints?: Record<string, unknown>
 }
 
+// KV transaction operation type
+type KvOp = { action: 'set'; key: string; value: string } | { action: 'delete'; key: string }
+
+// KV transaction context for collecting operations in renderer process
+interface KvTransactionContext {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string): void
+  delete(key: string): void
+}
+
 interface ApiType {
   getCookie: (name: string) => Promise<{
     success: boolean
@@ -293,6 +303,7 @@ interface ApiType {
   aliasesMutate: (params: { action: string; data?: any; alias?: string }) => Promise<void>
   kvGet: (params: { key?: string }) => Promise<any>
   kvMutate: (params: { action: string; key: string; value?: string }) => Promise<void>
+  kvTransaction: (callback: (tx: KvTransactionContext) => Promise<void>) => Promise<void>
   chatermGetChatermMessages: (data: { taskId: string }) => Promise<any>
   getTaskMetadata: (taskId: string) => Promise<{
     success: boolean
@@ -401,10 +412,6 @@ interface ApiType {
   getBastionDefinition: (type: string) => Promise<BastionDefinition | undefined>
   // Check if a specific bastion type is available
   hasBastionCapability: (type: string) => Promise<boolean>
-
-  // Editor configuration
-  getEditorConfig: () => Promise<any>
-  saveEditorConfig: (config: any) => Promise<{ success: boolean }>
 
   // K8s related APIs
   k8sGetContexts: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1070,6 +1070,30 @@ const api = {
   aliasesMutate: (params: { action: string; data?: any; alias?: string }) => ipcRenderer.invoke('db:aliases:mutate', params),
   kvGet: (params: { key?: string }) => ipcRenderer.invoke('db:kv:get', params),
   kvMutate: (params: { action: string; key: string; value?: string }) => ipcRenderer.invoke('db:kv:mutate', params),
+  async kvTransaction(
+    callback: (tx: { get(key: string): Promise<string | null>; set(key: string, value: string): void; delete(key: string): void }) => Promise<void>
+  ): Promise<void> {
+    const ops: Array<{ action: 'set'; key: string; value: string } | { action: 'delete'; key: string }> = []
+    const tx = {
+      async get(key: string): Promise<string | null> {
+        const row = await ipcRenderer.invoke('db:kv:get', { key })
+        if (row && row.value) {
+          return row.value
+        }
+        return null
+      },
+      set(key: string, value: string): void {
+        ops.push({ action: 'set', key, value })
+      },
+      delete(key: string): void {
+        ops.push({ action: 'delete', key })
+      }
+    }
+    await callback(tx)
+    if (ops.length > 0) {
+      await ipcRenderer.invoke('db:kv:transaction', ops)
+    }
+  },
   saveCustomBackground: (sourcePath: string) => ipcRenderer.invoke('saveCustomBackground', sourcePath),
 
   // Plugin
@@ -1152,10 +1176,6 @@ const api = {
     ipcRenderer.on('plugin:open-user-tab-request', subscription)
     return () => ipcRenderer.removeListener('plugin:open-user-tab-request', subscription)
   },
-
-  // Editor configuration
-  getEditorConfig: () => ipcRenderer.invoke('get-editor-config'),
-  saveEditorConfig: (config: any) => ipcRenderer.invoke('save-editor-config', config),
 
   // Get registered bastion types (plugin-based, not including built-in JumpServer)
   getRegisteredBastionTypes(): Promise<string[]> {

--- a/src/renderer/src/agent/storage/state.ts
+++ b/src/renderer/src/agent/storage/state.ts
@@ -15,11 +15,50 @@ import { GlobalStateKey, SecretKey } from './state-keys'
 import { storageContext } from './storage-context'
 import { getUserInfo } from '@/utils/permission'
 import { userConfigStore } from '@/store/userConfigStore'
+import { markSyncMetaDirty } from '@/services/configSyncManager'
 
 // global
 
+const AI_PREFERENCE_SYNC_KEYS = new Set<GlobalStateKey>([
+  'thinkingBudgetTokens',
+  'reasoningEffort',
+  'autoApprovalSettings',
+  'chatSettings',
+  'needProxy',
+  'proxyConfig',
+  'shellIntegrationTimeout'
+])
+
+function scheduleAiPreferencesSync(): void {
+  void import('@/services/aiPreferencesSyncService')
+    .then(async ({ aiPreferencesSyncService }) => {
+      await markSyncMetaDirty('aiPreferencesSyncMeta', 1)
+      aiPreferencesSyncService.scheduleUpload()
+    })
+    .catch(() => {
+      // Sync service may not be initialized yet, ignore.
+    })
+}
+
+function scheduleUserRulesSync(): void {
+  void import('@/services/userRulesSyncService')
+    .then(async ({ userRulesSyncService }) => {
+      await markSyncMetaDirty('userRulesSyncMeta', 1)
+      userRulesSyncService.scheduleUpload()
+    })
+    .catch(() => {
+      // Sync service may not be initialized yet, ignore.
+    })
+}
+
 export async function updateGlobalState(key: GlobalStateKey, value: any) {
   await storageContext.globalState.update(key, value)
+  if (AI_PREFERENCE_SYNC_KEYS.has(key)) {
+    scheduleAiPreferencesSync()
+  }
+  if (key === 'userRules') {
+    scheduleUserRulesSync()
+  }
 }
 
 export async function getGlobalState(key: GlobalStateKey) {

--- a/src/renderer/src/api/sync/sync.ts
+++ b/src/renderer/src/api/sync/sync.ts
@@ -1,0 +1,31 @@
+import syncRequest from '@/utils/syncRequest'
+
+const urls = {
+  getUserTermConfig: '/sync/user-config',
+  updateUserTermConfig: '/sync/user-config'
+}
+
+export function getUserTermConfig(params: { configType?: string }, options?: { signal?: AbortSignal }) {
+  return syncRequest({
+    method: 'get',
+    url: urls.getUserTermConfig,
+    params: params,
+    signal: options?.signal
+  })
+}
+
+export function updateUserTermConfig(
+  data: {
+    schemaVersion: number
+    config: string
+    configType?: string
+  },
+  options?: { signal?: AbortSignal }
+) {
+  return syncRequest({
+    method: 'put',
+    url: urls.updateUserTermConfig,
+    data: data,
+    signal: options?.signal
+  })
+}

--- a/src/renderer/src/api/user/user.ts
+++ b/src/renderer/src/api/user/user.ts
@@ -20,8 +20,6 @@ const urls = {
   userLogin: '/user/login-pwd',
   userLogOut: '/user/login-out',
   getUser: '/user/info',
-  getUserTermConfig: '/user/term-config',
-  updateUserTermConfig: '/user/term-config',
   userQuickCommand: '/user/quick-command',
   userQuickCommandInfo: '/user/quick-command/info',
   aliasUpdateTerm: '/term-api/alias/update',
@@ -106,22 +104,6 @@ export function getUser(params) {
     method: 'get',
     url: urls.getUser,
     params: params
-  })
-}
-
-export function getUserTermConfig(params) {
-  return request({
-    method: 'get',
-    url: urls.getUserTermConfig,
-    params: params
-  })
-}
-
-export function updateUserTermConfig(data) {
-  return request({
-    method: 'put',
-    url: urls.updateUserTermConfig,
-    data: data
   })
 }
 

--- a/src/renderer/src/services/__tests__/dataSyncService.test.ts
+++ b/src/renderer/src/services/__tests__/dataSyncService.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockGetStoredUserConfigSnapshot,
+  mockResolveDataSyncPreference,
+  mockChatSyncInitialize,
+  mockChatSyncEnable,
+  mockChatSyncDisable,
+  mockChatSyncReset,
+  mockUserConfigSyncInitialize,
+  mockUserConfigSyncStop,
+  mockUserConfigSyncReset,
+  mockEditorConfigSyncInitialize,
+  mockEditorConfigSyncStop,
+  mockEditorConfigSyncReset,
+  mockUserRulesSyncInitialize,
+  mockUserRulesSyncStop,
+  mockUserRulesSyncReset,
+  mockAiPreferencesSyncInitialize,
+  mockAiPreferencesSyncStop,
+  mockAiPreferencesSyncReset
+} = vi.hoisted(() => ({
+  mockGetStoredUserConfigSnapshot: vi.fn(),
+  mockResolveDataSyncPreference: vi.fn(),
+  mockChatSyncInitialize: vi.fn(),
+  mockChatSyncEnable: vi.fn(),
+  mockChatSyncDisable: vi.fn(),
+  mockChatSyncReset: vi.fn(),
+  mockUserConfigSyncInitialize: vi.fn(),
+  mockUserConfigSyncStop: vi.fn(),
+  mockUserConfigSyncReset: vi.fn(),
+  mockEditorConfigSyncInitialize: vi.fn(),
+  mockEditorConfigSyncStop: vi.fn(),
+  mockEditorConfigSyncReset: vi.fn(),
+  mockUserRulesSyncInitialize: vi.fn(),
+  mockUserRulesSyncStop: vi.fn(),
+  mockUserRulesSyncReset: vi.fn(),
+  mockAiPreferencesSyncInitialize: vi.fn(),
+  mockAiPreferencesSyncStop: vi.fn(),
+  mockAiPreferencesSyncReset: vi.fn()
+}))
+
+vi.mock('../userConfigStoreService', () => ({
+  getStoredUserConfigSnapshot: mockGetStoredUserConfigSnapshot,
+  resolveDataSyncPreference: mockResolveDataSyncPreference
+}))
+
+vi.mock('../chatSyncService', () => ({
+  chatSyncService: {
+    initialize: mockChatSyncInitialize,
+    enable: mockChatSyncEnable,
+    disable: mockChatSyncDisable,
+    reset: mockChatSyncReset
+  }
+}))
+
+vi.mock('../userConfigSyncService', () => ({
+  userConfigSyncService: {
+    initialize: mockUserConfigSyncInitialize,
+    stop: mockUserConfigSyncStop,
+    reset: mockUserConfigSyncReset
+  }
+}))
+
+vi.mock('../editorConfigSyncService', () => ({
+  editorConfigSyncService: {
+    initialize: mockEditorConfigSyncInitialize,
+    stop: mockEditorConfigSyncStop,
+    reset: mockEditorConfigSyncReset
+  }
+}))
+
+vi.mock('../userRulesSyncService', () => ({
+  userRulesSyncService: {
+    initialize: mockUserRulesSyncInitialize,
+    stop: mockUserRulesSyncStop,
+    reset: mockUserRulesSyncReset
+  }
+}))
+
+vi.mock('../aiPreferencesSyncService', () => ({
+  aiPreferencesSyncService: {
+    initialize: mockAiPreferencesSyncInitialize,
+    stop: mockAiPreferencesSyncStop,
+    reset: mockAiPreferencesSyncReset
+  }
+}))
+
+describe('DataSyncService', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    ;(window as any).api = {
+      setDataSyncEnabled: vi.fn(async () => ({ success: true }))
+    }
+
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => {
+      if (key === 'login-skipped') return null
+      if (key === 'ctm-token') return 'test-token'
+      return null
+    })
+
+    mockGetStoredUserConfigSnapshot.mockResolvedValue({})
+    mockResolveDataSyncPreference.mockReturnValue('enabled')
+    mockChatSyncInitialize.mockResolvedValue(undefined)
+    mockChatSyncEnable.mockResolvedValue(true)
+    mockChatSyncDisable.mockResolvedValue(true)
+    mockUserConfigSyncInitialize.mockResolvedValue(undefined)
+    mockEditorConfigSyncInitialize.mockResolvedValue(undefined)
+    mockUserRulesSyncInitialize.mockResolvedValue(undefined)
+    mockAiPreferencesSyncInitialize.mockResolvedValue(undefined)
+  })
+
+  it('enables chat sync and all config sync services when dataSync is enabled', async () => {
+    const { dataSyncService } = await import('../dataSyncService')
+
+    const ok = await dataSyncService.enableDataSync()
+
+    expect(ok).toBe(true)
+    expect((window as any).api.setDataSyncEnabled).toHaveBeenCalledWith(true)
+    expect(mockChatSyncEnable).toHaveBeenCalledTimes(1)
+    expect(mockUserConfigSyncInitialize).toHaveBeenCalledTimes(1)
+    expect(mockEditorConfigSyncInitialize).toHaveBeenCalledTimes(1)
+    expect(mockUserRulesSyncInitialize).toHaveBeenCalledTimes(1)
+    expect(mockAiPreferencesSyncInitialize).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables chat sync and stops all config sync services when dataSync is disabled', async () => {
+    const { dataSyncService } = await import('../dataSyncService')
+
+    const ok = await dataSyncService.disableDataSync()
+
+    expect(ok).toBe(true)
+    expect((window as any).api.setDataSyncEnabled).toHaveBeenCalledWith(false)
+    expect(mockChatSyncDisable).toHaveBeenCalledTimes(1)
+    expect(mockUserConfigSyncStop).toHaveBeenCalledTimes(1)
+    expect(mockEditorConfigSyncStop).toHaveBeenCalledTimes(1)
+    expect(mockUserRulesSyncStop).toHaveBeenCalledTimes(1)
+    expect(mockAiPreferencesSyncStop).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not initialize chat sync when dataSync preference is disabled at startup', async () => {
+    mockResolveDataSyncPreference.mockReturnValue('disabled')
+
+    const { dataSyncService } = await import('../dataSyncService')
+    await dataSyncService.initialize()
+
+    expect(mockChatSyncInitialize).not.toHaveBeenCalled()
+    expect(mockChatSyncEnable).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/services/__tests__/userConfigStoreService.test.ts
+++ b/src/renderer/src/services/__tests__/userConfigStoreService.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUserTermConfig, mockUpdateUserTermConfig } = vi.hoisted(() => ({
+  mockGetUserTermConfig: vi.fn(),
+  mockUpdateUserTermConfig: vi.fn()
+}))
+
+const { mockUserConfigPiniaStore } = vi.hoisted(() => ({
+  mockUserConfigPiniaStore: vi.fn(() => ({
+    updateLanguage: vi.fn(),
+    updateTheme: vi.fn(),
+    updateSecretRedaction: vi.fn(),
+    updateDataSync: vi.fn()
+  }))
+}))
+
+vi.mock('@/api/sync/sync', () => ({
+  getUserTermConfig: mockGetUserTermConfig,
+  updateUserTermConfig: mockUpdateUserTermConfig
+}))
+
+vi.mock('@/store/userConfigStore', () => ({
+  userConfigStore: mockUserConfigPiniaStore
+}))
+
+describe('UserConfigStoreService', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  it('persists dirty sync meta atomically when saving local config', async () => {
+    const kvStore = new Map<string, string>()
+
+    const kvGet = vi.fn(async ({ key }: { key?: string }) => {
+      if (!key || !kvStore.has(key)) {
+        return null
+      }
+      return { key, value: kvStore.get(key)! }
+    })
+
+    const kvMutate = vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+      if (action === 'set' && value !== undefined) {
+        kvStore.set(key, value)
+        return
+      }
+      if (action === 'delete') {
+        kvStore.delete(key)
+      }
+    })
+
+    const kvTransaction = vi.fn(
+      async (
+        callback: (tx: {
+          get(key: string): Promise<string | null>
+          set(key: string, value: string): void
+          delete(key: string): void
+        }) => Promise<void>
+      ) => {
+        const ops: Array<{ action: 'set'; key: string; value: string } | { action: 'delete'; key: string }> = []
+        await callback({
+          get: async (key) => kvStore.get(key) ?? null,
+          set: (key, value) => ops.push({ action: 'set', key, value }),
+          delete: (key) => ops.push({ action: 'delete', key })
+        })
+
+        for (const op of ops) {
+          if (op.action === 'set') {
+            kvStore.set(op.key, op.value)
+          } else {
+            kvStore.delete(op.key)
+          }
+        }
+      }
+    )
+
+    ;(window as any).api = {
+      kvGet,
+      kvMutate,
+      kvTransaction,
+      updateTheme: vi.fn()
+    }
+
+    mockGetUserTermConfig.mockResolvedValue({ data: { config: null } })
+    mockUpdateUserTermConfig.mockResolvedValue({ data: {} })
+
+    const { UserConfigStoreService } = await import('../userConfigStoreService')
+    const service = new UserConfigStoreService()
+
+    await service.initDB()
+    await service.saveConfig({ theme: 'dark' })
+
+    expect(kvTransaction).toHaveBeenCalledTimes(1)
+
+    const storedConfig = JSON.parse(kvStore.get('userConfig') ?? '{}')
+    const storedMeta = JSON.parse(kvStore.get('userConfigSyncMeta') ?? '{}')
+
+    expect(storedConfig.theme).toBe('dark')
+    expect(storedMeta.dirty).toBe(true)
+    expect(storedMeta.schemaVersion).toBe(1)
+  })
+
+  it('does not export a user-config specific default sync meta builder', async () => {
+    const module = await import('../userConfigStoreService')
+    expect('buildDefaultSyncMeta' in module).toBe(false)
+  })
+
+  it('supports chained remote schema migration and returns null when a step is missing', async () => {
+    const { migrateRemoteConfig } = await import('../userConfigStoreService')
+
+    expect(migrateRemoteConfig({ theme: 'dark' }, 0, 1)).toEqual({ theme: 'dark' })
+    expect(migrateRemoteConfig({ theme: 'dark' }, 0, 2)).toBeNull()
+  })
+
+  it('parseRemoteConfig extracts current platform shortcuts from platform-partitioned payload', async () => {
+    const { parseRemoteConfig, getPlatformKey } = await import('../userConfigStoreService')
+    const platformShortcuts = {
+      mac: { copy: 'Cmd+C' },
+      windows: { copy: 'Ctrl+C' },
+      linux: { copy: 'Ctrl+Shift+C' }
+    }
+
+    const parsed = parseRemoteConfig({
+      theme: 'dark',
+      shortcuts: platformShortcuts
+    })
+
+    expect(parsed.shortcuts).toEqual(platformShortcuts[getPlatformKey()])
+  })
+
+  it('sanitizeForSync normalizes platform-partitioned shortcuts to current platform', async () => {
+    const { sanitizeForSync, buildDefaultUserConfig, getPlatformKey } = await import('../userConfigStoreService')
+    const platformShortcuts = {
+      mac: { copy: 'Cmd+C' },
+      windows: { copy: 'Ctrl+C' },
+      linux: { copy: 'Ctrl+Shift+C' }
+    }
+    const config: any = {
+      ...buildDefaultUserConfig(),
+      shortcuts: platformShortcuts
+    }
+
+    const sanitized = sanitizeForSync(config)
+    expect(sanitized.shortcuts).toEqual(platformShortcuts[getPlatformKey()])
+  })
+
+  it('applyRemoteConfig writes userConfig only when no meta is provided, writes both atomically when meta is provided', async () => {
+    const kvStore = new Map<string, string>()
+    const txWrites: string[][] = []
+
+    kvStore.set(
+      'userConfig',
+      JSON.stringify({
+        id: 'userConfig',
+        updatedAt: 100,
+        autoCompleteStatus: 1,
+        vimStatus: false,
+        quickVimStatus: 1,
+        commonVimStatus: 2,
+        aliasStatus: 1,
+        highlightStatus: 1,
+        pinchZoomStatus: 1,
+        fontSize: 12,
+        scrollBack: 1000,
+        language: 'zh-CN',
+        cursorStyle: 'block',
+        middleMouseEvent: 'paste',
+        rightMouseEvent: 'contextMenu',
+        watermark: 'open',
+        secretRedaction: 'disabled',
+        dataSync: 'disabled',
+        theme: 'auto',
+        defaultLayout: 'terminal',
+        shortcuts: {},
+        sshAgentsStatus: 2,
+        sshAgentsMap: '[]',
+        sshProxyConfigs: [],
+        workspaceExpandedKeys: [],
+        lastCustomImage: '',
+        background: {
+          mode: 'none',
+          image: '',
+          opacity: 0.15,
+          brightness: 0.45
+        }
+      })
+    )
+    kvStore.set(
+      'userConfigSyncMeta',
+      JSON.stringify({
+        schemaVersion: 1,
+        lastPulledAt: 0,
+        lastPushedAt: 0,
+        lastSyncedPayload: '',
+        lastSyncedHash: '',
+        lastRemoteUpdatedAt: 0,
+        lastRemoteSchemaVersion: 0,
+        schemaBlocked: false,
+        dirty: true
+      })
+    )
+
+    const kvGet = vi.fn(async ({ key }: { key?: string }) => {
+      if (!key || !kvStore.has(key)) {
+        return null
+      }
+      return { key, value: kvStore.get(key)! }
+    })
+
+    const kvMutate = vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+      if (action === 'set' && value !== undefined) {
+        kvStore.set(key, value)
+        return
+      }
+      if (action === 'delete') {
+        kvStore.delete(key)
+      }
+    })
+
+    const kvTransaction = vi.fn(
+      async (
+        callback: (tx: {
+          get(key: string): Promise<string | null>
+          set(key: string, value: string): void
+          delete(key: string): void
+        }) => Promise<void>
+      ) => {
+        const ops: Array<{ action: 'set'; key: string; value: string } | { action: 'delete'; key: string }> = []
+        await callback({
+          get: async (key) => kvStore.get(key) ?? null,
+          set: (key, value) => ops.push({ action: 'set', key, value }),
+          delete: (key) => ops.push({ action: 'delete', key })
+        })
+
+        txWrites.push(ops.filter((op) => op.action === 'set').map((op) => op.key))
+
+        for (const op of ops) {
+          if (op.action === 'set') {
+            kvStore.set(op.key, op.value)
+          } else {
+            kvStore.delete(op.key)
+          }
+        }
+      }
+    )
+
+    ;(window as any).api = {
+      kvGet,
+      kvMutate,
+      kvTransaction,
+      updateTheme: vi.fn()
+    }
+
+    const { applyRemoteConfig } = await import('../userConfigStoreService')
+    await applyRemoteConfig({ fontSize: 14 })
+
+    expect(txWrites).toHaveLength(1)
+    expect(txWrites[0]).toEqual(['userConfig'])
+
+    // Now test with meta provided - should write both atomically
+    txWrites.length = 0
+    const meta = {
+      schemaVersion: 1,
+      lastPulledAt: Date.now(),
+      lastPushedAt: 0,
+      lastSyncedPayload: '{}',
+      lastSyncedHash: 'sha256:abc',
+      lastRemoteUpdatedAt: 1000,
+      lastRemoteSchemaVersion: 1,
+      schemaBlocked: false,
+      dirty: false
+    }
+    await applyRemoteConfig({ scrollBack: 2000 }, meta, 'userConfigSyncMeta')
+
+    expect(txWrites).toHaveLength(1)
+    expect(txWrites[0]).toEqual(['userConfig', 'userConfigSyncMeta'])
+  })
+})

--- a/src/renderer/src/services/__tests__/userConfigSyncService.test.ts
+++ b/src/renderer/src/services/__tests__/userConfigSyncService.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockGetConfig,
+  mockSanitizeForSync,
+  mockIsFlatShortcutConfig,
+  mockIsPlatformShortcuts,
+  mockParseRemoteConfig,
+  mockMigrateRemoteConfig,
+  mockBuildDefaultUserConfig,
+  mockGetPlatformKey,
+  mockApplyRemoteConfig,
+  mockGetUserTermConfig,
+  mockUpdateUserTermConfig
+} = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockSanitizeForSync: vi.fn(),
+  mockIsFlatShortcutConfig: vi.fn((value: unknown) => {
+    return (
+      !!value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.keys(value as Record<string, unknown>).length > 0 &&
+      Object.values(value as Record<string, unknown>).every((v) => typeof v === 'string')
+    )
+  }),
+  mockIsPlatformShortcuts: vi.fn((value: unknown) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj)
+    if (keys.length === 0) return false
+    const platforms = new Set(['mac', 'windows', 'linux'])
+    return keys.every((k) => platforms.has(k) && mockIsFlatShortcutConfig(obj[k]))
+  }),
+  mockParseRemoteConfig: vi.fn((payload) => payload),
+  mockMigrateRemoteConfig: vi.fn((payload) => payload),
+  mockBuildDefaultUserConfig: vi.fn(() => ({ theme: 'auto' })),
+  mockGetPlatformKey: vi.fn(() => {
+    const platform = navigator.platform.toUpperCase()
+    if (platform.includes('MAC')) return 'mac'
+    if (platform.includes('WIN')) return 'windows'
+    return 'linux'
+  }),
+  mockApplyRemoteConfig: vi.fn(),
+  mockGetUserTermConfig: vi.fn(),
+  mockUpdateUserTermConfig: vi.fn()
+}))
+
+vi.mock('../userConfigStoreService', () => ({
+  sanitizeForSync: mockSanitizeForSync,
+  isFlatShortcutConfig: mockIsFlatShortcutConfig,
+  isPlatformShortcuts: mockIsPlatformShortcuts,
+  parseRemoteConfig: mockParseRemoteConfig,
+  migrateRemoteConfig: mockMigrateRemoteConfig,
+  buildDefaultUserConfig: mockBuildDefaultUserConfig,
+  getPlatformKey: mockGetPlatformKey,
+  applyRemoteConfig: mockApplyRemoteConfig,
+  SUPPORTED_USER_CONFIG_SCHEMA_VERSION: 1,
+  SYNC_WHITELIST: ['theme'],
+  userConfigStore: {
+    getConfig: mockGetConfig
+  }
+}))
+
+vi.mock('@/api/sync/sync', () => ({
+  getUserTermConfig: mockGetUserTermConfig,
+  updateUserTermConfig: mockUpdateUserTermConfig
+}))
+
+function getCurrentPlatformKey(): 'mac' | 'windows' | 'linux' {
+  const platform = navigator.platform.toUpperCase()
+  if (platform.includes('MAC')) return 'mac'
+  if (platform.includes('WIN')) return 'windows'
+  return 'linux'
+}
+
+describe('UserConfigSyncService', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  it('uploads local config on initialize when payload drift exists despite dirty=false', async () => {
+    const kvStore = new Map<string, string>()
+    kvStore.set(
+      'userConfigSyncMeta',
+      JSON.stringify({
+        schemaVersion: 1,
+        lastPulledAt: 0,
+        lastPushedAt: 0,
+        lastSyncedPayload: JSON.stringify({ theme: 'auto' }),
+        lastSyncedHash: 'hash-old',
+        lastRemoteUpdatedAt: 0,
+        lastRemoteSchemaVersion: 1,
+        schemaBlocked: false,
+        dirty: false
+      })
+    )
+    ;(window as any).api = {
+      kvGet: vi.fn(async ({ key }: { key?: string }) => {
+        if (!key || !kvStore.has(key)) {
+          return null
+        }
+        return { key, value: kvStore.get(key)! }
+      }),
+      kvMutate: vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+        if (action === 'set' && value !== undefined) {
+          kvStore.set(key, value)
+        }
+      })
+    }
+
+    mockGetConfig.mockResolvedValue({ theme: 'dark' })
+    mockSanitizeForSync.mockImplementation((config) => ({ theme: config.theme }))
+    mockGetUserTermConfig.mockResolvedValue({
+      data: {
+        config: { theme: 'light' },
+        schemaVersion: 1,
+        updatedAt: 123,
+        configHash: 'hash-remote'
+      }
+    })
+    mockUpdateUserTermConfig.mockResolvedValue({
+      data: {
+        configHash: 'hash-local',
+        updatedAt: 456,
+        schemaVersion: 1
+      }
+    })
+
+    const { userConfigSyncService } = await import('../userConfigSyncService')
+
+    await userConfigSyncService.initialize()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(mockUpdateUserTermConfig).toHaveBeenCalledTimes(1)
+    expect(mockUpdateUserTermConfig.mock.calls[0][0]).toEqual({
+      schemaVersion: 1,
+      config: JSON.stringify({ theme: 'dark' }),
+      configType: 'user_config'
+    })
+    expect(mockApplyRemoteConfig).not.toHaveBeenCalled()
+  })
+
+  it('stores platform-partitioned shortcuts payload in lastSyncedPayload after remote apply', async () => {
+    const kvStore = new Map<string, string>()
+    const platformShortcuts = {
+      mac: { copy: 'Cmd+C', paste: 'Cmd+V' },
+      windows: { copy: 'Ctrl+C', paste: 'Ctrl+V' },
+      linux: { copy: 'Ctrl+Shift+C', paste: 'Ctrl+Shift+V' }
+    }
+    const currentPlatform = getCurrentPlatformKey()
+    const currentShortcuts = platformShortcuts[currentPlatform]
+    const { canonicalJSONStringify } = await import('../syncJson')
+    const canonicalLastSyncedPayload = canonicalJSONStringify({
+      shortcuts: platformShortcuts,
+      theme: 'dark'
+    })
+
+    kvStore.set(
+      'userConfigSyncMeta',
+      JSON.stringify({
+        schemaVersion: 1,
+        lastPulledAt: 0,
+        lastPushedAt: 0,
+        lastSyncedPayload: canonicalLastSyncedPayload,
+        lastSyncedHash: 'hash-old',
+        lastRemoteUpdatedAt: 0,
+        lastRemoteSchemaVersion: 1,
+        schemaBlocked: false,
+        dirty: false
+      })
+    )
+    ;(window as any).api = {
+      kvGet: vi.fn(async ({ key }: { key?: string }) => {
+        if (!key || !kvStore.has(key)) {
+          return null
+        }
+        return { key, value: kvStore.get(key)! }
+      }),
+      kvMutate: vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+        if (action === 'set' && value !== undefined) {
+          kvStore.set(key, value)
+        }
+      })
+    }
+
+    mockGetConfig.mockResolvedValue({ theme: 'dark', shortcuts: currentShortcuts })
+    mockSanitizeForSync.mockReturnValue({ theme: 'dark', shortcuts: currentShortcuts } as any)
+    mockParseRemoteConfig.mockReturnValue({ theme: 'dark', shortcuts: currentShortcuts } as any)
+    mockGetUserTermConfig.mockResolvedValue({
+      data: {
+        config: JSON.stringify({ theme: 'dark', shortcuts: platformShortcuts }),
+        schemaVersion: 1,
+        updatedAt: 123,
+        configHash: 'hash-remote'
+      }
+    })
+
+    const { userConfigSyncService } = await import('../userConfigSyncService')
+    await userConfigSyncService.initialize()
+
+    expect(mockParseRemoteConfig).toHaveBeenCalledWith(expect.objectContaining({ shortcuts: currentShortcuts, theme: 'dark' }))
+
+    const storedMeta = JSON.parse(kvStore.get('userConfigSyncMeta') ?? '{}')
+    const storedPayload = JSON.parse(storedMeta.lastSyncedPayload ?? '{}')
+    expect(storedPayload.shortcuts).toEqual(platformShortcuts)
+  })
+
+  it('applies compatible fields when remote schema version is lower than local support', async () => {
+    const kvStore = new Map<string, string>()
+    kvStore.set(
+      'userConfigSyncMeta',
+      JSON.stringify({
+        schemaVersion: 1,
+        lastPulledAt: 0,
+        lastPushedAt: 0,
+        lastSyncedPayload: JSON.stringify({ theme: 'dark' }),
+        lastSyncedHash: 'hash-old',
+        lastRemoteUpdatedAt: 0,
+        lastRemoteSchemaVersion: 1,
+        schemaBlocked: false,
+        dirty: false
+      })
+    )
+    ;(window as any).api = {
+      kvGet: vi.fn(async ({ key }: { key?: string }) => {
+        if (!key || !kvStore.has(key)) {
+          return null
+        }
+        return { key, value: kvStore.get(key)! }
+      }),
+      kvMutate: vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+        if (action === 'set' && value !== undefined) {
+          kvStore.set(key, value)
+        }
+      }),
+      kvTransaction: vi.fn(
+        async (
+          callback: (tx: {
+            get: (key: string) => Promise<string | null>
+            set: (key: string, value: string) => void
+            delete: (key: string) => void
+          }) => Promise<void>
+        ) => {
+          const ops: Array<{ action: 'set'; key: string; value: string } | { action: 'delete'; key: string }> = []
+          await callback({
+            get: async (key) => kvStore.get(key) ?? null,
+            set: (key, value) => ops.push({ action: 'set', key, value }),
+            delete: (key) => ops.push({ action: 'delete', key })
+          })
+          for (const op of ops) {
+            if (op.action === 'set') {
+              kvStore.set(op.key, op.value)
+            } else {
+              kvStore.delete(op.key)
+            }
+          }
+        }
+      )
+    }
+
+    mockGetConfig.mockResolvedValue({ theme: 'dark' })
+    mockSanitizeForSync.mockImplementation((config) => ({ theme: config.theme }))
+    mockParseRemoteConfig.mockReturnValue({ theme: 'light' } as any)
+    mockGetUserTermConfig.mockResolvedValue({
+      data: {
+        config: JSON.stringify({ theme: 'light', unknownField: 'ignored' }),
+        schemaVersion: 0,
+        updatedAt: 456,
+        configHash: 'hash-remote-lower'
+      }
+    })
+
+    const { userConfigSyncService } = await import('../userConfigSyncService')
+    await userConfigSyncService.initialize()
+
+    expect(mockMigrateRemoteConfig).toHaveBeenCalledWith({ theme: 'light', unknownField: 'ignored' }, 0, 1)
+    expect(mockApplyRemoteConfig).toHaveBeenCalledTimes(1)
+    expect(mockApplyRemoteConfig.mock.calls[0][0]).toEqual({ theme: 'light' })
+  })
+
+  it('blocks remote apply when remote schema version is higher than local support', async () => {
+    const kvStore = new Map<string, string>()
+    kvStore.set(
+      'userConfigSyncMeta',
+      JSON.stringify({
+        schemaVersion: 1,
+        lastPulledAt: 0,
+        lastPushedAt: 0,
+        lastSyncedPayload: '',
+        lastSyncedHash: '',
+        lastRemoteUpdatedAt: 0,
+        lastRemoteSchemaVersion: 0,
+        schemaBlocked: false,
+        dirty: false
+      })
+    )
+    ;(window as any).api = {
+      kvGet: vi.fn(async ({ key }: { key?: string }) => {
+        if (!key || !kvStore.has(key)) {
+          return null
+        }
+        return { key, value: kvStore.get(key)! }
+      }),
+      kvMutate: vi.fn(async ({ action, key, value }: { action: string; key: string; value?: string }) => {
+        if (action === 'set' && value !== undefined) {
+          kvStore.set(key, value)
+        }
+      }),
+      kvTransaction: vi.fn(
+        async (
+          callback: (tx: {
+            get: (key: string) => Promise<string | null>
+            set: (key: string, value: string) => void
+            delete: (key: string) => void
+          }) => Promise<void>
+        ) => {
+          const ops: Array<{ action: 'set'; key: string; value: string } | { action: 'delete'; key: string }> = []
+          await callback({
+            get: async (key) => kvStore.get(key) ?? null,
+            set: (key, value) => ops.push({ action: 'set', key, value }),
+            delete: (key) => ops.push({ action: 'delete', key })
+          })
+          for (const op of ops) {
+            if (op.action === 'set') {
+              kvStore.set(op.key, op.value)
+            } else {
+              kvStore.delete(op.key)
+            }
+          }
+        }
+      )
+    }
+
+    mockGetConfig.mockResolvedValue({ theme: 'dark' })
+    mockSanitizeForSync.mockImplementation((config) => ({ theme: config.theme }))
+    mockGetUserTermConfig.mockResolvedValue({
+      data: {
+        config: JSON.stringify({ theme: 'light' }),
+        schemaVersion: 2,
+        updatedAt: 999,
+        configHash: 'hash-remote-higher'
+      }
+    })
+
+    const { userConfigSyncService } = await import('../userConfigSyncService')
+    await userConfigSyncService.initialize()
+
+    expect(mockApplyRemoteConfig).not.toHaveBeenCalled()
+    const storedMeta = JSON.parse(kvStore.get('userConfigSyncMeta') ?? '{}')
+    expect(storedMeta.schemaBlocked).toBe(true)
+  })
+})

--- a/src/renderer/src/services/aiPreferencesSyncService.ts
+++ b/src/renderer/src/services/aiPreferencesSyncService.ts
@@ -1,0 +1,268 @@
+/**
+ * AI Preferences Sync Service
+ *
+ * Uses the generic ConfigSyncManager with an ai_preferences-specific adapter.
+ * Syncs AI-related settings (thinking budget, reasoning effort, auto-approval, proxy, etc.).
+ *
+ * SECURITY: Strips password and username from proxyConfig before uploading to server.
+ */
+
+import { ConfigSyncManager, type ConfigSyncAdapter, type ConfigSyncMeta } from './configSyncManager'
+import { canonicalJSONStringify } from './syncJson'
+
+const logger = createRendererLogger('service.aiPreferencesSync')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AiPreferences {
+  thinkingBudgetTokens?: number
+  reasoningEffort?: string
+  autoApprovalSettings?: {
+    version?: number
+    enabled?: boolean
+    actions?: Record<string, boolean>
+    maxRequests?: number
+    enableNotifications?: boolean
+    favorites?: string[]
+  }
+  chatSettings?: { mode?: string }
+  shellIntegrationTimeout?: number
+  needProxy?: boolean
+  proxyConfig?: {
+    type?: string
+    host?: string
+    port?: number
+    enableProxyIdentity?: boolean
+    // username and password are intentionally excluded from sync
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a safe AI preferences snapshot for upload.
+ * Strips sensitive fields (proxy username/password) before serialization.
+ */
+async function buildAiPreferencesSnapshot(): Promise<AiPreferences> {
+  const { getGlobalState } = await import('@renderer/agent/storage/state')
+
+  const [thinkingBudgetTokens, reasoningEffort, autoApprovalSettings, chatSettings, shellIntegrationTimeout, needProxy, proxyConfig] =
+    await Promise.all([
+      getGlobalState('thinkingBudgetTokens'),
+      getGlobalState('reasoningEffort'),
+      getGlobalState('autoApprovalSettings'),
+      getGlobalState('chatSettings'),
+      getGlobalState('shellIntegrationTimeout'),
+      getGlobalState('needProxy'),
+      getGlobalState('proxyConfig')
+    ])
+
+  const result: AiPreferences = {}
+
+  if (typeof thinkingBudgetTokens === 'number') {
+    result.thinkingBudgetTokens = thinkingBudgetTokens
+  }
+  if (typeof reasoningEffort === 'string') {
+    result.reasoningEffort = reasoningEffort
+  }
+  if (autoApprovalSettings && typeof autoApprovalSettings === 'object') {
+    const aas = autoApprovalSettings as any
+    result.autoApprovalSettings = {
+      version: aas.version,
+      enabled: aas.enabled,
+      actions: aas.actions ? { ...aas.actions } : undefined,
+      maxRequests: aas.maxRequests,
+      enableNotifications: aas.enableNotifications,
+      favorites: Array.isArray(aas.favorites) ? [...aas.favorites] : undefined
+    }
+  }
+  if (chatSettings && typeof chatSettings === 'object') {
+    result.chatSettings = { mode: (chatSettings as any).mode }
+  }
+  if (typeof shellIntegrationTimeout === 'number') {
+    result.shellIntegrationTimeout = shellIntegrationTimeout
+  }
+  if (typeof needProxy === 'boolean') {
+    result.needProxy = needProxy
+  }
+  if (proxyConfig && typeof proxyConfig === 'object') {
+    const pc = proxyConfig as any
+    // SECURITY: Strip username and password - never upload credentials to server
+    result.proxyConfig = {
+      type: pc.type,
+      host: pc.host,
+      port: pc.port,
+      enableProxyIdentity: pc.enableProxyIdentity
+    }
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+function validateAiPreferences(payload: unknown): AiPreferences | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const obj = payload as Record<string, unknown>
+  const result: AiPreferences = {}
+  let hasField = false
+
+  if ('thinkingBudgetTokens' in obj && typeof obj.thinkingBudgetTokens === 'number') {
+    result.thinkingBudgetTokens = obj.thinkingBudgetTokens
+    hasField = true
+  }
+  if ('reasoningEffort' in obj && typeof obj.reasoningEffort === 'string') {
+    result.reasoningEffort = obj.reasoningEffort
+    hasField = true
+  }
+  if ('autoApprovalSettings' in obj && typeof obj.autoApprovalSettings === 'object' && obj.autoApprovalSettings !== null) {
+    result.autoApprovalSettings = obj.autoApprovalSettings as AiPreferences['autoApprovalSettings']
+    hasField = true
+  }
+  if ('chatSettings' in obj && typeof obj.chatSettings === 'object' && obj.chatSettings !== null) {
+    result.chatSettings = obj.chatSettings as AiPreferences['chatSettings']
+    hasField = true
+  }
+  if ('shellIntegrationTimeout' in obj && typeof obj.shellIntegrationTimeout === 'number') {
+    result.shellIntegrationTimeout = obj.shellIntegrationTimeout
+    hasField = true
+  }
+  if ('needProxy' in obj && typeof obj.needProxy === 'boolean') {
+    result.needProxy = obj.needProxy
+    hasField = true
+  }
+  if ('proxyConfig' in obj && typeof obj.proxyConfig === 'object' && obj.proxyConfig !== null) {
+    result.proxyConfig = obj.proxyConfig as AiPreferences['proxyConfig']
+    hasField = true
+  }
+
+  return hasField ? result : null
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+const aiPreferencesAdapter: ConfigSyncAdapter<AiPreferences> = {
+  configType: 'ai_preferences',
+  metaKey: 'aiPreferencesSyncMeta',
+  schemaVersion: 1,
+
+  async readLocal(): Promise<AiPreferences> {
+    return buildAiPreferencesSnapshot()
+  },
+
+  serializeForUpload(data: AiPreferences): string {
+    return canonicalJSONStringify(data)
+  },
+
+  parseRemote(payload: unknown): AiPreferences | null {
+    return validateAiPreferences(payload)
+  },
+
+  async applyRemote(data: AiPreferences, meta?: ConfigSyncMeta, metaKey?: string): Promise<void> {
+    // Build the KV operations to write atomically.
+    // globalState keys are prefixed with "global_" (see key-storage.ts).
+    const ops: Array<{ key: string; value: string }> = []
+
+    if (data.thinkingBudgetTokens !== undefined) {
+      ops.push({ key: 'global_thinkingBudgetTokens', value: JSON.stringify(data.thinkingBudgetTokens) })
+    }
+    if (data.reasoningEffort !== undefined) {
+      ops.push({ key: 'global_reasoningEffort', value: JSON.stringify(data.reasoningEffort) })
+    }
+    if (data.autoApprovalSettings !== undefined) {
+      ops.push({ key: 'global_autoApprovalSettings', value: JSON.stringify(data.autoApprovalSettings) })
+    }
+    if (data.chatSettings !== undefined) {
+      ops.push({ key: 'global_chatSettings', value: JSON.stringify(data.chatSettings) })
+    }
+    if (data.shellIntegrationTimeout !== undefined) {
+      ops.push({ key: 'global_shellIntegrationTimeout', value: JSON.stringify(data.shellIntegrationTimeout) })
+    }
+    if (data.needProxy !== undefined) {
+      ops.push({ key: 'global_needProxy', value: JSON.stringify(data.needProxy) })
+    }
+    if (data.proxyConfig !== undefined) {
+      // Merge remote proxy config with local (preserve local credentials)
+      const { getGlobalState } = await import('@renderer/agent/storage/state')
+      const localProxy = (await getGlobalState('proxyConfig')) as Record<string, unknown> | null
+      const merged = {
+        ...(localProxy || {}),
+        ...data.proxyConfig,
+        // Preserve local username/password - remote never has them
+        username: (localProxy as any)?.username ?? '',
+        password: (localProxy as any)?.password ?? ''
+      }
+      ops.push({ key: 'global_proxyConfig', value: JSON.stringify(merged) })
+    }
+
+    // Atomic write: all config keys + sync meta in the same SQLite transaction
+    await window.api.kvTransaction(async (tx) => {
+      for (const op of ops) {
+        tx.set(op.key, op.value)
+      }
+      if (meta && metaKey) {
+        tx.set(metaKey, JSON.stringify(meta))
+      }
+    })
+
+    // Emit event so AI settings page can reload from local storage
+    try {
+      const eventBus = (await import('@/utils/eventBus')).default
+      eventBus.emit('aiPreferencesSyncApplied')
+    } catch {
+      // eventBus may not be available
+    }
+    logger.info('Applied remote AI preferences')
+  },
+
+  getDefault(): AiPreferences {
+    return {
+      thinkingBudgetTokens: 2048,
+      reasoningEffort: 'low',
+      shellIntegrationTimeout: 4,
+      needProxy: false
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+class AiPreferencesSyncService {
+  private static instance: AiPreferencesSyncService
+  private manager = new ConfigSyncManager(aiPreferencesAdapter)
+
+  static getInstance(): AiPreferencesSyncService {
+    if (!AiPreferencesSyncService.instance) {
+      AiPreferencesSyncService.instance = new AiPreferencesSyncService()
+    }
+    return AiPreferencesSyncService.instance
+  }
+
+  initialize(): Promise<void> {
+    return this.manager.initialize()
+  }
+
+  scheduleUpload(): void {
+    this.manager.scheduleUpload()
+  }
+
+  reset(): void {
+    this.manager.reset()
+  }
+
+  stop(): void {
+    this.manager.stop()
+  }
+}
+
+export const aiPreferencesSyncService = AiPreferencesSyncService.getInstance()

--- a/src/renderer/src/services/configSyncManager.ts
+++ b/src/renderer/src/services/configSyncManager.ts
@@ -1,0 +1,531 @@
+/**
+ * ConfigSyncManager - Generic config sync engine for all config_type values.
+ *
+ * Encapsulates the full protection mechanism set:
+ *   1. sessionGeneration - prevents stale async responses
+ *   2. debounce - aggregates rapid local changes
+ *   3. single-flight - at most one inflight upload at a time
+ *   4. consecutive failure degradation - stops retrying after MAX failures
+ *   5. schema version checks - blocks incompatible remote configs
+ *   6. dirty tracking - ensures pending changes are eventually uploaded
+ *   7. meta persistence - survives page refresh via SQLite KV store
+ *   8. AbortController signal - propagated to HTTP layer for real cancellation
+ *
+ * Usage: Each config_type provides a ConfigSyncAdapter<T> and instantiates
+ * ConfigSyncManager with it. The manager handles the rest.
+ */
+
+import { getUserTermConfig, updateUserTermConfig } from '@/api/sync/sync'
+
+const logger = createRendererLogger('service.configSyncManager')
+
+// ---------------------------------------------------------------------------
+// Adapter interface - each config_type implements this
+// ---------------------------------------------------------------------------
+
+export interface ConfigSyncAdapter<T> {
+  /** The config_type string sent to server */
+  readonly configType: string
+
+  /** SQLite KV key for storing sync metadata */
+  readonly metaKey: string
+
+  /** Current schema version */
+  readonly schemaVersion: number
+
+  /** Read the current local config snapshot */
+  readLocal(): Promise<T>
+
+  /**
+   * Serialize the local config for upload (must be deterministic).
+   * Returns a canonical JSON string suitable for comparison and PUT body.
+   */
+  serializeForUpload(data: T): string
+
+  /**
+   * Parse and validate a remote config payload.
+   * Returns null if the payload is invalid / should be rejected.
+   */
+  parseRemote(payload: unknown): T | null
+
+  /**
+   * Optional: migrate remote payload from an older schema to current schema.
+   * Return null when migration cannot be completed safely.
+   */
+  migrateRemote?(payload: unknown, fromVersion: number, toVersion: number): unknown | null
+
+  /**
+   * Apply a validated remote config locally.
+   * Responsible for writing to persistent storage and refreshing UI state.
+   * When meta + metaKey are provided, the implementation MUST write both
+   * config and meta inside the same SQLite transaction to avoid crash windows.
+   */
+  applyRemote(data: T, meta?: ConfigSyncMeta, metaKey?: string): Promise<void>
+
+  /**
+   * Optional: Return a default config for first-sync comparison.
+   * If the local config equals the default, no bootstrap upload is needed.
+   * Return null to skip this optimization (always bootstrap upload).
+   */
+  getDefault?(): T | null
+
+  /**
+   * Optional: Cache cross-platform data from remote config without applying it.
+   * Called when local wins on first sync so other-platform data is not lost.
+   */
+  cacheRemotePlatformData?(serverConfig: string): void
+}
+
+// ---------------------------------------------------------------------------
+// Sync metadata (persisted in SQLite KV per config_type)
+// ---------------------------------------------------------------------------
+
+export interface ConfigSyncMeta {
+  schemaVersion: number
+  lastPulledAt: number
+  lastPushedAt: number
+  lastSyncedPayload: string
+  lastSyncedHash: string
+  lastRemoteUpdatedAt: number
+  lastRemoteSchemaVersion: number
+  schemaBlocked: boolean
+  dirty: boolean
+}
+
+export function buildDefaultConfigSyncMeta(schemaVersion: number): ConfigSyncMeta {
+  return {
+    schemaVersion,
+    lastPulledAt: 0,
+    lastPushedAt: 0,
+    lastSyncedPayload: '',
+    lastSyncedHash: '',
+    lastRemoteUpdatedAt: 0,
+    lastRemoteSchemaVersion: 0,
+    schemaBlocked: false,
+    dirty: false
+  }
+}
+
+/**
+ * Mark sync metadata dirty for a specific config type.
+ *
+ * This is a lightweight helper for local write paths that are not yet fully
+ * unified behind a single storage boundary.
+ */
+export async function markSyncMetaDirty(metaKey: string, schemaVersion: number): Promise<void> {
+  try {
+    const current = await window.api.kvGet({ key: metaKey })
+    const meta = current?.value ? (JSON.parse(current.value) as ConfigSyncMeta) : buildDefaultConfigSyncMeta(schemaVersion)
+
+    if (meta.dirty && meta.schemaVersion === schemaVersion) {
+      return
+    }
+
+    await window.api.kvMutate({
+      action: 'set',
+      key: metaKey,
+      value: JSON.stringify({
+        ...meta,
+        schemaVersion,
+        dirty: true
+      } satisfies ConfigSyncMeta)
+    })
+  } catch (error) {
+    logger.error(`Failed to mark sync meta dirty: ${metaKey}`, { error })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ConfigSyncManager
+// ---------------------------------------------------------------------------
+
+export class ConfigSyncManager<T> {
+  // === Pure in-memory state ===
+  private sessionGeneration: number = 0
+  private consecutiveFailureCount: number = 0
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null
+  private inflightController: AbortController | null = null
+  private schemaBlocked: boolean = false
+  private stopped: boolean = true // starts stopped; initialize() activates
+
+  // === Constants ===
+  private readonly REQUEST_TIMEOUT = 15_000
+  private readonly DEBOUNCE_DELAY = 1_000
+  private readonly MAX_CONSECUTIVE_FAILURES = 3
+
+  constructor(private readonly adapter: ConfigSyncAdapter<T>) {}
+
+  // ---------------------------------------------------------------------------
+  // Initialize - startup pull
+  // ---------------------------------------------------------------------------
+
+  async initialize(): Promise<void> {
+    try {
+      this.stopped = false
+      this.sessionGeneration++
+      const gen = this.sessionGeneration
+      const configType = this.adapter.configType
+      logger.info(`[${configType}] Initializing sync`, { generation: gen })
+
+      // Reset failure counter on each init
+      this.consecutiveFailureCount = 0
+
+      // Read local config and meta
+      const localData = await this.adapter.readLocal()
+      let meta = await this.readMeta()
+      const isFirstSync = !meta
+      if (isFirstSync) {
+        meta = buildDefaultConfigSyncMeta(this.adapter.schemaVersion)
+        logger.info(`[${configType}] No sync meta found, treating as first-time sync`)
+      }
+
+      const localPayload = this.adapter.serializeForUpload(localData)
+
+      // Detect local drift
+      if (meta && !meta.dirty && meta.lastSyncedPayload && meta.lastSyncedPayload !== localPayload) {
+        logger.warn(`[${configType}] Detected local drift, marking dirty`)
+        meta.dirty = true
+        await this.writeMeta(meta)
+      }
+
+      // Fetch remote
+      let remoteData: any = null
+      try {
+        remoteData = await this.fetchWithTimeout((signal) => getUserTermConfig({ configType }, { signal }), gen)
+      } catch (err: any) {
+        if (err?.name === 'AbortError' || err?.message === 'STALE_SESSION') {
+          return
+        }
+        logger.error(`[${configType}] Failed to fetch remote config`, { error: err })
+        return
+      }
+
+      if (gen !== this.sessionGeneration) return
+
+      // Server has no config (field missing or empty string)
+      const serverConfig = remoteData?.data?.config
+      const serverHasConfig = serverConfig != null && typeof serverConfig === 'string' && serverConfig.length > 0
+
+      if (!serverHasConfig) {
+        const defaultData = this.adapter.getDefault?.() ?? null
+        const localIsDefault = defaultData !== null && localPayload === this.adapter.serializeForUpload(defaultData)
+
+        if (localIsDefault) {
+          meta!.dirty = false
+          await this.writeMeta(meta!)
+        } else {
+          meta!.dirty = true
+          await this.writeMeta(meta!)
+          this.scheduleUpload()
+        }
+        return
+      }
+
+      // Schema version check
+      const remoteSchemaVersion = remoteData?.data?.schemaVersion ?? 1
+      if (remoteSchemaVersion > this.adapter.schemaVersion) {
+        logger.warn(`[${configType}] Remote schema version too high`, {
+          remote: remoteSchemaVersion,
+          supported: this.adapter.schemaVersion
+        })
+        this.schemaBlocked = true
+        meta!.schemaBlocked = true
+        await this.writeMeta(meta!)
+        return
+      }
+
+      this.schemaBlocked = false
+      meta!.schemaBlocked = false
+
+      // First sync + local not default → local wins
+      if (isFirstSync) {
+        const defaultData = this.adapter.getDefault?.() ?? null
+        const localIsDefault = defaultData !== null && localPayload === this.adapter.serializeForUpload(defaultData)
+        if (!localIsDefault) {
+          logger.info(`[${configType}] First sync with custom local, local wins`)
+          // Cache cross-platform data from remote before overwriting
+          if (this.adapter.cacheRemotePlatformData && serverConfig) {
+            this.adapter.cacheRemotePlatformData(serverConfig)
+          }
+          meta!.dirty = true
+          await this.writeMeta(meta!)
+          this.scheduleUpload()
+          return
+        }
+      }
+
+      // Dirty → upload local
+      if (meta!.dirty) {
+        logger.info(`[${configType}] Local is dirty, scheduling upload`)
+        this.scheduleUpload()
+        return
+      }
+
+      // Apply remote config
+      const freshMeta = await this.readMeta()
+      if (freshMeta && freshMeta.dirty) {
+        this.scheduleUpload()
+        return
+      }
+      if (gen !== this.sessionGeneration) return
+
+      // Parse the remote config string
+      let parsedConfig: unknown
+      try {
+        parsedConfig = typeof serverConfig === 'string' ? JSON.parse(serverConfig) : serverConfig
+      } catch {
+        logger.warn(`[${configType}] Failed to parse remote config JSON`)
+        return
+      }
+
+      let payloadForValidation = parsedConfig
+      if (remoteSchemaVersion < this.adapter.schemaVersion) {
+        if (this.adapter.migrateRemote) {
+          const migrated = this.adapter.migrateRemote(parsedConfig, remoteSchemaVersion, this.adapter.schemaVersion)
+          if (migrated === null) {
+            logger.warn(`[${configType}] Failed to migrate remote config`, {
+              remote: remoteSchemaVersion,
+              supported: this.adapter.schemaVersion
+            })
+            return
+          }
+          payloadForValidation = migrated
+          logger.info(`[${configType}] Remote config migrated`, {
+            from: remoteSchemaVersion,
+            to: this.adapter.schemaVersion
+          })
+        } else {
+          logger.info(`[${configType}] Remote schema older than supported, applying compatible fields only`, {
+            remote: remoteSchemaVersion,
+            supported: this.adapter.schemaVersion
+          })
+        }
+      }
+
+      const validated = this.adapter.parseRemote(payloadForValidation)
+      if (validated === null) {
+        logger.warn(`[${configType}] Remote config failed validation, skipping apply`)
+        return
+      }
+
+      // Build the post-apply meta BEFORE calling applyRemote so it can be
+      // written atomically with the config inside the same SQLite transaction.
+      const appliedMeta: ConfigSyncMeta = {
+        ...meta!,
+        lastPulledAt: Date.now(),
+        lastRemoteUpdatedAt: remoteData?.data?.updatedAt ?? 0,
+        lastRemoteSchemaVersion: remoteSchemaVersion,
+        lastSyncedHash: remoteData?.data?.configHash ?? '',
+        lastSyncedPayload: this.adapter.serializeForUpload(validated),
+        schemaBlocked: false,
+        dirty: false
+      }
+
+      await this.adapter.applyRemote(validated, appliedMeta, this.adapter.metaKey)
+
+      logger.info(`[${configType}] Sync initialization completed`)
+    } catch (error) {
+      logger.error(`[${this.adapter.configType}] Sync initialization failed`, { error })
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Schedule upload (debounced)
+  // ---------------------------------------------------------------------------
+
+  scheduleUpload(): void {
+    if (this.stopped) {
+      return
+    }
+    if (this.schemaBlocked) {
+      logger.warn(`[${this.adapter.configType}] Upload skipped: schema blocked`)
+      return
+    }
+    if (this.consecutiveFailureCount >= this.MAX_CONSECUTIVE_FAILURES) {
+      logger.warn(`[${this.adapter.configType}] Upload skipped: failure limit reached`)
+      return
+    }
+    this.clearDebounce()
+    this.debounceTimer = setTimeout(() => this.doUpload(), this.DEBOUNCE_DELAY)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Execute upload (single-flight)
+  // ---------------------------------------------------------------------------
+
+  private async doUpload(): Promise<void> {
+    if (this.stopped) return
+    if (this.inflightController) {
+      logger.info(`[${this.adapter.configType}] Upload skipped: already in flight`)
+      return
+    }
+
+    const configType = this.adapter.configType
+
+    try {
+      const localData = await this.adapter.readLocal()
+      const payload = this.adapter.serializeForUpload(localData)
+
+      // Compare with last synced payload
+      const meta = await this.readMeta()
+      if (meta && payload === meta.lastSyncedPayload) {
+        if (meta.dirty) {
+          meta.dirty = false
+          await this.writeMeta(meta)
+        }
+        return
+      }
+
+      const gen = this.sessionGeneration
+
+      // Create AbortController
+      this.inflightController = new AbortController()
+      const signal = this.inflightController.signal
+      const timeoutId = setTimeout(() => this.inflightController?.abort(), this.REQUEST_TIMEOUT)
+
+      let response: any
+      try {
+        response = await updateUserTermConfig(
+          {
+            schemaVersion: this.adapter.schemaVersion,
+            config: payload,
+            configType
+          },
+          { signal }
+        )
+      } finally {
+        clearTimeout(timeoutId)
+        this.inflightController = null
+      }
+
+      // Verify generation
+      if (gen !== this.sessionGeneration) return
+
+      // Re-read and compare
+      const freshData = await this.adapter.readLocal()
+      const freshMeta = await this.readMeta()
+      if (!freshMeta) return
+
+      const currentPayload = this.adapter.serializeForUpload(freshData)
+      if (currentPayload === payload) {
+        freshMeta.lastSyncedPayload = payload
+        freshMeta.lastSyncedHash = response?.data?.configHash ?? ''
+        freshMeta.lastPushedAt = Date.now()
+        freshMeta.lastRemoteUpdatedAt = response?.data?.updatedAt ?? 0
+        freshMeta.lastRemoteSchemaVersion = response?.data?.schemaVersion ?? this.adapter.schemaVersion
+        freshMeta.dirty = false
+        freshMeta.schemaBlocked = false
+        await this.writeMeta(freshMeta)
+        this.consecutiveFailureCount = 0
+        logger.info(`[${configType}] Upload succeeded`)
+      } else {
+        freshMeta.dirty = true
+        await this.writeMeta(freshMeta)
+        this.scheduleUpload()
+      }
+    } catch (error: any) {
+      this.inflightController = null
+      if (error?.message === 'STALE_SESSION') return
+
+      logger.error(`[${configType}] Upload failed`, { error })
+
+      try {
+        const meta = await this.readMeta()
+        if (meta && !meta.dirty) {
+          meta.dirty = true
+          await this.writeMeta(meta)
+        }
+      } catch (metaErr) {
+        logger.error(`[${configType}] Failed to update meta after upload failure`, { error: metaErr })
+      }
+
+      this.consecutiveFailureCount++
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  reset(): void {
+    this.stopped = true
+    this.sessionGeneration++
+    this.abortInflight()
+    this.clearDebounce()
+    this.consecutiveFailureCount = 0
+    this.schemaBlocked = false
+    logger.info(`[${this.adapter.configType}] Sync reset (account switch)`)
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.sessionGeneration++
+    this.abortInflight()
+    this.clearDebounce()
+    this.consecutiveFailureCount = 0
+    logger.info(`[${this.adapter.configType}] Sync stopped (dataSync disabled)`)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private abortInflight(): void {
+    if (this.inflightController) {
+      this.inflightController.abort()
+      this.inflightController = null
+    }
+  }
+
+  private clearDebounce(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+  }
+
+  private async readMeta(): Promise<ConfigSyncMeta | null> {
+    try {
+      const result = await window.api.kvGet({ key: this.adapter.metaKey })
+      if (result?.value) {
+        return JSON.parse(result.value) as ConfigSyncMeta
+      }
+      return null
+    } catch (error) {
+      logger.error(`[${this.adapter.configType}] Failed to read sync meta`, { error })
+      return null
+    }
+  }
+
+  private async writeMeta(meta: ConfigSyncMeta): Promise<void> {
+    try {
+      await window.api.kvMutate({
+        action: 'set',
+        key: this.adapter.metaKey,
+        value: JSON.stringify(meta)
+      })
+    } catch (error) {
+      logger.error(`[${this.adapter.configType}] Failed to write sync meta`, { error })
+    }
+  }
+
+  private async fetchWithTimeout<R>(apiFn: (signal: AbortSignal) => Promise<R>, gen: number): Promise<R> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.REQUEST_TIMEOUT)
+
+    try {
+      const result = await apiFn(controller.signal)
+      if (gen !== this.sessionGeneration) {
+        throw new Error('STALE_SESSION')
+      }
+      return result
+    } catch (err: any) {
+      if (err?.name === 'AbortError') {
+        throw new DOMException('Request timeout', 'AbortError')
+      }
+      throw err
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+}

--- a/src/renderer/src/services/dataSyncService.ts
+++ b/src/renderer/src/services/dataSyncService.ts
@@ -1,7 +1,16 @@
-import { userConfigStore } from './userConfigStoreService'
+import { getStoredUserConfigSnapshot, resolveDataSyncPreference } from './userConfigStoreService'
 import { chatSyncService } from './chatSyncService'
+import { userConfigSyncService } from './userConfigSyncService'
+import { editorConfigSyncService } from './editorConfigSyncService'
+import { userRulesSyncService } from './userRulesSyncService'
+import { aiPreferencesSyncService } from './aiPreferencesSyncService'
 
 const logger = createRendererLogger('service.dataSync')
+
+/**
+ * All config sync services, iterated for lifecycle operations.
+ */
+const allConfigSyncServices = [userConfigSyncService, editorConfigSyncService, userRulesSyncService, aiPreferencesSyncService]
 
 /**
  * Data sync service - manages data sync start and stop in renderer process
@@ -45,16 +54,8 @@ export class DataSyncService {
         return
       }
 
-      // Get user config
-      const userConfig = await userConfigStore.getConfig()
-
-      if (!userConfig) {
-        logger.info('Unable to get user config, skipping data sync initialization')
-        return
-      }
-
-      // Check if data sync is enabled
-      const isDataSyncEnabled = userConfig.dataSync === 'enabled'
+      const rawConfig = await getStoredUserConfigSnapshot()
+      const isDataSyncEnabled = resolveDataSyncPreference(rawConfig, true) === 'enabled'
       logger.info('User data sync config', { enabled: isDataSyncEnabled })
 
       if (isDataSyncEnabled) {
@@ -62,9 +63,6 @@ export class DataSyncService {
       } else {
         logger.info('Data sync is disabled, not starting sync service')
       }
-
-      // Initialize chat sync alongside data sync
-      await chatSyncService.initialize()
 
       this.isInitialized = true
       logger.info('Data sync service initialization completed')
@@ -88,7 +86,22 @@ export class DataSyncService {
       const result = await window.api.setDataSyncEnabled(true)
 
       if (result?.success) {
-        logger.info('Data sync successfully enabled, background sync task is in progress...')
+        logger.info('Data sync successfully enabled, initializing chat sync and all config sync services...')
+
+        // Enable chat sync as part of unified dataSync switch (failure does not block others)
+        await chatSyncService.enable().catch((e) => {
+          logger.error('Chat sync enable failed', { error: e })
+        })
+
+        // Initialize all config sync services (failure does not block others)
+        await Promise.allSettled(
+          allConfigSyncServices.map((svc) =>
+            svc.initialize().catch((e) => {
+              logger.error('Config sync service initialization failed', { error: e })
+            })
+          )
+        )
+
         return true
       } else {
         logger.error('Failed to enable data sync', { error: result?.error })
@@ -115,7 +128,20 @@ export class DataSyncService {
       const result = await window.api.setDataSyncEnabled(false)
 
       if (result?.success) {
-        logger.info('Data sync successfully disabled')
+        logger.info('Data sync successfully disabled, stopping chat sync and all config sync services')
+
+        // Disable chat sync as part of unified dataSync switch
+        try {
+          await chatSyncService.disable()
+        } catch (e) {
+          logger.error('Chat sync disable failed', { error: e })
+        }
+
+        // Stop all config sync services
+        for (const svc of allConfigSyncServices) {
+          svc.stop()
+        }
+
         return true
       } else {
         logger.error('Failed to disable data sync', { error: result?.error })
@@ -133,6 +159,9 @@ export class DataSyncService {
   reset(): void {
     this.isInitialized = false
     chatSyncService.reset()
+    for (const svc of allConfigSyncServices) {
+      svc.reset()
+    }
     logger.info('Data sync service status has been reset')
   }
 

--- a/src/renderer/src/services/editorConfigSyncService.ts
+++ b/src/renderer/src/services/editorConfigSyncService.ts
@@ -1,0 +1,185 @@
+/**
+ * Editor Config Sync Service
+ *
+ * Uses the generic ConfigSyncManager with an editor_config-specific adapter.
+ * Syncs Monaco Editor preferences (font, tab size, word wrap, etc.).
+ */
+
+import { ConfigSyncManager, type ConfigSyncAdapter, type ConfigSyncMeta } from './configSyncManager'
+import { canonicalJSONStringify } from './syncJson'
+
+const logger = createRendererLogger('service.editorConfigSync')
+
+// ---------------------------------------------------------------------------
+// EditorConfig type (mirrored from stores/editorConfig.ts to avoid circular dep)
+// ---------------------------------------------------------------------------
+
+interface EditorConfigData {
+  fontSize: number
+  fontFamily: string
+  tabSize: number
+  wordWrap: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
+  minimap: boolean
+  mouseWheelZoom: boolean
+  cursorBlinking: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid'
+  lineHeight: number
+}
+
+function getDefaultEditorFontKey(): string {
+  const platform = navigator.platform.toLowerCase()
+  const userAgent = navigator.userAgent.toLowerCase()
+
+  if (platform.includes('win') || userAgent.includes('windows')) {
+    return 'cascadia-mono'
+  }
+  if (platform.includes('mac') || userAgent.includes('mac')) {
+    return 'sf-mono'
+  }
+  return 'ubuntu-mono'
+}
+
+const DEFAULT_EDITOR_FONT_FAMILY = getDefaultEditorFontKey()
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+function validateEditorConfig(payload: unknown): EditorConfigData | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const obj = payload as Record<string, unknown>
+  const result: Partial<EditorConfigData> = {}
+
+  if (typeof obj.fontSize === 'number' && obj.fontSize >= 8 && obj.fontSize <= 64) {
+    result.fontSize = obj.fontSize
+  }
+  if (typeof obj.fontFamily === 'string' && obj.fontFamily.length > 0) {
+    result.fontFamily = obj.fontFamily
+  }
+  if (typeof obj.tabSize === 'number' && [2, 4, 8].includes(obj.tabSize)) {
+    result.tabSize = obj.tabSize
+  }
+  if (typeof obj.wordWrap === 'string' && ['off', 'on', 'wordWrapColumn', 'bounded'].includes(obj.wordWrap)) {
+    result.wordWrap = obj.wordWrap as EditorConfigData['wordWrap']
+  }
+  if (typeof obj.minimap === 'boolean') {
+    result.minimap = obj.minimap
+  }
+  if (typeof obj.mouseWheelZoom === 'boolean') {
+    result.mouseWheelZoom = obj.mouseWheelZoom
+  }
+  if (typeof obj.cursorBlinking === 'string' && ['blink', 'smooth', 'phase', 'expand', 'solid'].includes(obj.cursorBlinking)) {
+    result.cursorBlinking = obj.cursorBlinking as EditorConfigData['cursorBlinking']
+  }
+  if (typeof obj.lineHeight === 'number' && obj.lineHeight >= 0 && obj.lineHeight <= 100) {
+    result.lineHeight = obj.lineHeight
+  }
+
+  // Must have at least one valid field
+  if (Object.keys(result).length === 0) return null
+  return result as EditorConfigData
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+const editorConfigAdapter: ConfigSyncAdapter<EditorConfigData> = {
+  configType: 'editor_config',
+  metaKey: 'editorConfigSyncMeta',
+  schemaVersion: 1,
+
+  async readLocal(): Promise<EditorConfigData> {
+    const result = await window.api.kvGet({ key: 'editorConfig' })
+    if (result?.value) {
+      try {
+        return JSON.parse(result.value)
+      } catch {
+        // fall through to default
+      }
+    }
+    return {
+      fontSize: 14,
+      fontFamily: DEFAULT_EDITOR_FONT_FAMILY,
+      tabSize: 4,
+      wordWrap: 'off',
+      minimap: true,
+      mouseWheelZoom: true,
+      cursorBlinking: 'blink',
+      lineHeight: 0
+    }
+  },
+
+  serializeForUpload(data: EditorConfigData): string {
+    return canonicalJSONStringify(data)
+  },
+
+  parseRemote(payload: unknown): EditorConfigData | null {
+    return validateEditorConfig(payload)
+  },
+
+  async applyRemote(data: EditorConfigData, meta?: ConfigSyncMeta, metaKey?: string): Promise<void> {
+    // Atomic write: config + meta in the same SQLite transaction
+    await window.api.kvTransaction(async (tx) => {
+      tx.set('editorConfig', JSON.stringify(data))
+      if (meta && metaKey) {
+        tx.set(metaKey, JSON.stringify(meta))
+      }
+    })
+    // The Pinia store will pick up the change on next loadConfig() call
+    // Emit event so the editor config store can reload
+    try {
+      const eventBus = (await import('@/utils/eventBus')).default
+      eventBus.emit('editorConfigSyncApplied')
+    } catch {
+      // eventBus may not be available
+    }
+    logger.info('Applied remote editor config')
+  },
+
+  getDefault(): EditorConfigData {
+    return {
+      fontSize: 14,
+      fontFamily: DEFAULT_EDITOR_FONT_FAMILY,
+      tabSize: 4,
+      wordWrap: 'off',
+      minimap: true,
+      mouseWheelZoom: true,
+      cursorBlinking: 'blink',
+      lineHeight: 0
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+class EditorConfigSyncService {
+  private static instance: EditorConfigSyncService
+  private manager = new ConfigSyncManager(editorConfigAdapter)
+
+  static getInstance(): EditorConfigSyncService {
+    if (!EditorConfigSyncService.instance) {
+      EditorConfigSyncService.instance = new EditorConfigSyncService()
+    }
+    return EditorConfigSyncService.instance
+  }
+
+  initialize(): Promise<void> {
+    return this.manager.initialize()
+  }
+
+  scheduleUpload(): void {
+    this.manager.scheduleUpload()
+  }
+
+  reset(): void {
+    this.manager.reset()
+  }
+
+  stop(): void {
+    this.manager.stop()
+  }
+}
+
+export const editorConfigSyncService = EditorConfigSyncService.getInstance()

--- a/src/renderer/src/services/shortcutService.ts
+++ b/src/renderer/src/services/shortcutService.ts
@@ -67,6 +67,11 @@ export class ShortcutService {
 
     // Load user-configured shortcuts
     this.loadShortcuts()
+
+    // Listen for remote shortcuts sync to reload bindings
+    eventBus.on('shortcutsSyncApplied', () => {
+      this.loadShortcuts()
+    })
   }
 
   private registerAction(id: string, name: string, handler: () => void, defaultKey: { mac: string; other: string }, nameKey: string) {

--- a/src/renderer/src/services/syncJson.ts
+++ b/src/renderer/src/services/syncJson.ts
@@ -1,0 +1,30 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item))
+  }
+
+  if (isPlainObject(value)) {
+    const sorted: Record<string, unknown> = {}
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = canonicalize(value[key])
+    }
+    return sorted
+  }
+
+  return value
+}
+
+/**
+ * Deterministic JSON serialization for sync payload/hash comparison.
+ * Recursively sorts object keys while preserving array order.
+ */
+export function canonicalJSONStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}

--- a/src/renderer/src/services/userConfigStoreService.ts
+++ b/src/renderer/src/services/userConfigStoreService.ts
@@ -1,5 +1,10 @@
 import { shortcutActions } from '@/config/shortcutActions'
-import { toRaw } from 'vue'
+import { toRaw, nextTick } from 'vue'
+import i18n from '@/locales'
+import eventBus from '@/utils/eventBus'
+import { getActualTheme } from '@/utils/themeUtils'
+import { userConfigStore as piniaConfigStore } from '@/store/userConfigStore'
+import { type ConfigSyncMeta, buildDefaultConfigSyncMeta } from './configSyncManager'
 
 const logger = createRendererLogger('service.userConfig')
 
@@ -11,12 +16,21 @@ export interface ShortcutConfig {
   [key: string]: string
 }
 
+export type PlatformKey = 'mac' | 'windows' | 'linux'
+export type PlatformShortcuts = Partial<Record<PlatformKey, ShortcutConfig>>
+
+const PLATFORM_KEYS: PlatformKey[] = ['mac', 'windows', 'linux']
+
 export interface BackgroundConfig {
   mode: 'none' | 'image'
   image: string
   opacity: number
   brightness: number
 }
+
+export const SUPPORTED_LANGUAGE_VALUES = ['zh-CN', 'zh-TW', 'en-US', 'de-DE', 'fr-FR', 'it-IT', 'pt-PT', 'ru-RU', 'ja-JP', 'ko-KR', 'ar-AR'] as const
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGE_VALUES)[number]
 
 export interface UserConfig {
   id: string
@@ -31,13 +45,15 @@ export interface UserConfig {
   fontSize: number
   fontFamily?: string
   scrollBack: number
-  language: string
+  language: SupportedLanguage
   cursorStyle: 'bar' | 'block' | 'underline' | undefined
+  terminalType?: string
   middleMouseEvent?: 'paste' | 'contextMenu' | 'none'
   rightMouseEvent?: 'paste' | 'contextMenu' | 'none'
   watermark: 'open' | 'close' | undefined
   secretRedaction: 'enabled' | 'disabled' | undefined
   dataSync: 'enabled' | 'disabled' | undefined
+  telemetry?: string
   theme: 'dark' | 'light' | 'auto' | undefined
   defaultLayout?: 'terminal' | 'agents'
   feature?: number
@@ -58,6 +74,89 @@ export interface UserConfig {
   workspaceShowIpMode?: boolean
   lastCustomImage?: string
   background: BackgroundConfig
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+export function isFlatShortcutConfig(value: unknown): value is ShortcutConfig {
+  return isPlainObject(value) && Object.keys(value).length > 0 && Object.values(value).every((v) => typeof v === 'string')
+}
+
+export function isPlatformShortcuts(value: unknown): value is PlatformShortcuts {
+  if (!isPlainObject(value)) return false
+  const keys = Object.keys(value)
+  if (keys.length === 0) return false
+  return keys.every((key) => PLATFORM_KEYS.includes(key as PlatformKey) && isFlatShortcutConfig((value as Record<string, unknown>)[key]))
+}
+
+export function getPlatformKey(): PlatformKey {
+  const platform = navigator.platform.toUpperCase()
+  if (platform.includes('MAC')) return 'mac'
+  if (platform.includes('WIN')) return 'windows'
+  return 'linux'
+}
+
+function resolveCurrentPlatformShortcuts(value: unknown): ShortcutConfig | null {
+  if (isFlatShortcutConfig(value)) {
+    return { ...value }
+  }
+  if (isPlatformShortcuts(value)) {
+    const current = value[getPlatformKey()]
+    return isFlatShortcutConfig(current) ? { ...current } : null
+  }
+  return null
+}
+
+export function buildDefaultShortcutConfig(platform: PlatformKey = getPlatformKey()): ShortcutConfig {
+  const defaultShortcuts: ShortcutConfig = {}
+  shortcutActions.forEach((action) => {
+    defaultShortcuts[action.id] = platform === 'mac' ? action.defaultKey.mac : action.defaultKey.other
+  })
+  return defaultShortcuts
+}
+
+export function buildDefaultUserConfig(now: number = Date.now()): UserConfig {
+  return {
+    id: 'userConfig',
+    updatedAt: now,
+    autoCompleteStatus: 1,
+    vimStatus: false,
+    quickVimStatus: 1,
+    commonVimStatus: 2,
+    aliasStatus: 1,
+    highlightStatus: 1,
+    pinchZoomStatus: 1,
+    fontSize: 12,
+    scrollBack: 1000,
+    language: 'zh-CN',
+    cursorStyle: 'block',
+    middleMouseEvent: 'paste',
+    rightMouseEvent: 'contextMenu',
+    watermark: 'open',
+    secretRedaction: 'disabled',
+    dataSync: 'disabled',
+    theme: 'auto',
+    defaultLayout: 'terminal',
+    feature: 0.0,
+    quickComand: false,
+    shortcuts: buildDefaultShortcutConfig(),
+    sshAgentsStatus: 2,
+    sshAgentsMap: '[]',
+    sshProxyConfigs: [],
+    workspaceExpandedKeys: [],
+    lastCustomImage: '',
+    background: {
+      mode: 'none',
+      image: '',
+      opacity: 0.15,
+      brightness: 0.45
+    }
+  }
 }
 
 export class UserConfigStoreService {
@@ -83,51 +182,7 @@ export class UserConfigStoreService {
   }
 
   private getDefaultConfig(): UserConfig {
-    // Detect if it's a Mac system
-    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-
-    // Dynamically generate default shortcut config from shortcutActions
-    const defaultShortcuts: ShortcutConfig = {}
-    shortcutActions.forEach((action) => {
-      defaultShortcuts[action.id] = isMac ? action.defaultKey.mac : action.defaultKey.other
-    })
-
-    return {
-      id: 'userConfig',
-      updatedAt: Date.now(),
-      autoCompleteStatus: 1,
-      vimStatus: false,
-      quickVimStatus: 1,
-      commonVimStatus: 2,
-      aliasStatus: 1,
-      highlightStatus: 1,
-      pinchZoomStatus: 1,
-      fontSize: 12,
-      scrollBack: 1000,
-      language: 'zh-CN',
-      cursorStyle: 'block' as 'block' | 'underline' | 'bar',
-      middleMouseEvent: 'paste' as 'paste' | 'contextMenu' | 'none',
-      rightMouseEvent: 'contextMenu' as 'paste' | 'contextMenu' | 'none',
-      watermark: 'open' as 'open' | 'close',
-      secretRedaction: 'disabled' as 'enabled' | 'disabled',
-      dataSync: 'disabled' as 'enabled' | 'disabled',
-      theme: 'dark' as 'dark' | 'light' | 'auto',
-      defaultLayout: 'terminal' as 'terminal' | 'agents',
-      feature: 0.0,
-      quickComand: false,
-      shortcuts: defaultShortcuts,
-      sshAgentsStatus: 2,
-      sshAgentsMap: '[]',
-      sshProxyConfigs: [],
-      workspaceExpandedKeys: [],
-      lastCustomImage: '',
-      background: {
-        mode: 'none',
-        image: '',
-        opacity: 0.15,
-        brightness: 0.45
-      }
-    }
+    return buildDefaultUserConfig()
   }
 
   async getConfig(): Promise<UserConfig> {
@@ -136,6 +191,12 @@ export class UserConfigStoreService {
       let savedConfig: any = {}
       if (result?.value) {
         savedConfig = JSON.parse(result.value)
+        if (!savedConfig || typeof savedConfig !== 'object' || Array.isArray(savedConfig)) {
+          logger.warn('Loaded unexpected userConfig payload from SQLite, falling back to defaults', {
+            rawValue: typeof result.value === 'string' ? result.value.slice(0, 200) : result.value
+          })
+          savedConfig = {}
+        }
       }
 
       const defaultConfig = this.getDefaultConfig()
@@ -212,13 +273,37 @@ export class UserConfigStoreService {
         updatedAt: Date.now()
       }
 
-      await window.api.kvMutate({
-        action: 'set',
-        key: 'userConfig',
-        value: JSON.stringify(sanitizedConfig)
+      await window.api.kvTransaction(async (tx) => {
+        const existingMetaRaw = await tx.get('userConfigSyncMeta')
+        const existingMeta = existingMetaRaw
+          ? (JSON.parse(existingMetaRaw) as ConfigSyncMeta)
+          : buildDefaultConfigSyncMeta(SUPPORTED_USER_CONFIG_SCHEMA_VERSION)
+
+        tx.set('userConfig', JSON.stringify(sanitizedConfig))
+        tx.set(
+          'userConfigSyncMeta',
+          JSON.stringify({
+            ...existingMeta,
+            schemaVersion: SUPPORTED_USER_CONFIG_SCHEMA_VERSION,
+            dirty: true
+          } satisfies ConfigSyncMeta)
+        )
       })
 
-      logger.info('Config saved successfully to SQLite')
+      logger.info('Config saved successfully to SQLite', {
+        theme: sanitizedConfig.theme,
+        language: sanitizedConfig.language,
+        defaultLayout: sanitizedConfig.defaultLayout,
+        watermark: sanitizedConfig.watermark
+      })
+
+      // Trigger sync upload after successful save
+      try {
+        const { userConfigSyncService } = await import('./userConfigSyncService')
+        userConfigSyncService.scheduleUpload()
+      } catch (e) {
+        // Sync service may not be initialized yet, ignore
+      }
     } catch (error) {
       logger.error('Error saving config to SQLite', { error: error })
       throw error
@@ -234,4 +319,305 @@ export class UserConfigStoreService {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Sync whitelist fields
+// ---------------------------------------------------------------------------
+
+export const SYNC_WHITELIST = [
+  'language',
+  'theme',
+  'defaultLayout',
+  'watermark',
+  'secretRedaction',
+  'fontSize',
+  'scrollBack',
+  'cursorStyle',
+  'terminalType',
+  'middleMouseEvent',
+  'rightMouseEvent',
+  'pinchZoomStatus',
+  'autoCompleteStatus',
+  'quickVimStatus',
+  'commonVimStatus',
+  'aliasStatus',
+  'highlightStatus',
+  'shortcuts'
+] as const
+
+export type SyncWhitelistKey = (typeof SYNC_WHITELIST)[number]
+
+export type SyncableUserConfig = Pick<UserConfig, SyncWhitelistKey>
+
+// ---------------------------------------------------------------------------
+// Schema version
+// ---------------------------------------------------------------------------
+
+export const SUPPORTED_USER_CONFIG_SCHEMA_VERSION = 1
+
+// ---------------------------------------------------------------------------
+// Field validators
+// ---------------------------------------------------------------------------
+
+export const SYNC_FIELD_VALIDATORS: Record<SyncWhitelistKey, (val: unknown) => boolean> = {
+  language: (val) => typeof val === 'string' && SUPPORTED_LANGUAGE_VALUES.includes(val as SupportedLanguage),
+  theme: (val) => typeof val === 'string' && ['dark', 'light', 'auto'].includes(val),
+  defaultLayout: (val) => typeof val === 'string' && ['terminal', 'agents'].includes(val),
+  watermark: (val) => typeof val === 'string' && ['open', 'close'].includes(val),
+  secretRedaction: (val) => typeof val === 'string' && ['enabled', 'disabled'].includes(val),
+  fontSize: (val) => typeof val === 'number' && Number.isInteger(val) && val >= 8 && val <= 64,
+  scrollBack: (val) => typeof val === 'number' && Number.isInteger(val) && val >= 1 && val <= 100000,
+  cursorStyle: (val) => typeof val === 'string' && ['block', 'bar', 'underline'].includes(val),
+  terminalType: (val) =>
+    typeof val === 'string' && ['xterm', 'xterm-256color', 'vt100', 'vt102', 'vt220', 'vt320', 'linux', 'scoansi', 'ansi'].includes(val),
+  middleMouseEvent: (val) => typeof val === 'string' && ['paste', 'contextMenu', 'none'].includes(val),
+  rightMouseEvent: (val) => typeof val === 'string' && ['paste', 'contextMenu', 'none'].includes(val),
+  pinchZoomStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  autoCompleteStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  quickVimStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  commonVimStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  aliasStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  highlightStatus: (val) => typeof val === 'number' && [1, 2].includes(val),
+  shortcuts: (val) => isFlatShortcutConfig(val) || isPlatformShortcuts(val)
+}
+
+// ---------------------------------------------------------------------------
+// Sanitize / parse helpers
+// ---------------------------------------------------------------------------
+
+export function sanitizeForSync(config: UserConfig): SyncableUserConfig {
+  const result = {} as SyncableUserConfig
+  for (const key of SYNC_WHITELIST) {
+    if (key in config && config[key] !== undefined) {
+      if (key === 'shortcuts') {
+        const resolved = resolveCurrentPlatformShortcuts((config as any)[key])
+        if (resolved) {
+          ;(result as any).shortcuts = resolved
+        }
+        continue
+      }
+      ;(result as any)[key] = config[key]
+    }
+  }
+  return result
+}
+
+export function parseRemoteConfig(payload: Record<string, unknown>): Partial<SyncableUserConfig> {
+  const result: Partial<SyncableUserConfig> = {}
+  for (const key of SYNC_WHITELIST) {
+    if (key in payload) {
+      const val = payload[key]
+      if (key === 'shortcuts') {
+        const validator = SYNC_FIELD_VALIDATORS[key]
+        if (validator(val)) {
+          const resolved = resolveCurrentPlatformShortcuts(val)
+          if (resolved) {
+            ;(result as any).shortcuts = resolved
+          }
+        } else {
+          logger.warn('Remote shortcuts failed validation, skipping')
+        }
+      } else {
+        const validator = SYNC_FIELD_VALIDATORS[key]
+        if (validator(val)) {
+          ;(result as any)[key] = val
+        }
+      }
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Schema migration registry
+// ---------------------------------------------------------------------------
+
+type MigrationFn = (config: Record<string, unknown>) => Record<string, unknown>
+
+export const remoteConfigMigrations: Record<number, MigrationFn> = {
+  // Current schema is v1. Legacy payloads from v0 map 1:1.
+  0: (config) => ({ ...config })
+}
+
+export function migrateRemoteConfig(config: Record<string, unknown>, fromVersion: number, toVersion: number): Record<string, unknown> | null {
+  if (fromVersion > toVersion) {
+    return null
+  }
+  if (fromVersion === toVersion) {
+    return { ...config }
+  }
+
+  let current = { ...config }
+  for (let version = fromVersion; version < toVersion; version++) {
+    const migrate = remoteConfigMigrations[version]
+    if (!migrate) {
+      logger.warn('Missing remote config migration step', { fromVersion, toVersion, missingStep: version })
+      return null
+    }
+    current = migrate(current)
+  }
+  return current
+}
+
 export const userConfigStore = new UserConfigStoreService()
+
+export async function getStoredUserConfigSnapshot(): Promise<Partial<UserConfig> | null> {
+  try {
+    const result = await window.api.kvGet({ key: 'userConfig' })
+    if (!result?.value) {
+      return null
+    }
+
+    const parsed = JSON.parse(result.value)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+
+    return parsed as Partial<UserConfig>
+  } catch (error) {
+    logger.warn('Failed to read raw userConfig snapshot', { error })
+    return null
+  }
+}
+
+export function resolveDataSyncPreference(storedConfig: Partial<UserConfig> | null, isLoggedIn: boolean): 'enabled' | 'disabled' {
+  const storedValue = storedConfig?.dataSync
+  if (storedValue === 'enabled' || storedValue === 'disabled') {
+    return storedValue
+  }
+
+  return isLoggedIn ? 'enabled' : 'disabled'
+}
+
+// ---------------------------------------------------------------------------
+// RemoteApplyGuard - suppresses deep watch writeback during remote apply
+// ---------------------------------------------------------------------------
+
+class RemoteApplyGuard {
+  private _applying = false
+  get isApplying(): boolean {
+    return this._applying
+  }
+
+  async run(fn: () => Promise<void>): Promise<void> {
+    this._applying = true
+    try {
+      await fn()
+    } finally {
+      await nextTick()
+      this._applying = false
+    }
+  }
+}
+
+export const remoteApplyGuard = new RemoteApplyGuard()
+
+// ---------------------------------------------------------------------------
+// Runtime side-effect dispatch (only for fields that actually changed)
+// ---------------------------------------------------------------------------
+
+export function dispatchSideEffects(changedFields: Partial<SyncableUserConfig>): void {
+  // language -> localStorage + i18n locale
+  if ('language' in changedFields && changedFields.language) {
+    localStorage.setItem('lang', changedFields.language)
+    i18n.global.locale.value = changedFields.language
+  }
+
+  // theme -> document class + main process
+  if ('theme' in changedFields && changedFields.theme) {
+    const actualTheme = getActualTheme(changedFields.theme)
+    document.documentElement.className = `theme-${actualTheme}`
+    eventBus.emit('updateTheme', actualTheme)
+    window.api.updateTheme(changedFields.theme)
+  }
+
+  // defaultLayout -> eventBus notification
+  if ('defaultLayout' in changedFields && changedFields.defaultLayout) {
+    eventBus.emit('defaultLayoutChanged', changedFields.defaultLayout)
+  }
+
+  // watermark -> eventBus notification
+  if ('watermark' in changedFields && changedFields.watermark) {
+    eventBus.emit('updateWatermark', changedFields.watermark)
+  }
+
+  // pinchZoomStatus -> eventBus notification
+  if ('pinchZoomStatus' in changedFields && changedFields.pinchZoomStatus !== undefined) {
+    eventBus.emit('pinchZoomStatusChanged', changedFields.pinchZoomStatus === 1)
+  }
+
+  // aliasStatus -> eventBus notification
+  if ('aliasStatus' in changedFields && changedFields.aliasStatus !== undefined) {
+    eventBus.emit('aliasStatusChanged', changedFields.aliasStatus)
+  }
+
+  // shortcuts -> notify shortcut service to reload bindings
+  if ('shortcuts' in changedFields && changedFields.shortcuts) {
+    eventBus.emit('shortcutsSyncApplied')
+  }
+
+  // Other fields (fontSize, scrollBack, cursorStyle, terminalType, etc.)
+  // are consumed via Pinia computed/watch - no extra side-effects needed.
+}
+
+// ---------------------------------------------------------------------------
+// Apply remote config - atomic write + Pinia refresh + side-effects + notify
+// ---------------------------------------------------------------------------
+
+export async function applyRemoteConfig(
+  parsedFields: Partial<SyncableUserConfig>,
+  meta?: import('./configSyncManager').ConfigSyncMeta,
+  metaKey?: string
+): Promise<void> {
+  await remoteApplyGuard.run(async () => {
+    // 1. Read current local config
+    const currentConfig = await userConfigStore.getConfig()
+
+    // 2. Identify actually changed fields (deep comparison for object-type fields)
+    const changedFields: Partial<SyncableUserConfig> = {}
+    for (const key of Object.keys(parsedFields) as Array<keyof SyncableUserConfig>) {
+      const remoteVal = parsedFields[key]
+      const localVal = currentConfig[key]
+      const isEqual =
+        typeof remoteVal === 'object' && remoteVal !== null ? JSON.stringify(remoteVal) === JSON.stringify(localVal) : remoteVal === localVal
+      if (!isEqual) {
+        ;(changedFields as any)[key] = remoteVal
+      }
+    }
+
+    // 3. No-op when remote payload does not change any synced field.
+    if (Object.keys(changedFields).length === 0) {
+      return
+    }
+
+    // 4. Merge changed whitelist fields into local config
+    const mergedConfig = { ...currentConfig, ...changedFields, updatedAt: Date.now() }
+
+    // 5. Atomic write SQLite (userConfig + syncMeta in the same transaction).
+    await window.api.kvTransaction(async (tx) => {
+      tx.set('userConfig', JSON.stringify(mergedConfig))
+      if (meta && metaKey) {
+        tx.set(metaKey, JSON.stringify(meta))
+      }
+    })
+
+    // 6. Refresh Pinia store for changed whitelist fields
+    const store = piniaConfigStore()
+    const piniaUpdatable: Record<string, (val: any) => void> = {
+      language: (v) => store.updateLanguage(v),
+      theme: (v) => store.updateTheme(v),
+      secretRedaction: (v) => store.updateSecretRedaction(v),
+      dataSync: (v) => store.updateDataSync(v)
+    }
+    for (const key of Object.keys(changedFields) as Array<keyof SyncableUserConfig>) {
+      if (piniaUpdatable[key]) {
+        piniaUpdatable[key]((changedFields as any)[key])
+      }
+    }
+
+    // 7. Dispatch runtime side-effects for changed fields
+    dispatchSideEffects(changedFields)
+
+    // 8. Notify setting pages to reload and wait for handlers to complete
+    await eventBus.emitAsync('userConfigSyncApplied')
+  })
+}

--- a/src/renderer/src/services/userConfigSyncService.ts
+++ b/src/renderer/src/services/userConfigSyncService.ts
@@ -1,0 +1,241 @@
+/**
+ * User Config Sync Service - Renderer Process
+ *
+ * Uses the generic ConfigSyncManager with a user_config-specific adapter.
+ * This service syncs the terminal/UI preferences whitelist fields.
+ *
+ * Lifecycle:
+ *   - initialize(): called on login / dataSync enable
+ *   - scheduleUpload(): called after local config change (saveConfig success)
+ *   - reset(): called on account switch (clears all state)
+ *   - stop(): called on dataSync disable (pauses sync, keeps persisted meta)
+ */
+
+import {
+  sanitizeForSync,
+  parseRemoteConfig,
+  migrateRemoteConfig,
+  applyRemoteConfig,
+  buildDefaultUserConfig,
+  getPlatformKey,
+  isFlatShortcutConfig,
+  isPlatformShortcuts,
+  SUPPORTED_USER_CONFIG_SCHEMA_VERSION,
+  type PlatformKey,
+  type PlatformShortcuts,
+  type SyncableUserConfig,
+  userConfigStore
+} from './userConfigStoreService'
+import { ConfigSyncManager, type ConfigSyncAdapter, type ConfigSyncMeta } from './configSyncManager'
+import { canonicalJSONStringify } from './syncJson'
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const PLATFORM_KEYS: PlatformKey[] = ['mac', 'windows', 'linux']
+
+function clonePlatformShortcuts(shortcuts: PlatformShortcuts): PlatformShortcuts {
+  const cloned: PlatformShortcuts = {}
+  for (const platform of PLATFORM_KEYS) {
+    const current = shortcuts[platform]
+    if (isFlatShortcutConfig(current)) {
+      cloned[platform] = { ...current }
+    }
+  }
+  return cloned
+}
+
+const PLATFORM_SHORTCUTS_CACHE_KEY = 'platformShortcutsCache'
+
+let cachedRemotePlatformShortcuts: PlatformShortcuts = {}
+
+function setCachedPlatformShortcuts(shortcuts: PlatformShortcuts): void {
+  cachedRemotePlatformShortcuts = clonePlatformShortcuts(shortcuts)
+  // Persist to SQLite so cache survives restart
+  window.api
+    .kvMutate({
+      action: 'set',
+      key: PLATFORM_SHORTCUTS_CACHE_KEY,
+      value: JSON.stringify(cachedRemotePlatformShortcuts)
+    })
+    .catch(() => {
+      // Non-critical: sync still works with current platform only
+    })
+}
+
+async function ensurePlatformShortcutsCache(): Promise<void> {
+  if (Object.keys(cachedRemotePlatformShortcuts).length > 0) return
+  try {
+    // Priority 1: dedicated persisted cache (survives restart)
+    const cacheResult = await window.api.kvGet({ key: PLATFORM_SHORTCUTS_CACHE_KEY })
+    if (cacheResult?.value) {
+      const cached = JSON.parse(cacheResult.value)
+      if (isPlatformShortcuts(cached)) {
+        cachedRemotePlatformShortcuts = clonePlatformShortcuts(cached)
+        return
+      }
+    }
+    // Priority 2: fallback to lastSyncedPayload in meta
+    const metaResult = await window.api.kvGet({ key: 'userConfigSyncMeta' })
+    if (!metaResult?.value) return
+    const meta = JSON.parse(metaResult.value) as { lastSyncedPayload?: string }
+    if (!meta.lastSyncedPayload || typeof meta.lastSyncedPayload !== 'string') return
+
+    const payload = JSON.parse(meta.lastSyncedPayload)
+    if (!isPlainObject(payload) || !('shortcuts' in payload)) return
+
+    const shortcuts = (payload as Record<string, unknown>).shortcuts
+    if (isPlatformShortcuts(shortcuts)) {
+      setCachedPlatformShortcuts(shortcuts)
+      return
+    }
+    if (isFlatShortcutConfig(shortcuts)) {
+      setCachedPlatformShortcuts({ [getPlatformKey()]: shortcuts })
+    }
+  } catch {
+    // Ignore cache restoration failures; sync still works with current platform only.
+  }
+}
+
+function normalizeShortcutsForUpload(shortcuts: unknown): PlatformShortcuts | null {
+  if (isPlatformShortcuts(shortcuts)) {
+    const normalized = clonePlatformShortcuts(shortcuts)
+    setCachedPlatformShortcuts(normalized)
+    return normalized
+  }
+
+  if (isFlatShortcutConfig(shortcuts)) {
+    const merged = clonePlatformShortcuts(cachedRemotePlatformShortcuts)
+    merged[getPlatformKey()] = { ...shortcuts }
+    setCachedPlatformShortcuts(merged)
+    return merged
+  }
+
+  return null
+}
+
+function preprocessRemotePayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const processed = { ...payload }
+  const shortcuts = processed.shortcuts
+
+  if (isPlatformShortcuts(shortcuts)) {
+    setCachedPlatformShortcuts(shortcuts)
+    const current = shortcuts[getPlatformKey()]
+    if (isFlatShortcutConfig(current)) {
+      processed.shortcuts = { ...current }
+    } else {
+      delete processed.shortcuts
+    }
+    return processed
+  }
+
+  if (isFlatShortcutConfig(shortcuts)) {
+    normalizeShortcutsForUpload(shortcuts)
+    processed.shortcuts = { ...shortcuts }
+  }
+
+  return processed
+}
+
+function buildCanonicalSyncPayload(data: Record<string, unknown>): string {
+  const payload: Record<string, unknown> = { ...data }
+  if ('shortcuts' in payload) {
+    const normalized = normalizeShortcutsForUpload(payload.shortcuts)
+    if (normalized) {
+      payload.shortcuts = normalized
+    }
+  }
+  return canonicalJSONStringify(payload)
+}
+
+// ---------------------------------------------------------------------------
+// Adapter for user_config
+// ---------------------------------------------------------------------------
+
+const userConfigAdapter: ConfigSyncAdapter<SyncableUserConfig> = {
+  configType: 'user_config',
+  metaKey: 'userConfigSyncMeta',
+  schemaVersion: SUPPORTED_USER_CONFIG_SCHEMA_VERSION,
+
+  async readLocal(): Promise<SyncableUserConfig> {
+    await ensurePlatformShortcutsCache()
+    const fullConfig = await userConfigStore.getConfig()
+    return sanitizeForSync(fullConfig)
+  },
+
+  serializeForUpload(data: SyncableUserConfig): string {
+    return buildCanonicalSyncPayload(data as Record<string, unknown>)
+  },
+
+  parseRemote(payload: unknown): SyncableUserConfig | null {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+    const preprocessed = preprocessRemotePayload(payload as Record<string, unknown>)
+    const parsed = parseRemoteConfig(preprocessed)
+    if (Object.keys(parsed).length === 0) return null
+    return parsed as SyncableUserConfig
+  },
+
+  migrateRemote(payload: unknown, fromVersion: number, toVersion: number): unknown | null {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+    return migrateRemoteConfig(payload as Record<string, unknown>, fromVersion, toVersion)
+  },
+
+  async applyRemote(data: SyncableUserConfig, meta?: ConfigSyncMeta, metaKey?: string): Promise<void> {
+    // applyRemoteConfig handles local userConfig apply + atomic meta write.
+    await applyRemoteConfig(data, meta, metaKey)
+  },
+
+  getDefault(): SyncableUserConfig {
+    return sanitizeForSync(buildDefaultUserConfig())
+  },
+
+  cacheRemotePlatformData(serverConfig: string): void {
+    try {
+      const parsed = typeof serverConfig === 'string' ? JSON.parse(serverConfig) : serverConfig
+      if (!isPlainObject(parsed) || !('shortcuts' in parsed)) return
+      const shortcuts = (parsed as Record<string, unknown>).shortcuts
+      if (isPlatformShortcuts(shortcuts)) {
+        setCachedPlatformShortcuts(shortcuts)
+      }
+    } catch {
+      // Non-critical: cache miss only affects cross-platform shortcuts
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton instance
+// ---------------------------------------------------------------------------
+
+class UserConfigSyncService {
+  private static instance: UserConfigSyncService
+  private manager = new ConfigSyncManager(userConfigAdapter)
+
+  static getInstance(): UserConfigSyncService {
+    if (!UserConfigSyncService.instance) {
+      UserConfigSyncService.instance = new UserConfigSyncService()
+    }
+    return UserConfigSyncService.instance
+  }
+
+  initialize(): Promise<void> {
+    return this.manager.initialize()
+  }
+
+  scheduleUpload(): void {
+    this.manager.scheduleUpload()
+  }
+
+  reset(): void {
+    cachedRemotePlatformShortcuts = {}
+    window.api.kvMutate({ action: 'delete', key: PLATFORM_SHORTCUTS_CACHE_KEY }).catch(() => {})
+    this.manager.reset()
+  }
+
+  stop(): void {
+    this.manager.stop()
+  }
+}
+
+export const userConfigSyncService = UserConfigSyncService.getInstance()

--- a/src/renderer/src/services/userRulesSyncService.ts
+++ b/src/renderer/src/services/userRulesSyncService.ts
@@ -1,0 +1,136 @@
+/**
+ * User Rules Sync Service
+ *
+ * Uses the generic ConfigSyncManager with a user_rules-specific adapter.
+ * Syncs user-defined instruction rules (array of {id, content, enabled}).
+ */
+
+import { ConfigSyncManager, type ConfigSyncAdapter, type ConfigSyncMeta } from './configSyncManager'
+
+const logger = createRendererLogger('service.userRulesSync')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface UserRule {
+  id: string
+  content: string
+  enabled: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+function validateUserRules(payload: unknown): UserRule[] | null {
+  if (!Array.isArray(payload)) return null
+  // Empty array is valid - means user cleared all rules
+  if (payload.length === 0) return []
+  const valid = payload
+    .filter((r: any) => typeof r === 'object' && r !== null && typeof r.id === 'string' && typeof r.content === 'string')
+    .map((r: any) => ({
+      id: r.id,
+      content: r.content,
+      enabled: r.enabled !== undefined ? Boolean(r.enabled) : true
+    }))
+  return valid
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+const userRulesAdapter: ConfigSyncAdapter<UserRule[]> = {
+  configType: 'user_rules',
+  metaKey: 'userRulesSyncMeta',
+  schemaVersion: 1,
+
+  async readLocal(): Promise<UserRule[]> {
+    try {
+      const { getGlobalState } = await import('@renderer/agent/storage/state')
+      const saved = await getGlobalState('userRules')
+      if (saved && Array.isArray(saved)) {
+        return saved
+          .filter((r: any) => typeof r === 'object' && r !== null && typeof r.content === 'string')
+          .map((r: any) => ({
+            id: r.id || '',
+            content: r.content,
+            enabled: r.enabled !== undefined ? Boolean(r.enabled) : true
+          }))
+      }
+    } catch {
+      // fall through
+    }
+    return []
+  },
+
+  serializeForUpload(data: UserRule[]): string {
+    // Sort rules by id for deterministic comparison
+    const sorted = [...data]
+      .filter((r) => r.content.trim() !== '')
+      .map((r) => ({ content: r.content, enabled: r.enabled, id: r.id }))
+      .sort((a, b) => a.id.localeCompare(b.id))
+    return JSON.stringify(sorted)
+  },
+
+  parseRemote(payload: unknown): UserRule[] | null {
+    return validateUserRules(payload)
+  },
+
+  async applyRemote(data: UserRule[], meta?: ConfigSyncMeta, metaKey?: string): Promise<void> {
+    // Atomic write: config + meta in the same SQLite transaction
+    await window.api.kvTransaction(async (tx) => {
+      tx.set('global_userRules', JSON.stringify(data))
+      if (meta && metaKey) {
+        tx.set(metaKey, JSON.stringify(meta))
+      }
+    })
+    // Emit event so the rules component can reload from local storage
+    try {
+      const eventBus = (await import('@/utils/eventBus')).default
+      eventBus.emit('userRulesSyncApplied')
+    } catch {
+      // eventBus may not be available
+    }
+    logger.info('Applied remote user rules')
+  },
+
+  getDefault(): UserRule[] {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+class UserRulesSyncService {
+  private static instance: UserRulesSyncService
+  private manager = new ConfigSyncManager(userRulesAdapter)
+
+  static getInstance(): UserRulesSyncService {
+    if (!UserRulesSyncService.instance) {
+      UserRulesSyncService.instance = new UserRulesSyncService()
+    }
+    return UserRulesSyncService.instance
+  }
+
+  initialize(): Promise<void> {
+    return this.manager.initialize()
+  }
+
+  scheduleUpload(): void {
+    this.manager.scheduleUpload()
+  }
+
+  reset(): void {
+    this.manager.reset()
+  }
+
+  stop(): void {
+    this.manager.stop()
+  }
+}
+
+export const userRulesSyncService = UserRulesSyncService.getInstance()

--- a/src/renderer/src/stores/__tests__/editorConfig.test.ts
+++ b/src/renderer/src/stores/__tests__/editorConfig.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useEditorConfigStore, FONT_FAMILY_OPTIONS } from '../editorConfig'
 
-// Mock window.api
+// Mock window.api with KV store methods
 const mockApi = {
-  getEditorConfig: vi.fn(),
-  saveEditorConfig: vi.fn()
+  kvGet: vi.fn(),
+  kvMutate: vi.fn()
 }
 
 Object.defineProperty(window, 'api', {
@@ -67,7 +67,7 @@ describe('EditorConfig Store', () => {
   })
 
   it('should update config correctly', async () => {
-    mockApi.saveEditorConfig.mockResolvedValue(undefined)
+    mockApi.kvMutate.mockResolvedValue(undefined)
 
     const store = useEditorConfigStore()
 
@@ -80,15 +80,19 @@ describe('EditorConfig Store', () => {
     expect(store.config.fontSize).toBe(16)
     expect(store.config.tabSize).toBe(2)
     expect(store.config.fontFamily).toBe('system-default')
-    expect(mockApi.saveEditorConfig).toHaveBeenCalledWith({
-      fontSize: 16,
-      fontFamily: 'system-default',
-      tabSize: 2,
-      wordWrap: 'off',
-      minimap: true,
-      mouseWheelZoom: true,
-      cursorBlinking: 'blink',
-      lineHeight: 0
+    expect(mockApi.kvMutate).toHaveBeenCalledWith({
+      action: 'set',
+      key: 'editorConfig',
+      value: JSON.stringify({
+        fontSize: 16,
+        fontFamily: 'system-default',
+        tabSize: 2,
+        wordWrap: 'off',
+        minimap: true,
+        mouseWheelZoom: true,
+        cursorBlinking: 'blink',
+        lineHeight: 0
+      })
     })
   })
 
@@ -104,7 +108,7 @@ describe('EditorConfig Store', () => {
       lineHeight: 20
     }
 
-    mockApi.getEditorConfig.mockResolvedValue(savedConfig)
+    mockApi.kvGet.mockResolvedValue({ value: JSON.stringify(savedConfig) })
 
     const store = useEditorConfigStore()
     await store.loadConfig()
@@ -124,7 +128,7 @@ describe('EditorConfig Store', () => {
       lineHeight: 0
     }
 
-    mockApi.getEditorConfig.mockResolvedValue(savedConfig)
+    mockApi.kvGet.mockResolvedValue({ value: JSON.stringify(savedConfig) })
 
     const store = useEditorConfigStore()
     await store.loadConfig()
@@ -135,7 +139,7 @@ describe('EditorConfig Store', () => {
   })
 
   it('should reset to default config', async () => {
-    mockApi.saveEditorConfig.mockResolvedValue(undefined)
+    mockApi.kvMutate.mockResolvedValue(undefined)
 
     const store = useEditorConfigStore()
 

--- a/src/renderer/src/stores/editorConfig.ts
+++ b/src/renderer/src/stores/editorConfig.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { editor } from 'monaco-editor'
+import { markSyncMetaDirty } from '@/services/configSyncManager'
 
 /**
  * Editor configuration interface
@@ -224,13 +225,14 @@ export const useEditorConfigStore = defineStore('editorConfig', () => {
   }))
 
   /**
-   * Load configuration from main process
+   * Load configuration from KV store
    */
   const loadConfig = async () => {
     try {
-      const savedConfig = await (window as any).api.getEditorConfig()
+      const result = await window.api.kvGet({ key: 'editorConfig' })
+      if (result?.value) {
+        const savedConfig = JSON.parse(result.value)
 
-      if (savedConfig) {
         // Validate saved font is in supported list
         const fontKey = savedConfig.fontFamily
         const isValidFont = FONT_CONFIGS.some((f) => f.key === fontKey)
@@ -247,7 +249,8 @@ export const useEditorConfigStore = defineStore('editorConfig', () => {
   }
 
   /**
-   * Save config to main process. Build plain object to avoid IPC "object could not be cloned" (Vue Proxy).
+   * Save config to KV store and trigger sync upload via editorConfigSyncService.
+   * Build plain object to avoid IPC "object could not be cloned" (Vue Proxy).
    */
   const saveConfig = async () => {
     try {
@@ -262,7 +265,16 @@ export const useEditorConfigStore = defineStore('editorConfig', () => {
         cursorBlinking: c.cursorBlinking,
         lineHeight: Number(c.lineHeight)
       }
-      await (window as any).api.saveEditorConfig(plain)
+      await window.api.kvMutate({ action: 'set', key: 'editorConfig', value: JSON.stringify(plain) })
+
+      // Trigger sync via the dedicated sync service (has full protection mechanisms)
+      try {
+        await markSyncMetaDirty('editorConfigSyncMeta', 1)
+        const { editorConfigSyncService } = await import('../services/editorConfigSyncService')
+        editorConfigSyncService.scheduleUpload()
+      } catch (e) {
+        // Sync service may not be initialized yet, ignore
+      }
     } catch (error) {
       logger.error('Failed to save editor config', { error: error })
       throw error

--- a/src/renderer/src/utils/eventBus.ts
+++ b/src/renderer/src/utils/eventBus.ts
@@ -35,4 +35,50 @@ export interface AppEvents {
 
 const emitter = mitt<AppEvents>()
 
-export default emitter
+const ASYNC_EMIT_DEFAULT_TIMEOUT_MS = 3_000
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) {
+    return promise
+  }
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`eventBus emitAsync timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timeoutId)
+        reject(error)
+      }
+    )
+  })
+}
+
+async function emitAsync<T extends keyof AppEvents>(type: T, event?: AppEvents[T], options?: { timeoutMs?: number }): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? ASYNC_EMIT_DEFAULT_TIMEOUT_MS
+  const handlers = emitter.all.get(type) as Set<(payload: AppEvents[T]) => unknown> | undefined
+
+  if (!handlers || handlers.size === 0) {
+    return
+  }
+
+  const tasks = Array.from(handlers).map(async (handler) => {
+    await withTimeout(Promise.resolve(handler(event as AppEvents[T])), timeoutMs)
+  })
+
+  await Promise.all(tasks)
+}
+
+const eventBus = {
+  on: emitter.on,
+  off: emitter.off,
+  emit: emitter.emit,
+  emitAsync
+}
+
+export default eventBus

--- a/src/renderer/src/utils/request.ts
+++ b/src/renderer/src/utils/request.ts
@@ -1,51 +1,58 @@
-import axios from 'axios'
+import axios, { type AxiosInstance } from 'axios'
 import config from '@/config'
 import { removeToken } from '@/utils/permission'
 
-const request = axios.create({
-  baseURL: config.api
-})
-
-// Add request interceptor
-request.interceptors.request.use(
-  async function (config) {
-    const isSkippedLogin = localStorage.getItem('login-skipped') === 'true'
-    if (isSkippedLogin) {
-      config.headers['Authorization'] = `Bearer guest_token`
-    } else {
-      const BearerToken = localStorage.getItem('ctm-token')
-      config.headers['Authorization'] = `Bearer ${BearerToken}`
-    }
-    return config
-  },
-  function (error) {
-    // Handle request error
-    return Promise.reject(error)
-  }
-)
-
-// Add response interceptor
-request.interceptors.response.use(
-  (res) => {
-    return res.data
-  },
-  function (error) {
-    const isSkippedLogin = localStorage.getItem('login-skipped') === 'true'
-
-    if (isSkippedLogin && error.response?.status === 401) {
-      return Promise.resolve({ data: {} })
-    }
-    if (error.response?.status === 401) {
-      const data = error.response.data
-      if (!(data.result && data.result.isLogin)) {
-        removeToken()
-        window.location.hash = '#/login'
+function attachAuthInterceptors(instance: AxiosInstance): AxiosInstance {
+  // Add request interceptor
+  instance.interceptors.request.use(
+    async function (config) {
+      const isSkippedLogin = localStorage.getItem('login-skipped') === 'true'
+      if (isSkippedLogin) {
+        config.headers['Authorization'] = `Bearer guest_token`
+      } else {
+        const BearerToken = localStorage.getItem('ctm-token')
+        config.headers['Authorization'] = `Bearer ${BearerToken}`
       }
+      return config
+    },
+    function (error) {
+      // Handle request error
+      return Promise.reject(error)
     }
-    // Status codes outside the 2xx range will trigger this function
-    // Handle response error
-    return Promise.reject(error)
-  }
-)
+  )
+
+  // Add response interceptor
+  instance.interceptors.response.use(
+    (res) => {
+      return res.data
+    },
+    function (error) {
+      const isSkippedLogin = localStorage.getItem('login-skipped') === 'true'
+
+      if (isSkippedLogin && error.response?.status === 401) {
+        return Promise.resolve({ data: {} })
+      }
+      if (error.response?.status === 401) {
+        const data = error.response.data
+        if (!(data.result && data.result.isLogin)) {
+          removeToken()
+          window.location.hash = '#/login'
+        }
+      }
+      // Status codes outside the 2xx range will trigger this function
+      // Handle response error
+      return Promise.reject(error)
+    }
+  )
+
+  return instance
+}
+
+export function createAuthedRequest(baseURL: string): AxiosInstance {
+  const instance = axios.create({ baseURL })
+  return attachAuthInterceptors(instance)
+}
+
+const request = createAuthedRequest(config.api)
 
 export default request

--- a/src/renderer/src/utils/syncRequest.ts
+++ b/src/renderer/src/utils/syncRequest.ts
@@ -1,0 +1,6 @@
+import { getSyncServerUrl } from '@/utils/edition'
+import { createAuthedRequest } from '@/utils/request'
+
+const syncRequest = createAuthedRequest(`${getSyncServerUrl()}/v1`)
+
+export default syncRequest

--- a/src/renderer/src/views/components/LeftTab/setting/__tests__/privacy.test.ts
+++ b/src/renderer/src/views/components/LeftTab/setting/__tests__/privacy.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import PrivacyComponent from '../privacy.vue'
@@ -19,6 +19,11 @@ import { notification } from 'ant-design-vue'
 import { userConfigStore } from '@/services/userConfigStoreService'
 import { dataSyncService } from '@/services/dataSyncService'
 import { getPrivacyPolicyUrl } from '@/utils/edition'
+
+const { mockUserConfigGetConfig, mockUserConfigSaveConfig } = vi.hoisted(() => ({
+  mockUserConfigGetConfig: vi.fn(),
+  mockUserConfigSaveConfig: vi.fn()
+}))
 
 // Test constants
 const DEFAULT_CONFIG = {
@@ -28,6 +33,15 @@ const DEFAULT_CONFIG = {
 }
 
 const PRIVACY_URL = 'https://example.com/privacy'
+
+// Mock window.api
+const mockWindowApi = {
+  sendToMain: vi.fn(),
+  kvGet: vi.fn()
+}
+
+;(globalThis as any).window = (globalThis as any).window || {}
+;(globalThis as any).window.api = mockWindowApi
 
 // Mock ant-design-vue components
 vi.mock('ant-design-vue', () => ({
@@ -88,19 +102,30 @@ const mockTranslations: Record<string, string> = {
 
 const mockT = (key: string) => mockTranslations[key] || key
 
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: mockT
-  })
-}))
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: mockT
+    })
+  }
+})
 
 // Mock userConfigStore service
-vi.mock('@/services/userConfigStoreService', () => ({
-  userConfigStore: {
-    getConfig: vi.fn(),
-    saveConfig: vi.fn()
+vi.mock('@/services/userConfigStoreService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/userConfigStoreService')>()
+  return {
+    ...actual,
+    userConfigStore: {
+      getConfig: mockUserConfigGetConfig,
+      saveConfig: mockUserConfigSaveConfig
+    },
+    remoteApplyGuard: {
+      isApplying: false
+    }
   }
-}))
+})
 
 // Mock dataSyncService
 vi.mock('@/services/dataSyncService', () => ({
@@ -111,20 +136,18 @@ vi.mock('@/services/dataSyncService', () => ({
 }))
 
 // Mock edition utils
-vi.mock('@/utils/edition', () => ({
-  getPrivacyPolicyUrl: vi.fn(() => PRIVACY_URL)
-}))
+vi.mock('@/utils/edition', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/edition')>()
+  return {
+    ...actual,
+    getPrivacyPolicyUrl: vi.fn(() => PRIVACY_URL)
+  }
+})
 
 // Mock permission utils
 vi.mock('@/utils/permission', () => ({
   getUserInfo: vi.fn(() => ({ uid: 'test-uid' }))
 }))
-
-// Mock window.api
-const mockWindowApi = {
-  sendToMain: vi.fn(),
-  kvGet: vi.fn()
-}
 
 describe('Privacy Component', () => {
   let wrapper: VueWrapper<any>
@@ -132,9 +155,11 @@ describe('Privacy Component', () => {
 
   // Helper function to wait for component updates
   const waitForUpdates = async (count = 2) => {
+    await flushPromises()
     for (let i = 0; i < count; i++) {
       await nextTick()
     }
+    await flushPromises()
   }
 
   // Helper function to create component wrapper
@@ -205,8 +230,8 @@ describe('Privacy Component', () => {
     vi.clearAllMocks()
 
     // Setup default mock return values
-    ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(DEFAULT_CONFIG)
-    ;(userConfigStore.saveConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+    mockUserConfigGetConfig.mockResolvedValue(DEFAULT_CONFIG)
+    mockUserConfigSaveConfig.mockResolvedValue(undefined)
     ;(dataSyncService.enableDataSync as ReturnType<typeof vi.fn>).mockResolvedValue(true)
     ;(dataSyncService.disableDataSync as ReturnType<typeof vi.fn>).mockResolvedValue(true)
     mockWindowApi.sendToMain.mockResolvedValue(undefined)
@@ -240,7 +265,7 @@ describe('Privacy Component', () => {
     })
 
     it('should initialize with default values when no config is saved', async () => {
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+      mockUserConfigGetConfig.mockResolvedValue(null)
 
       wrapper = createWrapper()
       await waitForUpdates()
@@ -253,7 +278,7 @@ describe('Privacy Component', () => {
 
     it('should handle config load errors gracefully', async () => {
       const error = new Error('Load failed')
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockRejectedValue(error)
+      mockUserConfigGetConfig.mockRejectedValue(error)
 
       wrapper = createWrapper()
       await waitForUpdates()
@@ -270,7 +295,7 @@ describe('Privacy Component', () => {
         dataSync: 'disabled',
         telemetry: 'disabled'
       }
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(savedConfig)
+      mockUserConfigGetConfig.mockResolvedValue(savedConfig)
       // Mock kvGet to return the same config
       mockWindowApi.kvGet.mockResolvedValue({
         value: JSON.stringify({ dataSync: 'disabled' })
@@ -284,7 +309,7 @@ describe('Privacy Component', () => {
     })
 
     it('should use default values when saved config has missing fields', async () => {
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      mockUserConfigGetConfig.mockResolvedValue({
         secretRedaction: 'enabled'
         // dataSync and telemetry are missing
       })
@@ -296,6 +321,23 @@ describe('Privacy Component', () => {
       expect(vm.userConfig.secretRedaction).toBe('enabled')
       expect(vm.userConfig.dataSync).toBe('enabled') // default
       expect(vm.userConfig.telemetry).toBe('unset') // default for telemetry
+    })
+
+    it('should not treat merged default disabled as an explicit data sync preference', async () => {
+      mockUserConfigGetConfig.mockResolvedValue({
+        secretRedaction: 'enabled',
+        dataSync: 'disabled',
+        telemetry: 'enabled'
+      })
+      mockWindowApi.kvGet.mockResolvedValue({
+        value: JSON.stringify({})
+      })
+
+      wrapper = createWrapper()
+      await waitForUpdates()
+
+      const vm = wrapper.vm as any
+      expect(vm.userConfig.dataSync).toBe('enabled')
     })
   })
 
@@ -557,7 +599,7 @@ describe('Privacy Component', () => {
 
     it('should handle save config errors and show notification', async () => {
       const error = new Error('Save failed')
-      ;(userConfigStore.saveConfig as ReturnType<typeof vi.fn>).mockRejectedValue(error)
+      mockUserConfigSaveConfig.mockRejectedValue(error)
 
       const vm = wrapper.vm as any
       vm.userConfig.secretRedaction = 'disabled'
@@ -687,7 +729,7 @@ describe('Privacy Component', () => {
 
   describe('Edge Cases', () => {
     it('should handle empty config object with defaults', async () => {
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      mockUserConfigGetConfig.mockResolvedValue({})
 
       wrapper = createWrapper()
       await waitForUpdates()
@@ -700,7 +742,7 @@ describe('Privacy Component', () => {
     })
 
     it('should handle null config gracefully', async () => {
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+      mockUserConfigGetConfig.mockResolvedValue(null)
 
       wrapper = createWrapper()
       await waitForUpdates()
@@ -713,7 +755,7 @@ describe('Privacy Component', () => {
     })
 
     it('should handle undefined config values with defaults', async () => {
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      mockUserConfigGetConfig.mockResolvedValue({
         secretRedaction: undefined,
         dataSync: undefined,
         telemetry: undefined
@@ -799,7 +841,7 @@ describe('Privacy Component', () => {
         dataSync: 'enabled',
         telemetry: 'enabled'
       }
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(initialConfig)
+      mockUserConfigGetConfig.mockResolvedValue(initialConfig)
 
       wrapper = createWrapper()
       await waitForUpdates()
@@ -824,7 +866,7 @@ describe('Privacy Component', () => {
         dataSync: 'disabled',
         telemetry: 'enabled'
       }
-      ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(initialConfig)
+      mockUserConfigGetConfig.mockResolvedValue(initialConfig)
 
       wrapper = createWrapper()
       await waitForUpdates()

--- a/src/renderer/src/views/components/LeftTab/setting/ai.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/ai.vue
@@ -491,13 +491,20 @@ watch(
 // Load saved configuration when component is mounted
 onMounted(async () => {
   await loadSavedConfig()
-  await saveConfig()
+  // Listen for ai_preferences specific sync events
+  eventBus.on('aiPreferencesSyncApplied', onAiSyncApplied)
 })
 
 // Save configuration before component unmounts
 onBeforeUnmount(async () => {
+  eventBus.off('aiPreferencesSyncApplied', onAiSyncApplied)
   await saveConfig()
 })
+
+const onAiSyncApplied = () => {
+  // aiPreferencesSyncService already applied remote data to local storage, just reload UI
+  loadSavedConfig()
+}
 
 // Validate shell integration timeout input
 const validateTimeout = (value: string) => {

--- a/src/renderer/src/views/components/LeftTab/setting/extensions.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/extensions.vue
@@ -78,10 +78,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import '@xterm/xterm/css/xterm.css'
 import { notification } from 'ant-design-vue'
-import { userConfigStore } from '@/services/userConfigStoreService'
+import { userConfigStore, remoteApplyGuard } from '@/services/userConfigStoreService'
 import eventBus from '@/utils/eventBus'
 import { captureExtensionUsage, ExtensionNames, ExtensionStatus } from '@/utils/telemetry'
 import { useI18n } from 'vue-i18n'
@@ -143,6 +143,7 @@ const saveConfig = async () => {
 watch(
   () => userConfig.value,
   async (newValue, oldValue) => {
+    if (remoteApplyGuard.isApplying) return
     if (oldValue && newValue.aliasStatus !== oldValue.aliasStatus) {
       return
     }
@@ -152,8 +153,17 @@ watch(
   { deep: true }
 )
 
+const reloadConfigOnSync = async () => {
+  await loadSavedConfig()
+}
+
 onMounted(async () => {
   await loadSavedConfig()
+  eventBus.on('userConfigSyncApplied', reloadConfigOnSync)
+})
+
+onBeforeUnmount(() => {
+  eventBus.off('userConfigSyncApplied', reloadConfigOnSync)
 })
 
 const handleAutoCompleteChange = async (checked) => {

--- a/src/renderer/src/views/components/LeftTab/setting/general.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/general.vue
@@ -296,7 +296,7 @@
 import { ref, onMounted, watch, onBeforeUnmount } from 'vue'
 import { notification } from 'ant-design-vue'
 import { DeleteOutlined, UploadOutlined, DesktopOutlined } from '@ant-design/icons-vue'
-import { userConfigStore } from '@/services/userConfigStoreService'
+import { userConfigStore, remoteApplyGuard } from '@/services/userConfigStoreService'
 import { userConfigStore as configStore } from '@/store/userConfigStore'
 import { useEditorConfigStore, type EditorConfig, FONT_FAMILY_OPTIONS } from '@/stores/editorConfig'
 import eventBus from '@/utils/eventBus'
@@ -413,15 +413,32 @@ const saveConfig = async () => {
 watch(
   () => userConfig.value,
   async () => {
+    if (remoteApplyGuard.isApplying) return
     await saveConfig()
   },
   { deep: true }
 )
 
+const reloadConfigOnSync = async () => {
+  await loadSavedConfig()
+}
+
+const reloadEditorConfigOnSync = async () => {
+  try {
+    await editorConfigStore.loadConfig()
+    editorConfig.value = editorConfigStore.getConfigSnapshot()
+  } catch (error) {
+    logger.error('Failed to reload editor config on sync', { error })
+  }
+}
+
 let systemThemeListener: (() => void) | null = null
 
 onMounted(async () => {
   await loadSavedConfig()
+
+  eventBus.on('userConfigSyncApplied', reloadConfigOnSync)
+  eventBus.on('editorConfigSyncApplied', reloadEditorConfigOnSync)
 
   // Add system theme change listener
   setupSystemThemeListener()
@@ -436,6 +453,8 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   eventBus.off('defaultLayoutChanged')
+  eventBus.off('userConfigSyncApplied', reloadConfigOnSync)
+  eventBus.off('editorConfigSyncApplied', reloadEditorConfigOnSync)
 
   // Remove system theme listener
   if (systemThemeListener) {

--- a/src/renderer/src/views/components/LeftTab/setting/privacy.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/privacy.vue
@@ -123,13 +123,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, computed } from 'vue'
 import { notification } from 'ant-design-vue'
-import { userConfigStore } from '@/services/userConfigStoreService'
+import { userConfigStore, remoteApplyGuard, getStoredUserConfigSnapshot, resolveDataSyncPreference } from '@/services/userConfigStoreService'
 import { dataSyncService } from '@/services/dataSyncService'
 import { useI18n } from 'vue-i18n'
 import { getPrivacyPolicyUrl } from '@/utils/edition'
 import { getUserInfo } from '@/utils/permission'
+import eventBus from '@/utils/eventBus'
 import type { TelemetrySetting } from '@shared/TelemetrySetting'
 
 const logger = createRendererLogger('settings.privacy')
@@ -236,35 +237,23 @@ const secretPatterns = computed(() => [
 
 const loadSavedConfig = async () => {
   try {
-    const rawConfigResult = await window.api.kvGet({ key: 'userConfig' })
-    let rawConfig: any = {}
-    if (rawConfigResult?.value) {
-      rawConfig = JSON.parse(rawConfigResult.value)
-    }
-
+    const rawConfig = await getStoredUserConfigSnapshot()
     const savedConfig = await userConfigStore.getConfig()
     if (savedConfig) {
-      let defaultDataSync: 'enabled' | 'disabled' = 'disabled'
+      const resolvedDataSync = resolveDataSyncPreference(rawConfig, isUserLoggedIn.value)
 
-      const persistedDataSync = (rawConfig.dataSync ?? savedConfig.dataSync) as 'enabled' | 'disabled' | undefined
-
-      if (persistedDataSync) {
-        defaultDataSync = persistedDataSync
-      } else if (isUserLoggedIn.value) {
-        defaultDataSync = 'enabled'
+      if (!rawConfig?.dataSync && isUserLoggedIn.value) {
         await userConfigStore.saveConfig({
           ...savedConfig,
           dataSync: 'enabled'
         } as any)
-      } else {
-        defaultDataSync = 'disabled'
       }
 
       userConfig.value = {
         ...userConfig.value,
         ...savedConfig,
         secretRedaction: (savedConfig.secretRedaction || 'enabled') as 'enabled' | 'disabled',
-        dataSync: defaultDataSync,
+        dataSync: resolvedDataSync,
         telemetry: ((savedConfig as any).telemetry || 'unset') as 'unset' | 'enabled' | 'disabled'
       } as any
     }
@@ -297,13 +286,23 @@ const saveConfig = async () => {
 watch(
   () => userConfig.value,
   async () => {
+    if (remoteApplyGuard.isApplying) return
     await saveConfig()
   },
   { deep: true }
 )
 
+const reloadConfigOnSync = async () => {
+  await loadSavedConfig()
+}
+
 onMounted(async () => {
   await loadSavedConfig()
+  eventBus.on('userConfigSyncApplied', reloadConfigOnSync)
+})
+
+onBeforeUnmount(() => {
+  eventBus.off('userConfigSyncApplied', reloadConfigOnSync)
 })
 
 const updateTelemetry = async () => {

--- a/src/renderer/src/views/components/LeftTab/setting/rules.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/rules.vue
@@ -130,6 +130,7 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { updateGlobalState, getGlobalState } from '@renderer/agent/storage/state'
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons-vue'
+import eventBus from '@/utils/eventBus'
 
 const logger = createRendererLogger('settings.rules')
 
@@ -143,10 +144,19 @@ interface Rule {
 // Load saved configuration when component is mounted
 onMounted(async () => {
   await loadUserRules()
+  // Listen for user_rules specific sync events
+  eventBus.on('userRulesSyncApplied', onRulesSyncApplied)
 })
 
-// Save configuration before component unmounts
-onBeforeUnmount(async () => {})
+// Clean up event listener before component unmounts
+onBeforeUnmount(async () => {
+  eventBus.off('userRulesSyncApplied', onRulesSyncApplied)
+})
+
+const onRulesSyncApplied = () => {
+  // userRulesSyncService already applied remote data to local storage, just reload UI
+  loadUserRules()
+}
 
 // Rules
 const userRules = ref<Rule[]>([])

--- a/src/renderer/src/views/components/LeftTab/setting/terminal.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/terminal.vue
@@ -359,7 +359,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import { notification } from 'ant-design-vue'
-import { userConfigStore } from '@/services/userConfigStoreService'
+import { userConfigStore, remoteApplyGuard } from '@/services/userConfigStoreService'
 import { useI18n } from 'vue-i18n'
 import eventBus from '@/utils/eventBus'
 
@@ -743,6 +743,7 @@ const saveConfig = async () => {
 watch(
   () => userConfig.value,
   async () => {
+    if (remoteApplyGuard.isApplying) return
     await saveConfig()
   },
   { deep: true }
@@ -755,16 +756,22 @@ watch(
   }
 )
 
+const reloadConfigOnSync = async () => {
+  await loadSavedConfig()
+}
+
 const handleOpenAddProxyConfigModal = () => {
   handleProxyConfigAdd()
 }
 
 onMounted(async () => {
   await loadSavedConfig()
+  eventBus.on('userConfigSyncApplied', reloadConfigOnSync)
   eventBus.on('openAddProxyConfigModal', handleOpenAddProxyConfigModal)
 })
 
 onBeforeUnmount(() => {
+  eventBus.off('userConfigSyncApplied', reloadConfigOnSync)
   eventBus.off('openAddProxyConfigModal', handleOpenAddProxyConfigModal)
 })
 </script>


### PR DESCRIPTION
- Implemented User Config Sync Service to manage terminal/UI preferences synchronization.
- Created User Rules Sync Service for syncing user-defined instruction rules.
- Updated editorConfig store to use KV store for loading and saving configurations.
- Enhanced event bus with async emit functionality for better event handling.
- Refactored components to listen for sync events and reload configurations accordingly.
- Improved test cases to mock new API methods and ensure proper functionality.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced cloud synchronization for user configurations, editor settings, keyboard shortcuts, AI preferences, and custom rules
  * Settings now automatically sync across sessions with built-in conflict resolution
  * Added atomic transaction support for reliable local data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->