### PR TITLE
fix(aitab): Fix local files  attachments into chat

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,7 @@ import { getActualTheme, loadUserTheme } from './themeManager'
 import { getLoginBaseUrl, getEdition, getProtocolPrefix, getProtocolName } from './config/edition'
 import { TelemetrySetting } from '@shared/TelemetrySetting'
 import { registerKnowledgeBaseHandlers } from './services/knowledgebase'
+import { registerStageChatAttachmentHandlers } from './services/agent/stageChatAttachment'
 import { startKbSync, stopKbSync } from './services/knowledgebase/sync'
 import { setupInteractionIpcHandlers } from './agent/services/interaction-detector/ipc-handlers'
 import type { WebviewMessage } from '@shared/WebviewMessage'
@@ -957,6 +958,7 @@ function updateNavigationState(): void {
 function setupIPC(): void {
   // KnowledgeBase module (local file-based KB) IPC handlers
   registerKnowledgeBaseHandlers()
+  registerStageChatAttachmentHandlers()
 
   ipcMain.handle('init-user-database', async (event, { uid }) => {
     try {

--- a/src/main/services/agent/__tests__/stageChatAttachment.test.ts
+++ b/src/main/services/agent/__tests__/stageChatAttachment.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import path from 'path'
+
+vi.mock('../../../agent/core/offload', () => ({
+  getOffloadDir: vi.fn((taskId: string) => path.join('/offload', taskId))
+}))
+
+vi.mock('../../knowledgebase', () => ({
+  getKnowledgeBaseRoot: vi.fn(() => path.join('/data', 'knowledgebase'))
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn(),
+  mkdir: vi.fn(),
+  copyFile: vi.fn()
+}))
+
+import * as fs from 'fs/promises'
+import { stageChatAttachment, MAX_CHAT_ATTACHMENT_BYTES } from '../stageChatAttachment'
+
+describe('stageChatAttachment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(process, 'cwd').mockReturnValue(path.resolve('/workspace/proj'))
+  })
+
+  it('returns as_is when file is under workspace', async () => {
+    const underWs = path.join(process.cwd(), 'src', 'a.md')
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 10 } as any)
+
+    const r = await stageChatAttachment('t1', underWs)
+
+    expect(r).toEqual({ mode: 'as_is', refPath: path.resolve(underWs) })
+    expect(fs.copyFile).not.toHaveBeenCalled()
+  })
+
+  it('copies to offload when outside workspace', async () => {
+    const outside = '/etc/secret.md'
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 5 } as any)
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.copyFile).mockResolvedValue(undefined)
+
+    const r = await stageChatAttachment('t1', outside)
+
+    expect(r.mode).toBe('offload')
+    expect(r.refPath).toMatch(/^offload\/user-uploads\/[0-9a-f-]+-secret\.md$/i)
+    expect(fs.copyFile).toHaveBeenCalledTimes(1)
+    const [, dest] = vi.mocked(fs.copyFile).mock.calls[0]
+    expect(String(dest)).toContain(path.join('offload', 't1', 'user-uploads'))
+  })
+
+  it('rejects oversized files', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: MAX_CHAT_ATTACHMENT_BYTES + 1 } as any)
+
+    await expect(stageChatAttachment('t1', '/x.txt')).rejects.toThrow(/exceeds maximum size/)
+  })
+
+  it('rejects empty taskId', async () => {
+    await expect(stageChatAttachment('', '/x.txt')).rejects.toThrow(/taskId is required/)
+  })
+})

--- a/src/main/services/agent/stageChatAttachment.ts
+++ b/src/main/services/agent/stageChatAttachment.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2025-present, chaterm.ai  All rights reserved.
+// Stages user-picked files for agent read_file: allowed paths stay as-is; others copy into task offload.
+
+import path from 'path'
+import { randomUUID } from 'crypto'
+import * as fs from 'fs/promises'
+import { ipcMain } from 'electron'
+import { getOffloadDir } from '../../agent/core/offload'
+import { getKnowledgeBaseRoot } from '../knowledgebase'
+import { createLogger } from '../logging'
+
+const logger = createLogger('stageChatAttachment')
+
+/** Match AiTab upload limit in renderer */
+export const MAX_CHAT_ATTACHMENT_BYTES = 1024 * 1024
+
+export type StageChatAttachmentResult = { mode: 'as_is'; refPath: string } | { mode: 'offload'; refPath: string }
+
+function isInsideDir(resolvedFile: string, resolvedDir: string): boolean {
+  const normFile = path.resolve(resolvedFile)
+  const normDir = path.resolve(resolvedDir)
+  if (normFile === normDir) return true
+  return normFile.startsWith(normDir + path.sep)
+}
+
+/** Align with Task.handleReadFileToolUse heuristic for KB paths */
+function isInKnowledgeBaseSegment(resolvedPath: string): boolean {
+  return resolvedPath.includes(`${path.sep}knowledgebase${path.sep}`)
+}
+
+function isAllowedWithoutCopy(taskId: string, srcResolved: string): boolean {
+  const workspace = process.cwd()
+  const offloadDir = getOffloadDir(taskId)
+  const kbRoot = getKnowledgeBaseRoot()
+
+  if (isInsideDir(srcResolved, workspace)) return true
+  if (isInsideDir(srcResolved, offloadDir)) return true
+  if (isInsideDir(srcResolved, kbRoot)) return true
+  if (isInKnowledgeBaseSegment(srcResolved)) return true
+  return false
+}
+
+/**
+ * Copy file into task offload when outside allowed read roots; otherwise return absolute path for chip.
+ */
+export async function stageChatAttachment(taskId: string, srcAbsPath: string): Promise<StageChatAttachmentResult> {
+  const trimmed = (srcAbsPath || '').trim()
+  if (!taskId?.trim()) {
+    throw new Error('taskId is required')
+  }
+  if (!trimmed) {
+    throw new Error('srcAbsPath is required')
+  }
+
+  const srcResolved = path.resolve(trimmed)
+  let stat
+  try {
+    stat = await fs.stat(srcResolved)
+  } catch {
+    throw new Error('Source file does not exist or is not accessible')
+  }
+  if (!stat.isFile()) {
+    throw new Error('Source path is not a file')
+  }
+  if (stat.size > MAX_CHAT_ATTACHMENT_BYTES) {
+    throw new Error(`File exceeds maximum size (${MAX_CHAT_ATTACHMENT_BYTES} bytes)`)
+  }
+
+  if (isAllowedWithoutCopy(taskId, srcResolved)) {
+    return { mode: 'as_is', refPath: srcResolved }
+  }
+
+  const offloadDir = path.resolve(getOffloadDir(taskId))
+  const uploadDir = path.join(offloadDir, 'user-uploads')
+  await fs.mkdir(uploadDir, { recursive: true })
+
+  const base = path.basename(srcResolved) || 'file'
+  const destName = `${randomUUID()}-${base}`
+  const destAbs = path.join(uploadDir, destName)
+  const resolvedDest = path.resolve(destAbs)
+
+  if (resolvedDest !== uploadDir && !resolvedDest.startsWith(uploadDir + path.sep)) {
+    logger.error('[stageChatAttachment] Refusing unsafe destination', { resolvedDest, uploadDir })
+    throw new Error('Invalid destination path')
+  }
+
+  await fs.copyFile(srcResolved, resolvedDest)
+
+  const refPath = `offload/user-uploads/${destName}`
+  logger.info('[stageChatAttachment] Copied to offload', { taskId, refPath })
+  return { mode: 'offload', refPath }
+}
+
+export function registerStageChatAttachmentHandlers(): void {
+  ipcMain.handle(
+    'agent:stage-chat-attachment',
+    async (_evt, payload: { taskId?: string; srcAbsPath?: string }): Promise<StageChatAttachmentResult> => {
+      const taskId = payload?.taskId ?? ''
+      const srcAbsPath = payload?.srcAbsPath ?? ''
+      return await stageChatAttachment(taskId, srcAbsPath)
+    }
+  )
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -355,6 +355,11 @@ interface ApiType {
   }) => Promise<{ canceled: boolean; filePaths: string[] } | undefined>
   getHomePath: () => Promise<string>
 
+  stageChatAttachment: (payload: {
+    taskId: string
+    srcAbsPath: string
+  }) => Promise<{ mode: 'as_is'; refPath: string } | { mode: 'offload'; refPath: string }>
+
   kbCheckPath: (absPath: string) => Promise<{ exists: boolean; isDirectory: boolean; isFile: boolean }>
   kbEnsureRoot: () => Promise<{ success: boolean }>
   kbGetRoot: () => Promise<{ root: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -928,6 +928,8 @@ const api = {
   checkUpdate: () => ipcRenderer.invoke('update:checkUpdate'),
   download: () => ipcRenderer.invoke('update:download'),
   showOpenDialog: (options) => ipcRenderer.invoke('dialog:openFile', options),
+  stageChatAttachment: (payload: { taskId: string; srcAbsPath: string }) =>
+    ipcRenderer.invoke('agent:stage-chat-attachment', payload) as Promise<{ mode: 'as_is'; refPath: string } | { mode: 'offload'; refPath: string }>,
   getHomePath: () => ipcRenderer.invoke('app:getHomePath'),
   autoUpdate: (update) => {
     ipcRenderer.on('update:autoUpdate', (_event, params) => update(params))

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -917,6 +917,8 @@ export default {
     imageProcessError: 'فشل معالجة الصورة, الرجاء المحاولة مرة أخرى',
     fileReadFailed: 'فشل قراءة الملف',
     fileReadErrorDesc: 'لا يمكن قراءة محتوى الملف, الرجاء التحقق من تنسيق الملف',
+    chatAttachmentNeedSession: 'يرجى فتح أو إنشاء تبويب دردشة أولاً',
+    chatAttachmentStageFailed: 'تعذر إرفاق الملف',
     fileContent: 'محتوى الملف ({fileName})',
     sendContentError: 'فشل إرسال المحتوى',
     sendContentEmpty: 'محتوى الإرسال فارغ, الرجاء إدخال محتوى',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -945,6 +945,8 @@ export default {
     imageProcessError: 'Bildverarbeitung fehlgeschlagen, bitte erneut versuchen',
     fileReadFailed: 'Datei lesen fehlgeschlagen',
     fileReadErrorDesc: 'Dateiinhalt konnte nicht gelesen werden, bitte überprüfen Sie, ob das Dateiformat korrekt ist',
+    chatAttachmentNeedSession: 'Bitte öffnen oder erstellen Sie zuerst einen Chat-Tab',
+    chatAttachmentStageFailed: 'Datei konnte nicht angehängt werden',
     fileContent: 'Dateiinhalt ({fileName})',
     sendContentError: 'Inhalt senden fehlgeschlagen',
     sendContentEmpty: 'Inhalt ist leer, bitte geben Sie Inhalt ein',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -940,6 +940,8 @@ export default {
     imageProcessError: 'Image processing failed, please try again',
     fileReadFailed: 'File Read Failed',
     fileReadErrorDesc: 'Unable to read file content, please check if the file format is correct',
+    chatAttachmentNeedSession: 'Please open or create a chat tab first',
+    chatAttachmentStageFailed: 'Could not attach the file',
     fileContent: 'File Content ({fileName})',
     sendContentError: 'Send Content Error',
     sendContentEmpty: 'Send content is empty, please enter content',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -950,6 +950,8 @@ export default {
     imageProcessError: "Échec du traitement de l'image, veuillez réessayer",
     fileReadFailed: 'Lecture du fichier échouée',
     fileReadErrorDesc: 'Impossible de lire le contenu du fichier, veuillez vérifier si le format du fichier est correct',
+    chatAttachmentNeedSession: 'Veuillez d’abord ouvrir ou créer un onglet de chat',
+    chatAttachmentStageFailed: 'Impossible de joindre le fichier',
     fileContent: 'Contenu du fichier ({fileName})',
     sendContentError: 'Erreur de envoi de contenu',
     sendContentEmpty: 'Le contenu à envoyer est vide, veuillez entrer du contenu',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -944,6 +944,8 @@ export default {
     imageProcessError: 'Elaborazione immagine fallita, riprova',
     fileReadFailed: 'Lettura file fallita',
     fileReadErrorDesc: 'Impossibile leggere il contenuto del file, per favore controlla se il formato del file è corretto',
+    chatAttachmentNeedSession: 'Apri o crea prima una scheda chat',
+    chatAttachmentStageFailed: 'Impossibile allegare il file',
     fileContent: 'Contenuto file ({fileName})',
     sendContentError: 'Invio contenuto fallito',
     sendContentEmpty: 'Contenuto vuoto, per favore inserisci contenuto',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -935,6 +935,8 @@ export default {
     imageProcessError: '画像処理に失敗しました、再試行してください',
     fileReadFailed: 'ファイルの読み込みに失敗しました',
     fileReadErrorDesc: 'ファイル内容の読み込みに失敗しました、ファイルの形式を確認してください',
+    chatAttachmentNeedSession: '先にチャットタブを開くか作成してください',
+    chatAttachmentStageFailed: 'ファイルを添付できませんでした',
     fileContent: 'ファイル内容 ({fileName})',
     sendContentError: 'コンテンツの送信に失敗しました',
     sendContentEmpty: 'コンテンツが空です、コンテンツを入力してください',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -931,6 +931,8 @@ export default {
     imageProcessError: '이미지 처리에 실패했습니다, 다시 시도해주세요',
     fileReadFailed: '파일 읽기 실패',
     fileReadErrorDesc: '파일 내용을 읽을 수 없습니다, 파일 형식을 확인해주세요',
+    chatAttachmentNeedSession: '먼저 채팅 탭을 열거나 만드세요',
+    chatAttachmentStageFailed: '파일을 첨부할 수 없습니다',
     fileContent: '파일 내용 ({fileName})',
     sendContentError: '콘텐츠 전송 오류',
     sendContentEmpty: '콘텐츠가 비어있습니다, 콘텐츠를 입력해주세요',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -943,6 +943,8 @@ export default {
     imageProcessError: 'Falha no processamento da imagem, tente novamente',
     fileReadFailed: 'Falha ao ler arquivo',
     fileReadErrorDesc: 'Não foi possível ler o conteúdo do arquivo, por favor, verifique se o formato do arquivo é correto',
+    chatAttachmentNeedSession: 'Abra ou crie um separador de chat primeiro',
+    chatAttachmentStageFailed: 'Não foi possível anexar o ficheiro',
     fileContent: 'Conteúdo do arquivo ({fileName})',
     sendContentError: 'Erro ao enviar conteúdo',
     sendContentEmpty: 'O conteúdo a ser enviado está vazio, por favor, insira o conteúdo',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -942,6 +942,8 @@ export default {
     imageProcessError: 'Ошибка обработки изображения, попробуйте снова',
     fileReadFailed: 'Ошибка чтения файла',
     fileReadErrorDesc: 'Не удалось прочитать содержимое файла, пожалуйста, проверьте формат файла',
+    chatAttachmentNeedSession: 'Сначала откройте или создайте вкладку чата',
+    chatAttachmentStageFailed: 'Не удалось прикрепить файл',
     fileContent: 'Содержимое файла ({fileName})',
     sendContentError: 'Ошибка отправки содержимого',
     sendContentEmpty: 'Содержимое пусто, пожалуйста, введите содержимое',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -926,6 +926,8 @@ export default {
     imageProcessError: '图片处理失败，请重试',
     fileReadFailed: '文件读取失败',
     fileReadErrorDesc: '无法读取文件内容，请检查文件格式是否正确',
+    chatAttachmentNeedSession: '请先打开或创建一个聊天标签',
+    chatAttachmentStageFailed: '无法添加该文件',
     fileContent: '文件内容 ({fileName})',
     sendContentError: '发送内容错误',
     sendContentEmpty: '发送内容为空，请输入内容',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -927,6 +927,8 @@ export default {
     imageProcessError: '圖片處理失敗，請重試',
     fileReadFailed: '檔案讀取失敗',
     fileReadErrorDesc: '無法讀取檔案內容，請檢查檔案格式是否正確',
+    chatAttachmentNeedSession: '請先開啟或建立一個聊天分頁',
+    chatAttachmentStageFailed: '無法加入該檔案',
     fileContent: '檔案內容 ({fileName})',
     sendContentError: '發送內容錯誤',
     sendContentEmpty: '發送內容為空，請輸入內容',

--- a/src/renderer/src/views/components/AiTab/components/InputSendContainer.vue
+++ b/src/renderer/src/views/components/AiTab/components/InputSendContainer.vue
@@ -213,13 +213,6 @@
     </div>
   </div>
   <input
-    ref="fileInputRef"
-    type="file"
-    accept=".txt,.md,.js,.ts,.py,.java,.cpp,.c,.html,.css,.json,.xml,.yaml,.yml,.sql,.sh,.bat,.ps1,.log,.csv,.tsv"
-    style="display: none"
-    @change="handleFileSelected"
-  />
-  <input
     ref="imageInputRef"
     type="file"
     accept="image/jpeg,image/png,image/gif,image/webp"
@@ -283,6 +276,7 @@ const { t } = useI18n()
 const {
   chatTextareaRef,
   currentTab,
+  currentChatId,
   chatTypeValue,
   chatAiModelValue,
   chatContainerScrollSignal,
@@ -659,19 +653,21 @@ const lockedModelTooltip = computed(() => {
 
 // Use user interactions composable
 const {
-  fileInputRef,
   imageInputRef,
   autoSendAfterVoice,
   handleTranscriptionComplete,
   handleTranscriptionError,
   handleFileUpload,
-  handleFileSelected,
   handleImageUpload,
   handleImageSelected,
   hasClipboardImages,
   handlePasteImage
-} = useUserInteractions({ sendMessage: props.sendMessage, insertChipAtCursor, insertImagePart: insertImageAtCursor })
-void fileInputRef
+} = useUserInteractions({
+  sendMessage: props.sendMessage,
+  insertChipAtCursor,
+  insertImagePart: insertImageAtCursor,
+  getTaskId: () => currentChatId.value
+})
 void imageInputRef
 
 const focus = () => {

--- a/src/renderer/src/views/components/AiTab/composables/__tests__/useUserInteractions.test.ts
+++ b/src/renderer/src/views/components/AiTab/composables/__tests__/useUserInteractions.test.ts
@@ -41,6 +41,8 @@ describe('useUserInteractions', () => {
   let chatInputParts: ReturnType<typeof ref<Array<{ type: string; text: string }>>>
 
   let mockInsertChipAtCursor: any
+  let mockShowOpenDialog: ReturnType<typeof vi.fn>
+  let mockStageChatAttachment: ReturnType<typeof vi.fn>
 
   const getText = (parts: Array<{ type: string; text: string }>) => {
     return parts
@@ -73,6 +75,13 @@ describe('useUserInteractions', () => {
       chatInputParts,
       appendTextToInputParts: mockAppendTextToInputParts
     } as any)
+
+    mockShowOpenDialog = vi.fn()
+    mockStageChatAttachment = vi.fn()
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      showOpenDialog: mockShowOpenDialog,
+      stageChatAttachment: mockStageChatAttachment
+    }
   })
 
   describe('handleTranscriptionComplete', () => {
@@ -131,86 +140,79 @@ describe('useUserInteractions', () => {
   })
 
   describe('handleFileUpload', () => {
-    it('should trigger file input click', () => {
-      const { handleFileUpload, fileInputRef } = useUserInteractions({ sendMessage: mockSendMessage })
-
-      const mockClick = vi.fn()
-      fileInputRef.value = { click: mockClick } as any
-
-      handleFileUpload()
-
-      expect(mockClick).toHaveBeenCalled()
-    })
-
-    it('should not throw when file input is not set', () => {
-      const { handleFileUpload } = useUserInteractions({ sendMessage: mockSendMessage })
-
-      expect(() => handleFileUpload()).not.toThrow()
-    })
-  })
-
-  describe('handleFileSelected', () => {
-    it('should handle no file selected', async () => {
-      const { handleFileSelected } = useUserInteractions({
-        sendMessage: mockSendMessage,
-        insertChipAtCursor: mockInsertChipAtCursor
-      })
-
-      const mockEvent = {
-        target: {
-          files: []
-        }
-      } as any
-
-      await handleFileSelected(mockEvent)
-
-      expect(getText(chatInputParts.value ?? [])).toBe('')
-      expect(mockInsertChipAtCursor).not.toHaveBeenCalled()
-    })
-
-    it('should warn when file is too large', async () => {
+    it('should warn when no task id', async () => {
       const { notification } = await import('ant-design-vue')
-      const { handleFileSelected } = useUserInteractions({
+      const { handleFileUpload } = useUserInteractions({
         sendMessage: mockSendMessage,
-        insertChipAtCursor: mockInsertChipAtCursor
+        insertChipAtCursor: mockInsertChipAtCursor,
+        getTaskId: () => undefined
       })
 
-      const largeFile = new File(['x'.repeat(2 * 1024 * 1024)], 'large.txt', { type: 'text/plain' })
-      const mockEvent = {
-        target: {
-          files: [largeFile],
-          value: 'test.txt'
-        }
-      } as any
-
-      await handleFileSelected(mockEvent)
+      await handleFileUpload()
 
       expect(notification.warning).toHaveBeenCalled()
-      expect(getText(chatInputParts.value ?? [])).toBe('')
+      expect(mockShowOpenDialog).not.toHaveBeenCalled()
       expect(mockInsertChipAtCursor).not.toHaveBeenCalled()
     })
 
-    it('should insert doc chip for selected file', async () => {
-      const { handleFileSelected } = useUserInteractions({
+    it('should do nothing when dialog canceled', async () => {
+      const { handleFileUpload } = useUserInteractions({
         sendMessage: mockSendMessage,
-        insertChipAtCursor: mockInsertChipAtCursor
+        insertChipAtCursor: mockInsertChipAtCursor,
+        getTaskId: () => 'task-1'
       })
+      mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
 
-      const file = Object.assign(new File(['Hello'], 'test.txt', { type: 'text/plain' }), {
-        path: '/Users/demo/test.txt'
+      await handleFileUpload()
+
+      expect(mockShowOpenDialog).toHaveBeenCalled()
+      expect(mockStageChatAttachment).not.toHaveBeenCalled()
+      expect(mockInsertChipAtCursor).not.toHaveBeenCalled()
+    })
+
+    it('should insert chip with absolute path when staged as_is', async () => {
+      const { handleFileUpload } = useUserInteractions({
+        sendMessage: mockSendMessage,
+        insertChipAtCursor: mockInsertChipAtCursor,
+        getTaskId: () => 'task-1'
       })
+      mockShowOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/Users/demo/notes.md'] })
+      mockStageChatAttachment.mockResolvedValue({ mode: 'as_is', refPath: '/Users/demo/notes.md' })
 
-      const mockEvent = {
-        target: {
-          files: [file],
-          value: 'test.txt'
-        }
-      } as any
+      await handleFileUpload()
 
-      await handleFileSelected(mockEvent)
+      expect(mockStageChatAttachment).toHaveBeenCalledWith({ taskId: 'task-1', srcAbsPath: '/Users/demo/notes.md' })
+      expect(mockInsertChipAtCursor).toHaveBeenCalledWith('doc', { absPath: '/Users/demo/notes.md', name: 'notes.md', type: 'file' }, 'notes.md')
+    })
 
-      expect(mockInsertChipAtCursor).toHaveBeenCalledWith('doc', { absPath: '/Users/demo/test.txt', name: 'test.txt', type: 'file' }, 'test.txt')
-      expect(mockEvent.target.value).toBe('')
+    it('should insert chip with offload ref when staged to offload', async () => {
+      const { handleFileUpload } = useUserInteractions({
+        sendMessage: mockSendMessage,
+        insertChipAtCursor: mockInsertChipAtCursor,
+        getTaskId: () => 'task-1'
+      })
+      mockShowOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/outside/x.md'] })
+      mockStageChatAttachment.mockResolvedValue({ mode: 'offload', refPath: 'offload/user-uploads/uuid-x.md' })
+
+      await handleFileUpload()
+
+      expect(mockInsertChipAtCursor).toHaveBeenCalledWith('doc', { absPath: 'offload/user-uploads/uuid-x.md', name: 'x.md', type: 'file' }, 'x.md')
+    })
+
+    it('should show error when staging fails', async () => {
+      const { notification } = await import('ant-design-vue')
+      const { handleFileUpload } = useUserInteractions({
+        sendMessage: mockSendMessage,
+        insertChipAtCursor: mockInsertChipAtCursor,
+        getTaskId: () => 'task-1'
+      })
+      mockShowOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/bad/path'] })
+      mockStageChatAttachment.mockRejectedValue(new Error('boom'))
+
+      await handleFileUpload()
+
+      expect(notification.error).toHaveBeenCalled()
+      expect(mockInsertChipAtCursor).not.toHaveBeenCalled()
     })
   })
 
@@ -305,11 +307,11 @@ describe('useUserInteractions', () => {
   })
 
   describe('refs', () => {
-    it('should provide fileInputRef', () => {
-      const { fileInputRef } = useUserInteractions({ sendMessage: mockSendMessage })
+    it('should provide imageInputRef', () => {
+      const { imageInputRef } = useUserInteractions({ sendMessage: mockSendMessage })
 
-      expect(fileInputRef).toBeDefined()
-      expect(fileInputRef.value).toBeUndefined()
+      expect(imageInputRef).toBeDefined()
+      expect(imageInputRef.value).toBeUndefined()
     })
 
     it('should provide autoSendAfterVoice', () => {

--- a/src/renderer/src/views/components/AiTab/composables/useUserInteractions.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useUserInteractions.ts
@@ -14,6 +14,36 @@ type SupportedImageType = (typeof SUPPORTED_IMAGE_TYPES)[number]
 // Maximum image size: 5MB
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024
 
+/** Match former <input accept> list — used as Electron open dialog filter */
+const CHAT_ATTACHMENT_FILTERS = [
+  {
+    name: 'Text',
+    extensions: [
+      'txt',
+      'md',
+      'js',
+      'ts',
+      'py',
+      'java',
+      'cpp',
+      'c',
+      'html',
+      'css',
+      'json',
+      'xml',
+      'yaml',
+      'yml',
+      'sql',
+      'sh',
+      'bat',
+      'ps1',
+      'log',
+      'csv',
+      'tsv'
+    ]
+  }
+]
+
 /**
  * Composable for user interaction events
  * Handles file upload, voice input, keyboard events and other user interactions
@@ -22,14 +52,15 @@ export interface UseUserInteractionsOptions {
   sendMessage: (sendType: string) => Promise<any>
   insertChipAtCursor?: (chipType: 'doc' | 'chat', ref: DocOption | ChatOption, label: string) => void
   insertImagePart?: (imagePart: ImageContentPart) => void
+  /** Current chat / task id for staging attachments into offload when needed */
+  getTaskId?: () => string | undefined
 }
 
 export function useUserInteractions(options: UseUserInteractionsOptions) {
   const { t } = i18n.global
   const { chatInputParts, appendTextToInputParts } = useSessionState()
-  const { sendMessage, insertChipAtCursor, insertImagePart } = options
+  const { sendMessage, insertChipAtCursor, insertImagePart, getTaskId } = options
 
-  const fileInputRef = ref<HTMLInputElement>()
   const imageInputRef = ref<HTMLInputElement>()
   const autoSendAfterVoice = ref(false)
   const currentEditingId = ref<string | null>(null)
@@ -50,43 +81,39 @@ export function useUserInteractions(options: UseUserInteractionsOptions) {
     logger.error('Voice transcription error', { error: error })
   }
 
-  const handleFileUpload = () => {
-    fileInputRef.value?.click()
-  }
+  const handleFileUpload = async () => {
+    if (!insertChipAtCursor) return
 
-  const handleFileSelected = async (event: Event) => {
-    const target = event.target as HTMLInputElement
-    const file = target.files?.[0]
-
-    if (!file) return
-
-    try {
-      if (file.size > 1024 * 1024) {
-        notification.warning({
-          message: t('ai.fileTooLarge'),
-          description: t('ai.fileTooLargeDesc'),
-          duration: 3
-        })
-        return
-      }
-
-      const fileName = file.name
-      const filePath = (file as File & { path?: string }).path || fileName
-
-      if (insertChipAtCursor) {
-        insertChipAtCursor('doc', { absPath: filePath, name: fileName, type: 'file' }, fileName)
-      }
-    } catch (error) {
-      logger.error('File read error', { error: error })
-      notification.error({
-        message: t('ai.fileReadFailed'),
-        description: t('ai.fileReadErrorDesc'),
+    const taskId = getTaskId?.()?.trim()
+    if (!taskId) {
+      notification.warning({
+        message: t('ai.chatAttachmentNeedSession'),
         duration: 3
       })
-    } finally {
-      if (target) {
-        target.value = ''
-      }
+      return
+    }
+
+    try {
+      const result = await window.api.showOpenDialog({
+        properties: ['openFile'],
+        filters: CHAT_ATTACHMENT_FILTERS
+      })
+      if (!result || result.canceled || !result.filePaths?.length) return
+
+      const srcAbsPath = result.filePaths[0]
+      const staged = await window.api.stageChatAttachment({ taskId, srcAbsPath })
+      const refPath = staged.refPath
+      const displayName = srcAbsPath.split(/[/\\]/).pop() || refPath.split(/[/\\]/).pop() || 'file'
+
+      insertChipAtCursor('doc', { absPath: refPath, name: displayName, type: 'file' }, displayName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Chat file attachment error', { error })
+      notification.error({
+        message: t('ai.chatAttachmentStageFailed'),
+        description: message || t('ai.fileReadErrorDesc'),
+        duration: 4
+      })
     }
   }
 
@@ -218,14 +245,12 @@ export function useUserInteractions(options: UseUserInteractionsOptions) {
   }
 
   return {
-    fileInputRef,
     imageInputRef,
     autoSendAfterVoice,
     currentEditingId,
     handleTranscriptionComplete,
     handleTranscriptionError,
     handleFileUpload,
-    handleFileSelected,
     handleImageUpload,
     handleImageSelected,
     hasClipboardImages,


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat file attachment capability with file upload dialog interface
  * Implemented automatic file staging and validation with 1MB size limit
  * Enhanced file handling to support both workspace and external files
  * Added multi-language support for attachment-related user messages across 12 languages

* **Tests**
  * Added comprehensive test suite for file attachment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->