### PR TITLE
fix: update cursorAccent colors in K8sConnect and sshConnect components for improved visibility

### DIFF
--- a/src/renderer/src/views/components/K8s/K8sConnect.vue
+++ b/src/renderer/src/views/components/K8s/K8sConnect.vue
@@ -106,7 +106,7 @@ const getTerminalTheme = (themeOverride?: string) => {
       background: hasBackground ? 'rgba(245, 245, 245, 0.82)' : '#f5f5f5',
       foreground: '#000000',
       cursor: '#000000',
-      cursorAccent: '#000000',
+      cursorAccent: '#f5f5f5',
       selectionBackground: '#add6ff80',
       selectionInactiveBackground: '#add6ff5a'
     }
@@ -115,7 +115,7 @@ const getTerminalTheme = (themeOverride?: string) => {
     background: hasBackground ? 'transparent' : '#141414',
     foreground: '#e0e0e0',
     cursor: '#e0e0e0',
-    cursorAccent: '#e0e0e0',
+    cursorAccent: '#141414',
     selectionBackground: 'rgba(255, 255, 255, 0.3)',
     selectionInactiveBackground: 'rgba(255, 255, 255, 0.2)'
   }

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -503,7 +503,7 @@ onMounted(async () => {
               background: config.background?.image ? 'rgba(245, 245, 245, 0.82)' : '#f5f5f5',
               foreground: '#000000',
               cursor: '#000000',
-              cursorAccent: '#000000',
+              cursorAccent: '#f5f5f5',
               selectionBackground: '#add6ff80',
               selectionInactiveBackground: '#add6ff5a'
             }
@@ -511,7 +511,7 @@ onMounted(async () => {
               background: config.background?.image ? 'transparent' : '#141414',
               foreground: '#e0e0e0',
               cursor: '#e0e0e0',
-              cursorAccent: '#e0e0e0',
+              cursorAccent: '#141414',
               selectionBackground: 'rgba(255, 255, 255, 0.3)',
               selectionInactiveBackground: 'rgba(255, 255, 255, 0.2)'
             }
@@ -777,7 +777,7 @@ onMounted(async () => {
               background: config.background?.image ? 'rgba(245, 245, 245, 0.82)' : '#f5f5f5',
               foreground: '#000000',
               cursor: '#000000',
-              cursorAccent: '#000000',
+              cursorAccent: '#f5f5f5',
               selectionBackground: '#add6ff80',
               selectionInactiveBackground: '#add6ff5a'
             }
@@ -785,7 +785,7 @@ onMounted(async () => {
               background: configStore.getUserConfig.background.image ? 'transparent' : '#141414',
               foreground: '#e0e0e0',
               cursor: '#e0e0e0',
-              cursorAccent: '#e0e0e0',
+              cursorAccent: '#141414',
               selectionBackground: 'rgba(255, 255, 255, 0.3)',
               selectionInactiveBackground: 'rgba(255, 255, 255, 0.2)'
             }


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #1848 

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminal cursor accent colors in SSH and Kubernetes connection components to align with theme backgrounds, improving visual consistency and terminal visibility across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->