### PR TITLE
feat: Add automatic reconnection for SSH connections when disconnected

### DIFF
--- a/src/main/ssh/__tests__/sshHandle.reconnect.test.ts
+++ b/src/main/ssh/__tests__/sshHandle.reconnect.test.ts
@@ -1,0 +1,273 @@
+import { EventEmitter } from 'events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type IpcHandler = (event: any, payload?: any) => any
+
+class FakeShellStream extends EventEmitter {
+  public stderr = new EventEmitter()
+
+  end() {
+    this.emit('close')
+  }
+
+  write(_data: unknown, cb?: (err?: Error) => void) {
+    cb?.()
+  }
+}
+
+class FakeClient extends EventEmitter {
+  public _sock = { destroyed: false }
+  public currentShellStream: FakeShellStream | null = null
+  public lastConnectConfig: Record<string, unknown> | null = null
+
+  connect(config: Record<string, unknown>) {
+    this.lastConnectConfig = config
+    this.emit('ready')
+  }
+
+  shell(_opts: Record<string, unknown>, cb: (err: Error | null, stream: FakeShellStream) => void) {
+    const stream = new FakeShellStream()
+    this.currentShellStream = stream
+    cb(null, stream)
+  }
+
+  exec(_cmd: string, _opts: any, cbArg?: any) {
+    const cb = typeof _opts === 'function' ? _opts : cbArg
+    if (typeof cb !== 'function') return
+    const stream = new FakeShellStream()
+    cb(null, stream)
+    stream.emit('close', 0)
+  }
+
+  end() {
+    this._sock.destroyed = true
+    this.emit('close')
+  }
+}
+
+const baseConnectionInfo = (id: string) => ({
+  id,
+  host: '127.0.0.1',
+  port: 22,
+  username: 'tester',
+  password: 'secret',
+  sshType: 'ssh',
+  disablePostConnectProbe: true
+})
+
+const setupHandlers = async () => {
+  vi.resetModules()
+
+  const handlers = new Map<string, IpcHandler>()
+  const createdClients: FakeClient[] = []
+
+  const ipcMainMock = {
+    handle: vi.fn((channel: string, handler: IpcHandler) => {
+      handlers.set(channel, handler)
+    }),
+    on: vi.fn(),
+    once: vi.fn(),
+    removeAllListeners: vi.fn()
+  }
+
+  const appMock = { getAppPath: () => process.cwd() }
+
+  vi.doMock('electron', () => ({
+    app: appMock,
+    ipcMain: ipcMainMock,
+    BrowserWindow: {
+      fromWebContents: vi.fn(() => ({}))
+    },
+    dialog: {
+      showOpenDialog: vi.fn(),
+      showSaveDialog: vi.fn()
+    },
+    default: {
+      app: appMock,
+      ipcMain: ipcMainMock
+    }
+  }))
+
+  const ClientMock = vi.fn(function MockClient(this: unknown) {
+    const client = new FakeClient()
+    createdClients.push(client)
+    return client
+  })
+
+  vi.doMock('ssh2', () => ({
+    Client: ClientMock
+  }))
+
+  vi.doMock('../proxy', () => ({
+    createProxySocket: vi.fn()
+  }))
+
+  vi.doMock('../jumpserver/errorUtils', () => ({
+    buildErrorResponse: vi.fn((error: unknown) => ({
+      status: 'error',
+      message: error instanceof Error ? error.message : String(error)
+    }))
+  }))
+
+  vi.doMock('../jumpserverHandle', () => ({
+    jumpserverConnections: new Map(),
+    handleJumpServerConnection: vi.fn(),
+    jumpserverShellStreams: new Map(),
+    jumpserverExecStreams: new Map(),
+    jumpserverMarkedCommands: new Map(),
+    jumpserverConnectionStatus: new Map(),
+    jumpserverLastCommand: new Map(),
+    createJumpServerExecStream: vi.fn(),
+    executeCommandOnJumpServerExec: vi.fn(),
+    jumpserverSessionPids: new Map()
+  }))
+
+  vi.doMock('../algorithms', () => ({
+    getAlgorithmsByAssetType: vi.fn(() => undefined)
+  }))
+
+  vi.doMock('../bastionPlugin', () => ({
+    connectBastionByType: vi.fn(async () => null),
+    shellBastionSession: vi.fn(async () => null),
+    resizeBastionSession: vi.fn(async () => null),
+    writeBastionSession: vi.fn(async () => null),
+    disconnectBastionSession: vi.fn(async () => null)
+  }))
+
+  vi.doMock('../postConnectProbePolicy', () => ({
+    shouldSkipPostConnectProbe: vi.fn(() => true)
+  }))
+
+  vi.doMock('../sftpTransfer', () => ({
+    sftpConnectionInfoMap: new Map()
+  }))
+
+  vi.doMock('../ssh-agent/ChatermSSHAgent', () => ({
+    SSHAgentManager: {
+      getInstance: vi.fn(() => ({
+        getAgent: vi.fn(),
+        enableAgent: vi.fn(),
+        addKey: vi.fn(),
+        removeKey: vi.fn(),
+        listKeys: vi.fn(() => [])
+      }))
+    }
+  }))
+
+  vi.doMock('@logging/index', () => ({
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn()
+    }))
+  }))
+
+  const sshHandle = await import('../sshHandle')
+  sshHandle.registerSSHHandlers()
+
+  return {
+    handlers,
+    createdClients
+  }
+}
+
+const getCloseInfo = (sendSpy: ReturnType<typeof vi.fn>, id: string) => {
+  const closeCalls = sendSpy.mock.calls.filter((call) => call[0] === `ssh:shell:close:${id}`)
+  expect(closeCalls.length).toBeGreaterThan(0)
+  return closeCalls[closeCalls.length - 1][1]
+}
+
+const connectAndOpenShell = async (handlers: Map<string, IpcHandler>, id: string, sendSpy: ReturnType<typeof vi.fn>) => {
+  const connectHandler = handlers.get('ssh:connect')
+  const shellHandler = handlers.get('ssh:shell')
+  expect(connectHandler).toBeTypeOf('function')
+  expect(shellHandler).toBeTypeOf('function')
+
+  await connectHandler!({ sender: { send: vi.fn() } }, baseConnectionInfo(id))
+  const shellPromise = shellHandler!({ sender: { send: sendSpy } }, { id, terminalType: 'xterm-256color' })
+  await new Promise((resolve) => setTimeout(resolve, 350))
+  await shellPromise
+}
+
+describe('sshHandle reconnect close classification', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits network close info when connection error has network code', async () => {
+    const { handlers, createdClients } = await setupHandlers()
+    const id = 'session-network-code'
+    const sendSpy = vi.fn()
+    await connectAndOpenShell(handlers, id, sendSpy)
+
+    const client = createdClients[0]
+    expect(client).toBeDefined()
+    client.emit('error', { code: 'ECONNRESET', message: 'connection reset by peer' })
+    client.currentShellStream?.emit('close')
+
+    const closeInfo = getCloseInfo(sendSpy, id)
+    expect(closeInfo).toMatchObject({
+      reason: 'network',
+      isNetworkDisconnect: true,
+      errorCode: 'ECONNRESET'
+    })
+  })
+
+  it('emits manual close info on explicit disconnect', async () => {
+    const { handlers } = await setupHandlers()
+    const id = 'session-manual'
+    const sendSpy = vi.fn()
+    await connectAndOpenShell(handlers, id, sendSpy)
+
+    const disconnectHandler = handlers.get('ssh:disconnect')
+    expect(disconnectHandler).toBeTypeOf('function')
+
+    const result = await disconnectHandler!({}, { id })
+    expect(result).toMatchObject({ status: 'success' })
+
+    const closeInfo = getCloseInfo(sendSpy, id)
+    expect(closeInfo).toEqual({
+      reason: 'manual',
+      isNetworkDisconnect: false
+    })
+  })
+
+  it('emits unknown close info when transport closes without prior error', async () => {
+    const { handlers, createdClients } = await setupHandlers()
+    const id = 'session-unknown'
+    const sendSpy = vi.fn()
+    await connectAndOpenShell(handlers, id, sendSpy)
+
+    const client = createdClients[0]
+    expect(client).toBeDefined()
+    client.emit('close')
+    client.currentShellStream?.emit('close')
+
+    const closeInfo = getCloseInfo(sendSpy, id)
+    expect(closeInfo).toMatchObject({
+      reason: 'unknown',
+      isNetworkDisconnect: false,
+      errorMessage: 'SSH connection closed'
+    })
+  })
+
+  it('classifies network disconnect by error message pattern when code is absent', async () => {
+    const { handlers, createdClients } = await setupHandlers()
+    const id = 'session-network-message'
+    const sendSpy = vi.fn()
+    await connectAndOpenShell(handlers, id, sendSpy)
+
+    const client = createdClients[0]
+    expect(client).toBeDefined()
+    client.currentShellStream?.emit('error', { message: 'socket hang up while reading from channel' })
+    client.currentShellStream?.emit('close')
+
+    const closeInfo = getCloseInfo(sendSpy, id)
+    expect(closeInfo).toMatchObject({
+      reason: 'network',
+      isNetworkDisconnect: true,
+      errorMessage: 'socket hang up while reading from channel'
+    })
+  })
+})

--- a/src/main/ssh/sshHandle.ts
+++ b/src/main/ssh/sshHandle.ts
@@ -121,6 +121,144 @@ export const connectionStatus = new Map()
 
 export const sshSessionPids = new Map<string, number>()
 
+// Track how a shell session ended so renderer can decide whether to auto reconnect.
+type ShellCloseReason = 'manual' | 'network' | 'unknown'
+
+type ShellCloseInfoPayload = {
+  reason: ShellCloseReason
+  isNetworkDisconnect: boolean
+  errorCode?: string
+  errorMessage?: string
+}
+
+const manualDisconnectSessions = new Set<string>()
+// Per-session close metadata consumed once when shell close is emitted to renderer.
+const lastConnectionErrorBySession = new Map<string, { errorCode?: string; errorMessage?: string; isNetwork: boolean }>()
+const pendingShellCloseInfoBySession = new Map<string, ShellCloseInfoPayload>()
+
+// Known socket/network error codes that indicate network interruption.
+const NETWORK_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'EPIPE',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'ECONNREFUSED'
+])
+
+// Message pattern fallback for errors that do not expose a stable error code.
+const NETWORK_ERROR_PATTERNS = [
+  /timed out/i,
+  /keepalive/i,
+  /connection lost/i,
+  /connection reset/i,
+  /socket hang up/i,
+  /network is unreachable/i,
+  /not reachable/i,
+  /broken pipe/i
+]
+
+// Classify whether an SSH/connect error is likely caused by network break.
+const isLikelyNetworkDisconnect = (err: any): boolean => {
+  const code = String(err?.code || err?.errno || '').toUpperCase()
+  const message = String(err?.message || '')
+
+  if (code && NETWORK_ERROR_CODES.has(code)) {
+    return true
+  }
+
+  return NETWORK_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+// Cache close reason so shell close IPC can report a precise disconnect reason.
+const setPendingShellCloseInfo = (sessionId: string, info: ShellCloseInfoPayload) => {
+  if (!sessionId) return
+  pendingShellCloseInfoBySession.set(sessionId, info)
+  logger.info('Pending shell close info updated', {
+    event: 'ssh.shell.close.pending',
+    connectionId: sessionId,
+    reason: info.reason,
+    isNetworkDisconnect: info.isNetworkDisconnect,
+    errorCode: info.errorCode,
+    errorMessage: info.errorMessage
+  })
+}
+
+// Record the latest connection failure for later close/end event classification.
+const recordSessionConnectionError = (sessionId: string, err: any) => {
+  if (!sessionId) return
+  const errorCode = String(err?.code || err?.errno || '').toUpperCase() || undefined
+  const errorMessage = String(err?.message || '').trim() || undefined
+  const isNetwork = isLikelyNetworkDisconnect(err)
+
+  lastConnectionErrorBySession.set(sessionId, {
+    errorCode,
+    errorMessage,
+    isNetwork
+  })
+
+  setPendingShellCloseInfo(sessionId, {
+    reason: isNetwork ? 'network' : 'unknown',
+    isNetworkDisconnect: isNetwork,
+    errorCode,
+    errorMessage
+  })
+
+  logger.info('Session connection error recorded', {
+    event: 'ssh.session.error.recorded',
+    connectionId: sessionId,
+    errorCode,
+    errorMessage,
+    isNetworkDisconnect: isNetwork
+  })
+}
+
+// Clear reconnect-related transient state for a session.
+const clearSessionConnectionState = (sessionId: string) => {
+  if (!sessionId) return
+  manualDisconnectSessions.delete(sessionId)
+  lastConnectionErrorBySession.delete(sessionId)
+  pendingShellCloseInfoBySession.delete(sessionId)
+}
+
+// Consume close metadata once to prevent duplicate reconnect decisions.
+const consumeShellCloseInfo = (sessionId: string): ShellCloseInfoPayload => {
+  if (!sessionId) {
+    return { reason: 'unknown', isNetworkDisconnect: false }
+  }
+
+  if (manualDisconnectSessions.has(sessionId)) {
+    clearSessionConnectionState(sessionId)
+    return {
+      reason: 'manual',
+      isNetworkDisconnect: false
+    }
+  }
+
+  const pending = pendingShellCloseInfoBySession.get(sessionId)
+  if (pending) {
+    pendingShellCloseInfoBySession.delete(sessionId)
+    lastConnectionErrorBySession.delete(sessionId)
+    return pending
+  }
+
+  const lastError = lastConnectionErrorBySession.get(sessionId)
+  if (lastError) {
+    lastConnectionErrorBySession.delete(sessionId)
+    return {
+      reason: lastError.isNetwork ? 'network' : 'unknown',
+      isNetworkDisconnect: lastError.isNetwork,
+      errorCode: lastError.errorCode,
+      errorMessage: lastError.errorMessage
+    }
+  }
+
+  return { reason: 'unknown', isNetworkDisconnect: false }
+}
+
 // Set KeyboardInteractive authentication timeout (milliseconds)
 export const KeyboardInteractiveTimeout = 300000 // 5 minutes timeout
 const MaxKeyboardInteractiveAttempts = 5 // Max KeyboardInteractive attempts
@@ -449,6 +587,7 @@ const handleAttemptConnection = async (event, connectionInfo, resolve, reject, r
     proxyCommand
   } = connectionInfo
   retryCount++
+  clearSessionConnectionState(id)
 
   logger.info('Starting SSH connection attempt', {
     event: 'ssh.connect.start',
@@ -492,6 +631,7 @@ const handleAttemptConnection = async (event, connectionInfo, resolve, reject, r
   const conn = new Client()
 
   conn.on('ready', () => {
+    clearSessionConnectionState(id)
     sshConnections.set(id, conn) // Save connection object
     connectionStatus.set(id, { isVerified: true })
     connectionEvents.emit(`connection-status-changed:${id}`, { isVerified: true })
@@ -540,6 +680,7 @@ const handleAttemptConnection = async (event, connectionInfo, resolve, reject, r
   })
 
   conn.on('error', (err) => {
+    recordSessionConnectionError(id, err)
     connectionStatus.set(id, { isVerified: false })
 
     connectionEvents.emit(`connection-status-changed:${id}`, { isVerified: false })
@@ -564,6 +705,7 @@ const handleAttemptConnection = async (event, connectionInfo, resolve, reject, r
     port: port || 22,
     username,
     keepaliveInterval: 10000, // Keep connection alive
+    keepaliveCountMax: 3,
     tryKeyboard: true, // Enable keyboard interactive authentication
     readyTimeout: KeyboardInteractiveTimeout, // Connection timeout, 30 seconds
     algorithms
@@ -627,6 +769,64 @@ const handleAttemptConnection = async (event, connectionInfo, resolve, reject, r
     logger.error('Connection configuration error', { event: 'ssh.config.error', error: err })
     reject(new Error(`Connection configuration error: ${err}`))
   }
+
+  // Classify unexpected transport close and preserve reason for renderer reconnect logic.
+  conn.on('close', () => {
+    if (manualDisconnectSessions.has(id)) {
+      logger.info('SSH connection close ignored (manual disconnect)', {
+        event: 'ssh.conn.close.manual',
+        connectionId: id
+      })
+      return
+    }
+
+    const existing = pendingShellCloseInfoBySession.get(id)
+    if (existing) {
+      return
+    }
+
+    const lastError = lastConnectionErrorBySession.get(id)
+    setPendingShellCloseInfo(id, {
+      reason: lastError?.isNetwork ? 'network' : 'unknown',
+      isNetworkDisconnect: !!lastError?.isNetwork,
+      errorCode: lastError?.errorCode,
+      errorMessage: lastError?.errorMessage || 'SSH connection closed'
+    })
+    logger.info('SSH connection close captured', {
+      event: 'ssh.conn.close',
+      connectionId: id,
+      hasLastError: !!lastError
+    })
+  })
+
+  // Some network drops surface as "end"; handle it the same as "close".
+  conn.on('end', () => {
+    if (manualDisconnectSessions.has(id)) {
+      logger.info('SSH connection end ignored (manual disconnect)', {
+        event: 'ssh.conn.end.manual',
+        connectionId: id
+      })
+      return
+    }
+
+    const existing = pendingShellCloseInfoBySession.get(id)
+    if (existing) {
+      return
+    }
+
+    const lastError = lastConnectionErrorBySession.get(id)
+    setPendingShellCloseInfo(id, {
+      reason: lastError?.isNetwork ? 'network' : 'unknown',
+      isNetworkDisconnect: !!lastError?.isNetwork,
+      errorCode: lastError?.errorCode,
+      errorMessage: lastError?.errorMessage || 'SSH connection ended'
+    })
+    logger.info('SSH connection end captured', {
+      event: 'ssh.conn.end',
+      connectionId: id,
+      hasLastError: !!lastError
+    })
+  })
 }
 export const getUniqueRemoteName = async (sftp: SFTPWrapper, remoteDir: string, originalName: string, isDir: boolean): Promise<string> => {
   const list = await new Promise<{ filename: string; longname: string; attrs: any }[]>((resolve, reject) => {
@@ -976,10 +1176,23 @@ export const registerSSHHandlers = () => {
         event.sender.send(`ssh:shell:stderr:${id}`, data.toString('utf8'))
       })
 
+      stream.on('error', (err) => {
+        recordSessionConnectionError(id, err)
+      })
+
       stream.on('close', () => {
         flushBuffer()
-        logger.debug('Shell stream closed', { event: 'ssh.stream.close', connectionId: id, method })
-        event.sender.send(`ssh:shell:close:${id}`)
+        const closeInfo = consumeShellCloseInfo(id)
+        logger.info('Shell stream closed', {
+          event: 'ssh.stream.close',
+          connectionId: id,
+          method,
+          closeReason: closeInfo.reason,
+          isNetworkDisconnect: closeInfo.isNetworkDisconnect,
+          errorCode: closeInfo.errorCode,
+          errorMessage: closeInfo.errorMessage
+        })
+        event.sender.send(`ssh:shell:close:${id}`, closeInfo)
         shellStreams.delete(id)
       })
     }
@@ -1386,6 +1599,16 @@ export const registerSSHHandlers = () => {
     }
 
     // Default SSH handling
+    manualDisconnectSessions.add(id)
+    logger.info('Mark session as manual disconnect', {
+      event: 'ssh.disconnect.manual.mark',
+      connectionId: id
+    })
+    setPendingShellCloseInfo(id, {
+      reason: 'manual',
+      isNetworkDisconnect: false
+    })
+
     const stream = shellStreams.get(id)
     if (stream) {
       stream.end()
@@ -1423,12 +1646,14 @@ export const registerSSHHandlers = () => {
       cleanSftpConnection(id)
       sshConnections.delete(id)
       sftpConnections.delete(id)
+      clearSessionConnectionState(id)
       logger.info('SSH connection disconnected', {
         event: 'ssh.disconnect.success',
         connectionId: id
       })
       return { status: 'success', message: 'Disconnected' }
     }
+    clearSessionConnectionState(id)
     logger.warn('SSH disconnect requested for non-existent connection', {
       event: 'ssh.disconnect.notfound',
       connectionId: id

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -196,7 +196,10 @@ interface ApiType {
   selectPrivateKey: () => Promise<any>
   onShellData: (id: string, callback: (data: any) => void) => () => void
   onShellError: (id: string, callback: (data: any) => void) => () => void
-  onShellClose: (id: string, callback: () => void) => () => void
+  onShellClose: (
+    id: string,
+    callback: (data?: { reason: 'manual' | 'network' | 'unknown'; isNetworkDisconnect: boolean; errorCode?: string; errorMessage?: string }) => void
+  ) => () => void
   recordTerminalState: (params: any) => Promise<any>
   recordCommand: (params: any) => Promise<any>
   sshSftpList: (opts: { id: string; path: string }) => Promise<any>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -842,7 +842,7 @@ const api = {
     return () => ipcRenderer.removeListener(`ssh:shell:stderr:${id}`, listener)
   },
   onShellClose: (id, callback) => {
-    const listener = () => callback()
+    const listener = (_event, data) => callback(data)
     ipcRenderer.on(`ssh:shell:close:${id}`, listener)
     return () => ipcRenderer.removeListener(`ssh:shell:close:${id}`, listener)
   },

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1221,6 +1221,19 @@ export default {
     welcomeMessage: '{username}, مرحبا بك في Chaterm',
     reconnecting: 'جاري الاتصال...',
     terminalConnectionError: 'خطأ في الاتصال. الرجاء التحقق من أن الخادم المحلي يعمل.',
+    autoReconnect: {
+      tag: 'إعادة الاتصال',
+      networkIssue: 'مشكلة في الشبكة',
+      networkOfflineWaitingRestoration: 'الشبكة غير متصلة. جارٍ انتظار استعادة الاتصال...',
+      stoppedAfterMaxAttempts: 'تم التوقف بعد {max} محاولات فاشلة. اضغط Enter لإعادة المحاولة يدويًا.',
+      attemptProgress: 'محاولة {current}/{max}...',
+      connectedOnAttempt: 'تم الاتصال بنجاح في المحاولة {current}/{max}.',
+      attemptFailed: 'فشلت المحاولة {current}/{max}.',
+      retryingInSeconds: 'إعادة المحاولة خلال {seconds}ث...',
+      networkRestoredStartReconnect: 'تمت استعادة الشبكة. بدء إعادة الاتصال...',
+      detectedNetworkDisconnect: 'تم اكتشاف انقطاع في الشبكة ({reason}).',
+      networkOfflineWaitingReconnect: 'الشبكة غير متصلة. جارٍ انتظار إعادة الاتصال...'
+    },
     jumpserver: {
       connectingToBastionHost: 'يتم الاتصال بالخادم البعيد...',
       connectedToBastionHost: 'تم الاتصال بالخادم البعيد بنجاح, الرجاء الانتظار...',

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1221,6 +1221,19 @@ export default {
     welcomeMessage: '{username}, مرحبا بك في Chaterm',
     reconnecting: 'جاري الاتصال...',
     terminalConnectionError: 'خطأ في الاتصال. الرجاء التحقق من أن الخادم المحلي يعمل.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'يتم الاتصال بالخادم البعيد...',
       connectedToBastionHost: 'تم الاتصال بالخادم البعيد بنجاح, الرجاء الانتظار...',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1249,6 +1249,19 @@ export default {
     welcomeMessage: '{username}, Willkommen bei Chaterm',
     reconnecting: 'Erneut verbinden...',
     terminalConnectionError: 'Verbindungsfehler. Bitte prüfen Sie, ob der Terminal-Server läuft.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Verbindung zu remote bastion host...',
       connectedToBastionHost: 'Erfolgreich verbunden zu bastion host, bitte warten...',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1249,6 +1249,19 @@ export default {
     welcomeMessage: '{username}, Willkommen bei Chaterm',
     reconnecting: 'Erneut verbinden...',
     terminalConnectionError: 'Verbindungsfehler. Bitte prüfen Sie, ob der Terminal-Server läuft.',
+    autoReconnect: {
+      tag: 'Auto-Neuverbindung',
+      networkIssue: 'Netzwerkproblem',
+      networkOfflineWaitingRestoration: 'Das Netzwerk ist offline. Warte auf Wiederherstellung der Verbindung...',
+      stoppedAfterMaxAttempts: 'Nach {max} fehlgeschlagenen Versuchen gestoppt. Drücke Enter, um manuell erneut zu versuchen.',
+      attemptProgress: 'Versuch {current}/{max}...',
+      connectedOnAttempt: 'Bei Versuch {current}/{max} erfolgreich verbunden.',
+      attemptFailed: 'Versuch {current}/{max} fehlgeschlagen.',
+      retryingInSeconds: 'Erneuter Versuch in {seconds}s...',
+      networkRestoredStartReconnect: 'Netzwerk wiederhergestellt. Starte Neuverbindung...',
+      detectedNetworkDisconnect: 'Netzwerkunterbrechung erkannt ({reason}).',
+      networkOfflineWaitingReconnect: 'Das Netzwerk ist offline. Warte auf Neuverbindung...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Verbindung zu remote bastion host...',
       connectedToBastionHost: 'Erfolgreich verbunden zu bastion host, bitte warten...',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -1243,6 +1243,19 @@ export default {
     connectingTo: 'Connecting to {ip}',
     welcomeMessage: '{username}, Welcome to use Chaterm',
     reconnecting: 'Reconnecting...',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     terminalConnectionError: 'Connection error. Please check if the terminal server is running.',
     jumpserver: {
       connectingToBastionHost: 'Connecting to remote bastion host...',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1254,6 +1254,19 @@ export default {
     welcomeMessage: '{username}, Bienvenue sur Chaterm',
     reconnecting: 'Reconnexion...',
     terminalConnectionError: "Erreur de connexion. Veuillez vérifier si le serveur terminal est en cours d'exécution.",
+    autoReconnect: {
+      tag: 'ReconnexionAuto',
+      networkIssue: 'problème réseau',
+      networkOfflineWaitingRestoration: 'Le réseau est hors ligne. En attente du rétablissement de la connexion...',
+      stoppedAfterMaxAttempts: 'Arrêt après {max} tentatives échouées. Appuyez sur Entrée pour réessayer manuellement.',
+      attemptProgress: 'Tentative {current}/{max}...',
+      connectedOnAttempt: 'Connexion réussie à la tentative {current}/{max}.',
+      attemptFailed: 'Échec de la tentative {current}/{max}.',
+      retryingInSeconds: 'Nouvelle tentative dans {seconds}s...',
+      networkRestoredStartReconnect: 'Réseau rétabli. Démarrage de la reconnexion...',
+      detectedNetworkDisconnect: 'Déconnexion réseau détectée ({reason}).',
+      networkOfflineWaitingReconnect: 'Le réseau est hors ligne. En attente de la reconnexion...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Connexion au hôte bastion distant...',
       connectedToBastionHost: 'Connexion au hôte bastion distant réussie, veuillez patienter...',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1254,6 +1254,19 @@ export default {
     welcomeMessage: '{username}, Bienvenue sur Chaterm',
     reconnecting: 'Reconnexion...',
     terminalConnectionError: "Erreur de connexion. Veuillez vérifier si le serveur terminal est en cours d'exécution.",
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Connexion au hôte bastion distant...',
       connectedToBastionHost: 'Connexion au hôte bastion distant réussie, veuillez patienter...',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1252,6 +1252,19 @@ export default {
     welcomeMessage: '{username}, Benvenuto in Chaterm',
     reconnecting: 'Riconnessione...',
     terminalConnectionError: 'Errore connessione. Per favore controlla se il server terminale è in esecuzione.',
+    autoReconnect: {
+      tag: 'RiconnessioneAuto',
+      networkIssue: 'problema di rete',
+      networkOfflineWaitingRestoration: 'La rete non è disponibile. In attesa del ripristino della connessione...',
+      stoppedAfterMaxAttempts: 'Interrotto dopo {max} tentativi falliti. Premi Invio per riprovare manualmente.',
+      attemptProgress: 'Tentativo {current}/{max}...',
+      connectedOnAttempt: 'Connessione riuscita al tentativo {current}/{max}.',
+      attemptFailed: 'Tentativo {current}/{max} fallito.',
+      retryingInSeconds: 'Nuovo tentativo tra {seconds}s...',
+      networkRestoredStartReconnect: 'Rete ripristinata. Avvio della riconnessione...',
+      detectedNetworkDisconnect: 'Rilevata disconnessione di rete ({reason}).',
+      networkOfflineWaitingReconnect: 'La rete non è disponibile. In attesa della riconnessione...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Connessione al host bastion remoto...',
       connectedToBastionHost: 'Connessione al host bastion riuscita, per favore attendi...',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1252,6 +1252,19 @@ export default {
     welcomeMessage: '{username}, Benvenuto in Chaterm',
     reconnecting: 'Riconnessione...',
     terminalConnectionError: 'Errore connessione. Per favore controlla se il server terminale è in esecuzione.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Connessione al host bastion remoto...',
       connectedToBastionHost: 'Connessione al host bastion riuscita, per favore attendi...',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1239,6 +1239,19 @@ export default {
     welcomeMessage: '{username}, Chatermを使用してください',
     reconnecting: '再接続中...',
     terminalConnectionError: '接続エラー。ターミナルサーバーが実行中かどうかを確認してください。',
+    autoReconnect: {
+      tag: '自動再接続',
+      networkIssue: 'ネットワークの問題',
+      networkOfflineWaitingRestoration: 'ネットワークがオフラインです。接続の復旧を待機しています...',
+      stoppedAfterMaxAttempts: '{max} 回連続で失敗したため停止しました。Enter キーで手動再試行してください。',
+      attemptProgress: '再試行 {current}/{max}...',
+      connectedOnAttempt: '{current}/{max} 回目で接続に成功しました。',
+      attemptFailed: '{current}/{max} 回目の再試行に失敗しました。',
+      retryingInSeconds: '{seconds}秒後に再試行します...',
+      networkRestoredStartReconnect: 'ネットワークが復旧しました。再接続を開始します...',
+      detectedNetworkDisconnect: 'ネットワーク切断を検知しました（{reason}）。',
+      networkOfflineWaitingReconnect: 'ネットワークがオフラインです。再接続を待機しています...'
+    },
     jumpserver: {
       connectingToBastionHost: 'リモート踏み台サーバーに接続中...',
       connectedToBastionHost: '踏み台サーバーに接続しました。しばらくお待ちください...',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1239,6 +1239,19 @@ export default {
     welcomeMessage: '{username}, Chatermを使用してください',
     reconnecting: '再接続中...',
     terminalConnectionError: '接続エラー。ターミナルサーバーが実行中かどうかを確認してください。',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'リモート踏み台サーバーに接続中...',
       connectedToBastionHost: '踏み台サーバーに接続しました。しばらくお待ちください...',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1235,6 +1235,19 @@ export default {
     welcomeMessage: '{username}, Chaterm 사용을 환영합니다',
     reconnecting: '연결 재시도 중...',
     terminalConnectionError: '연결 오류. 터미널 서버가 실행 중인지 확인해주세요.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: '원격 배스천 호스트에 연결 중...',
       connectedToBastionHost: '배스천 호스트에 성공적으로 연결되었습니다. 잠시만 기다려주세요...',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1235,6 +1235,19 @@ export default {
     welcomeMessage: '{username}, Chaterm 사용을 환영합니다',
     reconnecting: '연결 재시도 중...',
     terminalConnectionError: '연결 오류. 터미널 서버가 실행 중인지 확인해주세요.',
+    autoReconnect: {
+      tag: '자동 재연결',
+      networkIssue: '네트워크 문제',
+      networkOfflineWaitingRestoration: '네트워크가 오프라인입니다. 연결 복구를 기다리는 중입니다...',
+      stoppedAfterMaxAttempts: '{max}회 실패하여 중단되었습니다. Enter 키를 눌러 수동으로 다시 시도하세요.',
+      attemptProgress: '시도 {current}/{max}...',
+      connectedOnAttempt: '{current}/{max}번째 시도에서 연결에 성공했습니다.',
+      attemptFailed: '{current}/{max}번째 시도에 실패했습니다.',
+      retryingInSeconds: '{seconds}초 후 다시 시도합니다...',
+      networkRestoredStartReconnect: '네트워크가 복구되었습니다. 재연결을 시작합니다...',
+      detectedNetworkDisconnect: '네트워크 연결 끊김이 감지되었습니다 ({reason}).',
+      networkOfflineWaitingReconnect: '네트워크가 오프라인입니다. 재연결을 기다리는 중입니다...'
+    },
     jumpserver: {
       connectingToBastionHost: '원격 배스천 호스트에 연결 중...',
       connectedToBastionHost: '배스천 호스트에 성공적으로 연결되었습니다. 잠시만 기다려주세요...',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1248,6 +1248,19 @@ export default {
     welcomeMessage: '{username}, Bem-vindo ao Chaterm',
     reconnecting: 'Reconectando...',
     terminalConnectionError: 'Erro de conexão. Por favor, verifique se o servidor terminal está em execução.',
+    autoReconnect: {
+      tag: 'ReconexãoAuto',
+      networkIssue: 'problema de rede',
+      networkOfflineWaitingRestoration: 'A rede está offline. A aguardar o restabelecimento da ligação...',
+      stoppedAfterMaxAttempts: 'Parado após {max} tentativas falhadas. Prima Enter para tentar novamente manualmente.',
+      attemptProgress: 'Tentativa {current}/{max}...',
+      connectedOnAttempt: 'Ligação estabelecida com sucesso na tentativa {current}/{max}.',
+      attemptFailed: 'A tentativa {current}/{max} falhou.',
+      retryingInSeconds: 'Nova tentativa em {seconds}s...',
+      networkRestoredStartReconnect: 'Rede restabelecida. A iniciar reconexão...',
+      detectedNetworkDisconnect: 'Detetada desconexão de rede ({reason}).',
+      networkOfflineWaitingReconnect: 'A rede está offline. A aguardar reconexão...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Conectando ao host bastion remoto...',
       connectedToBastionHost: 'Conectado ao host bastion com sucesso, por favor, aguarde...',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1248,6 +1248,19 @@ export default {
     welcomeMessage: '{username}, Bem-vindo ao Chaterm',
     reconnecting: 'Reconectando...',
     terminalConnectionError: 'Erro de conexão. Por favor, verifique se o servidor terminal está em execução.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Conectando ao host bastion remoto...',
       connectedToBastionHost: 'Conectado ao host bastion com sucesso, por favor, aguarde...',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1247,6 +1247,19 @@ export default {
     welcomeMessage: '{username}, Добро пожаловать в использование Chaterm',
     reconnecting: 'Переподключение...',
     terminalConnectionError: 'Ошибка соединения. Пожалуйста, проверьте, запущен ли терминальный сервер.',
+    autoReconnect: {
+      tag: 'Автопереподключение',
+      networkIssue: 'проблема сети',
+      networkOfflineWaitingRestoration: 'Сеть недоступна. Ожидание восстановления соединения...',
+      stoppedAfterMaxAttempts: 'Остановлено после {max} неудачных попыток. Нажмите Enter, чтобы повторить вручную.',
+      attemptProgress: 'Попытка {current}/{max}...',
+      connectedOnAttempt: 'Успешное подключение на попытке {current}/{max}.',
+      attemptFailed: 'Попытка {current}/{max} не удалась.',
+      retryingInSeconds: 'Повтор через {seconds} с...',
+      networkRestoredStartReconnect: 'Сеть восстановлена. Запуск переподключения...',
+      detectedNetworkDisconnect: 'Обнаружен сетевой разрыв ({reason}).',
+      networkOfflineWaitingReconnect: 'Сеть недоступна. Ожидание переподключения...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Соединение с удаленным bastion хостом...',
       connectedToBastionHost: 'Успешно соединено с bastion хостом, пожалуйста, подождите...',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1247,6 +1247,19 @@ export default {
     welcomeMessage: '{username}, Добро пожаловать в использование Chaterm',
     reconnecting: 'Переподключение...',
     terminalConnectionError: 'Ошибка соединения. Пожалуйста, проверьте, запущен ли терминальный сервер.',
+    autoReconnect: {
+      tag: 'AutoReconnect',
+      networkIssue: 'network issue',
+      networkOfflineWaitingRestoration: 'Network is offline. Waiting for connection restoration...',
+      stoppedAfterMaxAttempts: 'Stopped after {max} failed attempts. Press Enter to retry manually.',
+      attemptProgress: 'Attempt {current}/{max}...',
+      connectedOnAttempt: 'Connected successfully on attempt {current}/{max}.',
+      attemptFailed: 'Attempt {current}/{max} failed.',
+      retryingInSeconds: 'Retrying in {seconds}s...',
+      networkRestoredStartReconnect: 'Network restored. Starting reconnect...',
+      detectedNetworkDisconnect: 'Detected network disconnect ({reason}).',
+      networkOfflineWaitingReconnect: 'Network is offline. Waiting for reconnection...'
+    },
     jumpserver: {
       connectingToBastionHost: 'Соединение с удаленным bastion хостом...',
       connectedToBastionHost: 'Успешно соединено с bastion хостом, пожалуйста, подождите...',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -1230,6 +1230,19 @@ export default {
     welcomeMessage: '{username}, 欢迎您使用Chaterm智能终端',
     reconnecting: '正在重新连接...',
     terminalConnectionError: '连接错误。请检查终端服务器是否运行。',
+    autoReconnect: {
+      tag: '自动重连',
+      networkIssue: '网络异常',
+      networkOfflineWaitingRestoration: '网络已断开，等待网络恢复...',
+      stoppedAfterMaxAttempts: '重连失败已达 {max} 次，已停止自动重连。请按 Enter 手动重连。',
+      attemptProgress: '正在进行第 {current}/{max} 次重连...',
+      connectedOnAttempt: '第 {current}/{max} 次重连成功。',
+      attemptFailed: '第 {current}/{max} 次重连失败。',
+      retryingInSeconds: '{seconds} 秒后重试...',
+      networkRestoredStartReconnect: '网络已恢复，开始重连...',
+      detectedNetworkDisconnect: '检测到网络断开（{reason}）。',
+      networkOfflineWaitingReconnect: '网络已断开，等待重新联网...'
+    },
     jumpserver: {
       connectingToBastionHost: '正在连接远程堡垒机...',
       connectedToBastionHost: '已成功连接堡垒机，请稍候...',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -1231,6 +1231,19 @@ export default {
     welcomeMessage: '{username}, 歡迎您使用Chaterm智能終端',
     reconnecting: '正在重新連接...',
     terminalConnectionError: '連接錯誤。請檢查終端服務器是否運行。',
+    autoReconnect: {
+      tag: '自動重連',
+      networkIssue: '網路異常',
+      networkOfflineWaitingRestoration: '網路已中斷，等待網路恢復...',
+      stoppedAfterMaxAttempts: '重連失敗已達 {max} 次，已停止自動重連。請按 Enter 手動重連。',
+      attemptProgress: '正在進行第 {current}/{max} 次重連...',
+      connectedOnAttempt: '第 {current}/{max} 次重連成功。',
+      attemptFailed: '第 {current}/{max} 次重連失敗。',
+      retryingInSeconds: '{seconds} 秒後重試...',
+      networkRestoredStartReconnect: '網路已恢復，開始重連...',
+      detectedNetworkDisconnect: '檢測到網路中斷（{reason}）。',
+      networkOfflineWaitingReconnect: '網路已中斷，等待重新連網...'
+    },
     jumpserver: {
       connectingToBastionHost: '正在連接遠程堡壘機...',
       connectedToBastionHost: '已成功連接堡壘機，請稍候...',

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -156,6 +156,12 @@ const HEAVY_UI_SEPARATOR_RE = /=+/
 
 const logger = createRendererLogger('ssh.connect')
 const { t } = useI18n()
+type ShellCloseInfo = {
+  reason: 'manual' | 'network' | 'unknown'
+  isNetworkDisconnect: boolean
+  errorCode?: string
+  errorMessage?: string
+}
 const selectFlag = ref(false)
 const configStore = userConfigStore()
 const isTransparent = computed(() => !!configStore.getUserConfig.background.image)
@@ -359,6 +365,17 @@ const setRef = (el, key) => {
   }
 }
 const isConnected = ref(false)
+// Auto reconnect state used when a session is interrupted by network failure.
+const manualDisconnectRequested = ref(false)
+const disconnectedByNetwork = ref(false)
+const waitingForNetworkRestore = ref(false)
+const autoReconnectAttempts = ref(0)
+const autoReconnectInProgress = ref(false)
+const connectInProgress = ref(false)
+const AUTO_RECONNECT_MAX_ATTEMPTS = 3
+const AUTO_RECONNECT_BASE_DELAY_MS = 2000
+let autoReconnectTimer: ReturnType<typeof setTimeout> | null = null
+
 const terminal = ref<Terminal | null>(null)
 const fitAddon = ref<FitAddon | null>(null)
 const connectionId = ref('')
@@ -691,6 +708,8 @@ onMounted(async () => {
   if (config.pinchZoomStatus === 1) {
     window.addEventListener('wheel', handleWheel)
   }
+  window.addEventListener('online', handleBrowserOnline)
+  window.addEventListener('offline', handleBrowserOffline)
   window.addEventListener('keydown', handleGlobalKeyDown)
   window.addEventListener('click', () => {
     if (contextmenu.value && typeof contextmenu.value.hide === 'function') {
@@ -925,6 +944,8 @@ const handlePinchZoomStatusChanged = async (enabled: boolean) => {
 }
 
 onBeforeUnmount(() => {
+  manualDisconnectRequested.value = true
+  resetAutoReconnectState()
   cachedSelectionButton = null
   if (sendTerminalStateTimer) {
     clearTimeout(sendTerminalStateTimer)
@@ -936,6 +957,8 @@ onBeforeUnmount(() => {
   }
   window.removeEventListener('resize', handleResize)
   window.removeEventListener('wheel', handleWheel)
+  window.removeEventListener('online', handleBrowserOnline)
+  window.removeEventListener('offline', handleBrowserOffline)
   inputManager.unregisterInstances(connectionId.value)
   if (resizeObserver) {
     resizeObserver.disconnect()
@@ -1253,212 +1276,453 @@ const handleResize = debounce(() => {
 
 const emit = defineEmits(['connectSSH', 'disconnectSSH', 'closeTabInTerm', 'createNewTerm'])
 
-const connectSSH = async () => {
-  if (termOndata) {
-    termOndata.dispose()
-    termOndata = null
+// Keep reconnect prompts fully i18n-based.
+const getAutoReconnectMessage = (key: string, params?: Record<string, unknown>) => {
+  return t(`ssh.autoReconnect.${key}`, params || {})
+}
+
+// Mirror reconnect progress to app logger and terminal output.
+const writeAutoReconnectLog = (text: string) => {
+  const tag = getAutoReconnectMessage('tag')
+  logger.info('Auto reconnect trace', {
+    event: 'ssh.auto-reconnect.trace',
+    connectionId: connectionId.value,
+    message: text
+  })
+  cusWrite?.(`\r\n[${tag}] ${text}\r\n`, { isUserCall: true })
+}
+
+// Ensure only one reconnect timer is active at any time.
+const clearAutoReconnectTimer = () => {
+  if (autoReconnectTimer) {
+    clearTimeout(autoReconnectTimer)
+    autoReconnectTimer = null
   }
-  if (termOnBinary) {
-    termOnBinary?.dispose()
-    termOnBinary = null
+}
+
+// Reset reconnect state after success or when reconnect flow is cancelled.
+const resetAutoReconnectState = () => {
+  clearAutoReconnectTimer()
+  autoReconnectInProgress.value = false
+  autoReconnectAttempts.value = 0
+  waitingForNetworkRestore.value = false
+  disconnectedByNetwork.value = false
+}
+
+// Manual reconnect should interrupt pending automatic retry loops.
+const prepareManualReconnectAttempt = () => {
+  clearAutoReconnectTimer()
+  autoReconnectInProgress.value = false
+  autoReconnectAttempts.value = 0
+}
+
+// Central retry scheduler: gate by state, retry with backoff, stop after max attempts.
+const scheduleAutoReconnect = (delayMs = 0) => {
+  if (!disconnectedByNetwork.value || manualDisconnectRequested.value || isConnected.value) {
+    logger.info('Skip auto reconnect scheduling', {
+      event: 'ssh.auto-reconnect.schedule.skip',
+      connectionId: connectionId.value,
+      disconnectedByNetwork: disconnectedByNetwork.value,
+      manualDisconnectRequested: manualDisconnectRequested.value,
+      isConnected: isConnected.value
+    })
+    return
   }
+  clearAutoReconnectTimer()
 
-  if (terminal.value) {
-    const textarea = terminal.value.element?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
-    if (textarea) {
-      if (textareaCompositionListener) {
-        textarea.removeEventListener('compositionend', textareaCompositionListener)
-        textareaCompositionListener = null
-      }
-      if (textareaPasteListener) {
-        textarea.removeEventListener('paste', textareaPasteListener)
-        textareaPasteListener = null
-      }
-    }
-  }
-
-  try {
-    const skipAssetLookup = shouldSkipAssetLookup(props.connectData)
-    const assetInfo = skipAssetLookup ? null : await api.connectAssetInfo({ uuid: props.connectData.uuid })
-    const password = ref('')
-    const privateKey = ref('')
-    const passphrase = ref('')
-    if (assetInfo) {
-      password.value = assetInfo.auth_type === 'password' ? assetInfo.password : ''
-      privateKey.value = assetInfo.auth_type === 'keyBased' ? assetInfo.privateKey : ''
-      passphrase.value = assetInfo.auth_type === 'keyBased' ? assetInfo.passphrase : ''
-    } else {
-      password.value = props.connectData.authType === 'password' ? props.connectData.password : ''
-      privateKey.value = props.connectData.authType === 'privateKey' ? props.connectData.privateKey : ''
-      passphrase.value = props.connectData.passphrase || ''
-    }
-
-    const email = userInfoStore().userInfo.email
-
-    const connOrgType = props.serverInfo.organizationId === 'personal' ? 'local' : 'local-team'
-    const connConnectHost = assetInfo?.asset_ip || props.connectData.host || props.connectData.ip
-    const connUsername = assetInfo?.username || props.connectData.username
-    const connAssetIp = assetInfo?.asset_ip || props.connectData.host
-    const connHostname = assetInfo?.hostname || props.connectData.hostname
-    const connPort = assetInfo?.port || props.connectData.port
-    const connHost = assetInfo?.host || props.connectData.host
-    const connPassword = assetInfo?.password || props.connectData.password
-    const connComment = assetInfo?.comment || props.connectData.comment
-    const connSshType = assetInfo?.sshType || 'ssh'
-    const connAssetType = assetInfo?.asset_type || props.connectData.asset_type || ''
-
-    const hostnameBase64 = props.serverInfo.organizationId === 'personal' ? Base64Util.encode(connAssetIp) : Base64Util.encode(connHostname)
-
-    const sessionId = uuidv4() // Different for each tab
-    const jumpserverUuid = assetInfo?.organization_uuid || props.connectData.uuid
-
-    connectionId.value = `${connUsername}@${props.connectData.ip}:${connOrgType}:${hostnameBase64}:${sessionId}`
-
-    // Fork path: reuse an existing authenticated SSH connection
-    if (props.connectData.forkFromConnectionId) {
-      logger.info('Fork SSH session from existing connection', {
-        sourceConnectionId: props.connectData.forkFromConnectionId,
-        newConnectionId: connectionId.value
+  autoReconnectTimer = setTimeout(async () => {
+    if (!disconnectedByNetwork.value || manualDisconnectRequested.value || isConnected.value) {
+      logger.info('Cancel auto reconnect tick', {
+        event: 'ssh.auto-reconnect.tick.cancel',
+        connectionId: connectionId.value,
+        disconnectedByNetwork: disconnectedByNetwork.value,
+        manualDisconnectRequested: manualDisconnectRequested.value,
+        isConnected: isConnected.value
       })
-      const forkResult = await api.forkSession({
-        sourceConnectionId: props.connectData.forkFromConnectionId,
-        newConnectionId: connectionId.value,
-        host: connConnectHost,
-        port: connPort,
-        username: connUsername
+      return
+    }
+    if (autoReconnectInProgress.value) {
+      logger.info('Auto reconnect already in progress', {
+        event: 'ssh.auto-reconnect.in_progress',
+        connectionId: connectionId.value
       })
-      if (forkResult.status === 'connected') {
-        const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
-        const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
-        terminal.value?.writeln('')
-        terminal.value?.writeln(welcome)
-        terminal.value?.writeln(t('ssh.connectingTo', { ip: props.connectData.ip }))
-        await startShell()
-        shellOpenedAt = Date.now()
-        setupTerminalInput()
-        // Single deferred resize after guard window to avoid rapid setWindow killing the shell
-        setTimeout(() => {
-          handleResize()
-          terminal.value?.scrollToBottom()
-          terminal.value?.focus()
-        }, RESIZE_GUARD_MS + 100)
-        registerSshConnection(props.currentConnectionId, connectionId.value)
-      } else {
-        const errorMsg = formatStatusMessage(t('ssh.connectionFailed', { message: forkResult?.message || 'Fork failed' }), 'error')
-        terminal.value?.writeln(errorMsg)
-      }
-      connectionSftpAvailable.value = await api.checkSftpConnAvailable(connectionId.value)
-      emit('connectSSH', { isConnected: isConnected })
       return
     }
 
-    // Setup status listener for bastion host connections
-    // All plugin bastions reuse the jumpserver:status-update channel
-    if (shouldUseBastionStatusChannel(connSshType) && terminal.value) {
-      jumpServerStatusHandler = createJumpServerStatusHandler(terminal.value, connectionId.value, translateJumpServerStatus)
-      jumpServerStatusHandler.setupStatusListener(api)
+    if (!navigator.onLine) {
+      waitingForNetworkRestore.value = true
+      writeAutoReconnectLog(getAutoReconnectMessage('networkOfflineWaitingRestoration'))
+      return
     }
 
-    const jmsToken = ref(localStorage.getItem('jms-token'))
-
-    const connData: any = {
-      id: connectionId.value, // Session ID (unique for each tab)
-      assetUuid: jumpserverUuid, // JumpServer UUID (for connection pool reuse)
-      host: connConnectHost,
-      port: connPort,
-      username: connUsername,
-      password: connPassword,
-      privateKey: privateKey.value,
-      passphrase: passphrase.value,
-      targetIp: connHost,
-      targetHostname: connHostname,
-      targetAsset: connComment || connHost,
-      comment: connComment,
-      sshType: connSshType,
-      terminalType: config.terminalType,
-      agentForward: config.sshAgentsStatus === 1,
-      isOfficeDevice: isOfficeDevice.value,
-      connIdentToken: jmsToken.value || '',
-      asset_type: connAssetType, // Pass asset_type to main process for switch handling
-      proxyCommand: props.connectData.proxyCommand || '',
-      source: props.connectData.source || '',
-      wakeupSource: props.connectData.wakeupSource || props.connectData.source || '',
-      disablePostConnectProbe: skipAssetLookup
-    }
-    connData.needProxy = assetInfo?.need_proxy === 1 || false
-    if (connData.needProxy) {
-      connData.proxyConfig = config.sshProxyConfigs.find((item) => item.name === assetInfo?.proxy_name)
-    }
-
-    const { mark: perfMark } = await import('@/utils/perf')
-    perfMark('chaterm/terminal/willConnect')
-    const result = await api.connect(connData)
-    perfMark('chaterm/terminal/didConnect')
-
-    if (jumpServerStatusHandler) {
-      jumpServerStatusHandler.cleanup()
-      jumpServerStatusHandler = null
-    }
-
-    const isSwitchDevice = connAssetType?.startsWith('person-switch-') ?? false
-    if (isSwitchDevice) {
-      connectionHasSudo.value = false
-      getCmdList([])
-    } else {
-      api
-        .connectReadyData(connectionId.value)
-        .then((connectReadyData) => {
-          connectionHasSudo.value = connectReadyData?.hasSudo
-          getCmdList(connectReadyData?.commandList)
+    if (autoReconnectAttempts.value >= AUTO_RECONNECT_MAX_ATTEMPTS) {
+      writeAutoReconnectLog(
+        getAutoReconnectMessage('stoppedAfterMaxAttempts', {
+          max: AUTO_RECONNECT_MAX_ATTEMPTS
         })
-        .catch((error) => {
-          logger.error('Failed to receive command list', { error: error })
+      )
+      disconnectedByNetwork.value = false
+      autoReconnectInProgress.value = false
+      waitingForNetworkRestore.value = false
+      return
+    }
+
+    autoReconnectInProgress.value = true
+    autoReconnectAttempts.value += 1
+    const currentAttempt = autoReconnectAttempts.value
+    writeAutoReconnectLog(
+      getAutoReconnectMessage('attemptProgress', {
+        current: currentAttempt,
+        max: AUTO_RECONNECT_MAX_ATTEMPTS
+      })
+    )
+
+    const success = await connectSSH({ isAutoReconnect: true })
+    autoReconnectInProgress.value = false
+
+    if (success) {
+      writeAutoReconnectLog(
+        getAutoReconnectMessage('connectedOnAttempt', {
+          current: currentAttempt,
+          max: AUTO_RECONNECT_MAX_ATTEMPTS
+        })
+      )
+      resetAutoReconnectState()
+      return
+    }
+
+    writeAutoReconnectLog(
+      getAutoReconnectMessage('attemptFailed', {
+        current: currentAttempt,
+        max: AUTO_RECONNECT_MAX_ATTEMPTS
+      })
+    )
+
+    if (currentAttempt >= AUTO_RECONNECT_MAX_ATTEMPTS) {
+      writeAutoReconnectLog(
+        getAutoReconnectMessage('stoppedAfterMaxAttempts', {
+          max: AUTO_RECONNECT_MAX_ATTEMPTS
+        })
+      )
+      disconnectedByNetwork.value = false
+      waitingForNetworkRestore.value = false
+      return
+    }
+
+    const nextDelay = AUTO_RECONNECT_BASE_DELAY_MS * currentAttempt
+    writeAutoReconnectLog(
+      getAutoReconnectMessage('retryingInSeconds', {
+        seconds: Math.ceil(nextDelay / 1000)
+      })
+    )
+    scheduleAutoReconnect(nextDelay)
+  }, delayMs)
+}
+
+// Browser offline/online events are used to pause and resume reconnect attempts.
+const handleBrowserOffline = () => {
+  waitingForNetworkRestore.value = true
+  logger.info('Browser network offline event', {
+    event: 'ssh.auto-reconnect.browser.offline',
+    connectionId: connectionId.value
+  })
+}
+
+const handleBrowserOnline = () => {
+  waitingForNetworkRestore.value = false
+  logger.info('Browser network online event', {
+    event: 'ssh.auto-reconnect.browser.online',
+    connectionId: connectionId.value,
+    disconnectedByNetwork: disconnectedByNetwork.value,
+    manualDisconnectRequested: manualDisconnectRequested.value,
+    isConnected: isConnected.value
+  })
+
+  if (disconnectedByNetwork.value && !manualDisconnectRequested.value && !isConnected.value) {
+    writeAutoReconnectLog(getAutoReconnectMessage('networkRestoredStartReconnect'))
+    scheduleAutoReconnect(0)
+  }
+}
+
+const connectSSH = async (_opts?: { isAutoReconnect?: boolean }) => {
+  // Prevent concurrent connect calls (auto reconnect + manual reconnect).
+  if (connectInProgress.value) {
+    logger.info('Skip SSH connect because another connect is in progress', {
+      event: 'ssh.connect.skip.in_progress',
+      connectionId: connectionId.value,
+      isAutoReconnect: _opts?.isAutoReconnect === true
+    })
+    return false
+  }
+
+  connectInProgress.value = true
+  try {
+    manualDisconnectRequested.value = false
+    clearAutoReconnectTimer()
+    let connectSuccess = false
+    logger.info('Start SSH connect', {
+      event: 'ssh.connect.start.renderer',
+      connectionId: connectionId.value,
+      isAutoReconnect: _opts?.isAutoReconnect === true
+    })
+
+    if (terminal.value) {
+      const textarea = terminal.value.element?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+      if (textarea) {
+        if (textareaCompositionListener) {
+          textarea.removeEventListener('compositionend', textareaCompositionListener)
+          textareaCompositionListener = null
+        }
+        if (textareaPasteListener) {
+          textarea.removeEventListener('paste', textareaPasteListener)
+          textareaPasteListener = null
+        }
+      }
+    }
+
+    try {
+      const skipAssetLookup = shouldSkipAssetLookup(props.connectData)
+      const assetInfo = skipAssetLookup ? null : await api.connectAssetInfo({ uuid: props.connectData.uuid })
+      const password = ref('')
+      const privateKey = ref('')
+      const passphrase = ref('')
+      if (assetInfo) {
+        password.value = assetInfo.auth_type === 'password' ? assetInfo.password : ''
+        privateKey.value = assetInfo.auth_type === 'keyBased' ? assetInfo.privateKey : ''
+        passphrase.value = assetInfo.auth_type === 'keyBased' ? assetInfo.passphrase : ''
+      } else {
+        password.value = props.connectData.authType === 'password' ? props.connectData.password : ''
+        privateKey.value = props.connectData.authType === 'privateKey' ? props.connectData.privateKey : ''
+        passphrase.value = props.connectData.passphrase || ''
+      }
+
+      const email = userInfoStore().userInfo.email
+      const isAutoReconnect = _opts?.isAutoReconnect === true
+      const shouldFocusAfterConnect = !isAutoReconnect && props.isActive && props.activeTabId === props.currentConnectionId
+
+      const connOrgType = props.serverInfo.organizationId === 'personal' ? 'local' : 'local-team'
+      const connConnectHost = assetInfo?.asset_ip || props.connectData.host || props.connectData.ip
+      const connUsername = assetInfo?.username || props.connectData.username
+      const connAssetIp = assetInfo?.asset_ip || props.connectData.host
+      const connHostname = assetInfo?.hostname || props.connectData.hostname
+      const connPort = assetInfo?.port || props.connectData.port
+      const connHost = assetInfo?.host || props.connectData.host
+      const connPassword = assetInfo?.password || props.connectData.password
+      const connComment = assetInfo?.comment || props.connectData.comment
+      const connSshType = assetInfo?.sshType || 'ssh'
+      const connAssetType = assetInfo?.asset_type || props.connectData.asset_type || ''
+
+      const hostnameBase64 = props.serverInfo.organizationId === 'personal' ? Base64Util.encode(connAssetIp) : Base64Util.encode(connHostname)
+
+      const sessionId = uuidv4() // Different for each tab
+      const jumpserverUuid = assetInfo?.organization_uuid || props.connectData.uuid
+
+      connectionId.value = `${connUsername}@${props.connectData.ip}:${connOrgType}:${hostnameBase64}:${sessionId}`
+
+      // Fork path: reuse an existing authenticated SSH connection
+      if (props.connectData.forkFromConnectionId) {
+        logger.info('Fork SSH session from existing connection', {
+          sourceConnectionId: props.connectData.forkFromConnectionId,
+          newConnectionId: connectionId.value,
+          isAutoReconnect
+        })
+        const forkResult = await api.forkSession({
+          sourceConnectionId: props.connectData.forkFromConnectionId,
+          newConnectionId: connectionId.value,
+          host: connConnectHost,
+          port: connPort,
+          username: connUsername
+        })
+        if (forkResult.status === 'connected') {
+          disconnectedByNetwork.value = false
+          waitingForNetworkRestore.value = false
+          autoReconnectAttempts.value = 0
+          if (!isAutoReconnect) {
+            const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
+            const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
+            terminal.value?.writeln('')
+            terminal.value?.writeln(welcome)
+            terminal.value?.writeln(t('ssh.connectingTo', { ip: props.connectData.ip }))
+          }
+          await startShell()
+          shellOpenedAt = Date.now()
+          setupTerminalInput()
+          // Single deferred resize after guard window to avoid rapid setWindow killing
+          setTimeout(() => {
+            handleResize()
+            terminal.value?.scrollToBottom()
+            if (shouldFocusAfterConnect) {
+              terminal.value?.focus()
+            }
+          }, RESIZE_GUARD_MS + 100)
+          registerSshConnection(props.currentConnectionId, connectionId.value)
+          connectSuccess = true
+          logger.info('SSH connect succeeded (fork)', {
+            event: 'ssh.connect.success.renderer',
+            connectionId: connectionId.value,
+            isAutoReconnect
+          })
+        } else {
+          const resolvedForkMessage = forkResult?.message || 'Fork failed'
+          const errorMsg = formatStatusMessage(t('ssh.connectionFailed', { message: resolvedForkMessage }), 'error')
+          terminal.value?.writeln(errorMsg)
+          logger.info('SSH connect failed (fork)', {
+            event: 'ssh.connect.failed.renderer',
+            connectionId: connectionId.value,
+            isAutoReconnect,
+            status: forkResult?.status,
+            message: resolvedForkMessage
+          })
+        }
+      } else {
+        // Setup status listener for bastion host connections
+        // All plugin bastions reuse the jumpserver:status-update channel
+        if (shouldUseBastionStatusChannel(connSshType) && terminal.value) {
+          jumpServerStatusHandler = createJumpServerStatusHandler(terminal.value, connectionId.value, translateJumpServerStatus)
+          jumpServerStatusHandler.setupStatusListener(api)
+        }
+
+        const jmsToken = ref(localStorage.getItem('jms-token'))
+
+        const connData: any = {
+          id: connectionId.value, // Session ID (unique for each tab)
+          assetUuid: jumpserverUuid, // JumpServer UUID (for connection pool reuse)
+          host: connConnectHost,
+          port: connPort,
+          username: connUsername,
+          password: connPassword,
+          privateKey: privateKey.value,
+          passphrase: passphrase.value,
+          targetIp: connHost,
+          targetHostname: connHostname,
+          targetAsset: connComment || connHost,
+          comment: connComment,
+          sshType: connSshType,
+          terminalType: config.terminalType,
+          agentForward: config.sshAgentsStatus === 1,
+          isOfficeDevice: isOfficeDevice.value,
+          connIdentToken: jmsToken.value || '',
+          asset_type: connAssetType, // Pass asset_type to main process for switch handling
+          proxyCommand: props.connectData.proxyCommand || '',
+          source: props.connectData.source || '',
+          wakeupSource: props.connectData.wakeupSource || props.connectData.source || '',
+          disablePostConnectProbe: skipAssetLookup
+        }
+        connData.needProxy = assetInfo?.need_proxy === 1 || false
+        if (connData.needProxy) {
+          connData.proxyConfig = config.sshProxyConfigs.find((item) => item.name === assetInfo?.proxy_name)
+        }
+
+        const { mark: perfMark } = await import('@/utils/perf')
+        perfMark('chaterm/terminal/willConnect')
+        const result = await api.connect(connData)
+        perfMark('chaterm/terminal/didConnect')
+
+        if (jumpServerStatusHandler) {
+          jumpServerStatusHandler.cleanup()
+          jumpServerStatusHandler = null
+        }
+
+        const isSwitchDevice = connAssetType?.startsWith('person-switch-') ?? false
+        if (isSwitchDevice) {
           connectionHasSudo.value = false
           getCmdList([])
-        })
-    }
+        } else {
+          api
+            .connectReadyData(connectionId.value)
+            .then((connectReadyData) => {
+              connectionHasSudo.value = connectReadyData?.hasSudo
+              getCmdList(connectReadyData?.commandList)
+            })
+            .catch((error) => {
+              logger.error('Failed to receive command list', { error: error })
+              connectionHasSudo.value = false
+              getCmdList([])
+            })
+        }
 
-    if (result.status === 'connected') {
-      perfMark('chaterm/terminal/connected')
-      const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
-      const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
-      terminal.value?.writeln('') // Add empty line separator
-      terminal.value?.writeln(welcome)
-      terminal.value?.writeln(t('ssh.connectingTo', { ip: props.connectData.ip }))
-      await startShell()
-      shellOpenedAt = Date.now()
-      setupTerminalInput()
-      // Single deferred resize after guard window to avoid rapid setWindow killing the shell
-      setTimeout(() => {
-        handleResize()
-        terminal.value?.scrollToBottom()
-        terminal.value?.focus()
-      }, RESIZE_GUARD_MS + 100)
-      if (shouldSkipAssetLookup(props.connectData)) {
-        logger.info('Skip shell PID probe for xshell wakeup session', {
-          connectionId: connectionId.value,
-          source: props.connectData?.wakeupSource || props.connectData?.source || 'unknown'
-        })
-      } else {
-        api.setShellPid(connectionId.value)
+        if (result.status === 'connected') {
+          perfMark('chaterm/terminal/connected')
+          disconnectedByNetwork.value = false
+          waitingForNetworkRestore.value = false
+          autoReconnectAttempts.value = 0
+          if (!isAutoReconnect) {
+            const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
+            const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
+            terminal.value?.writeln('') // Add empty line separator
+            terminal.value?.writeln(welcome)
+            terminal.value?.writeln(t('ssh.connectingTo', { ip: props.connectData.ip }))
+          }
+          await startShell()
+          shellOpenedAt = Date.now()
+          setupTerminalInput()
+          // Single deferred resize after guard window to avoid rapid setWindow killing the shell
+          setTimeout(() => {
+            handleResize()
+            terminal.value?.scrollToBottom()
+            if (shouldFocusAfterConnect) {
+              terminal.value?.focus()
+              terminal.value?.focus()
+            }
+          }, RESIZE_GUARD_MS + 100)
+          if (shouldSkipAssetLookup(props.connectData)) {
+            logger.info('Skip shell PID probe for xshell wakeup session', {
+              connectionId: connectionId.value,
+              source: props.connectData?.wakeupSource || props.connectData?.source || 'unknown'
+            })
+          } else {
+            api.setShellPid(connectionId.value)
+          }
+          registerSshConnection(props.currentConnectionId, connectionId.value)
+          connectSuccess = true
+          logger.info('SSH connect succeeded', {
+            event: 'ssh.connect.success.renderer',
+            connectionId: connectionId.value,
+            isAutoReconnect
+          })
+        } else {
+          const resolvedMessage = result?.messageKey ? t(result.messageKey, result.messageParams || {}) : (result?.message as string)
+          const errorMsg = formatStatusMessage(t('ssh.connectionFailed', { message: resolvedMessage }), 'error')
+          terminal.value?.writeln(errorMsg)
+          logger.info('SSH connect failed (status)', {
+            event: 'ssh.connect.failed.renderer',
+            connectionId: connectionId.value,
+            isAutoReconnect,
+            status: result.status,
+            message: resolvedMessage
+          })
+        }
       }
-      registerSshConnection(props.currentConnectionId, connectionId.value)
-    } else {
-      const resolvedMessage = result?.messageKey ? t(result.messageKey, result.messageParams || {}) : (result?.message as string)
-      const errorMsg = formatStatusMessage(t('ssh.connectionFailed', { message: resolvedMessage }), 'error')
-      terminal.value?.writeln(errorMsg)
-    }
-  } catch (error: any) {
-    if (jumpServerStatusHandler) {
-      jumpServerStatusHandler.cleanup()
-      jumpServerStatusHandler = null
-    }
+    } catch (error: any) {
+      if (jumpServerStatusHandler) {
+        jumpServerStatusHandler.cleanup()
+        jumpServerStatusHandler = null
+      }
 
-    const errorMsg = formatStatusMessage(t('ssh.connectionError', { message: error.message || t('ssh.unknownError') }), 'error')
-    terminal.value?.writeln(errorMsg)
+      const errorMsg = formatStatusMessage(t('ssh.connectionError', { message: error.message || t('ssh.unknownError') }), 'error')
+      terminal.value?.writeln(errorMsg)
+      logger.info('SSH connect failed (exception)', {
+        event: 'ssh.connect.error.renderer',
+        connectionId: connectionId.value,
+        isAutoReconnect: _opts?.isAutoReconnect === true,
+        error: error?.message || String(error)
+      })
+    }
+    try {
+      connectionSftpAvailable.value = connectSuccess ? await api.checkSftpConnAvailable(connectionId.value) : false
+    } catch (error) {
+      connectionSftpAvailable.value = false
+      logger.warn('Check SFTP availability failed after SSH connect', {
+        event: 'ssh.connect.sftp.check_failed',
+        connectionId: connectionId.value,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+    emit('connectSSH', { isConnected: isConnected })
+    return isConnected.value
+  } finally {
+    connectInProgress.value = false
   }
-  connectionSftpAvailable.value = await api.checkSftpConnAvailable(connectionId.value)
-  emit('connectSSH', { isConnected: isConnected })
 }
 
 const {
@@ -1496,9 +1760,14 @@ const startShell = async () => {
       const removeErrorListener = api.onShellError(connectionId.value, (data) => {
         cusWrite?.(data)
       })
-      const removeCloseListener = api.onShellClose(connectionId.value, () => {
+      const removeCloseListener = api.onShellClose(connectionId.value, (closeInfo?: ShellCloseInfo) => {
         isConnected.value = false
-        cusWrite?.('\r\n' + t('ssh.connectionClosed') + '\r\n\r\n')
+        logger.info('Shell close received', {
+          event: 'ssh.shell.close.renderer',
+          connectionId: connectionId.value,
+          closeInfo
+        })
+        cusWrite?.('\r\n' + t('ssh.connectionClosed') + '\r\n')
         cusWrite?.(
           t('ssh.disconnectedFromHost', {
             host: props.serverInfo.title,
@@ -1506,6 +1775,44 @@ const startShell = async () => {
           }) + '\r\n'
         )
         cusWrite?.('\r\n' + t('ssh.pressEnterToReconnect') + '\r\n', { isUserCall: true })
+
+        // Manual disconnect should not trigger automatic reconnect.
+        if (manualDisconnectRequested.value) {
+          disconnectedByNetwork.value = false
+          waitingForNetworkRestore.value = false
+          return
+        }
+
+        const isNetworkDisconnect = closeInfo?.isNetworkDisconnect === true || closeInfo?.reason === 'network' || (!closeInfo && !navigator.onLine)
+        logger.info('Shell close classification', {
+          event: 'ssh.shell.close.classify.renderer',
+          connectionId: connectionId.value,
+          isNetworkDisconnect,
+          closeInfo,
+          navigatorOnLine: navigator.onLine
+        })
+        if (!isNetworkDisconnect) {
+          disconnectedByNetwork.value = false
+          waitingForNetworkRestore.value = false
+          return
+        }
+
+        // Start reconnect flow only for network-related disconnects.
+        disconnectedByNetwork.value = true
+        waitingForNetworkRestore.value = !navigator.onLine
+        autoReconnectAttempts.value = 0
+        const reasonText = closeInfo?.errorMessage || closeInfo?.errorCode || getAutoReconnectMessage('networkIssue')
+        writeAutoReconnectLog(
+          getAutoReconnectMessage('detectedNetworkDisconnect', {
+            reason: reasonText
+          })
+        )
+
+        if (navigator.onLine) {
+          scheduleAutoReconnect(0)
+        } else {
+          writeAutoReconnectLog(getAutoReconnectMessage('networkOfflineWaitingReconnect'))
+        }
       })
 
       cleanupListeners.value.push(removeDataListener, removeErrorListener, removeCloseListener)
@@ -2086,6 +2393,7 @@ const setupTerminalInput = () => {
       }
     } else if (data == '\r') {
       if (!isConnected.value) {
+        prepareManualReconnectAttempt()
         cusWrite?.('\r\n' + t('ssh.reconnecting') + '\r\n', { isUserCall: true })
         connectSSH()
         return
@@ -4374,6 +4682,12 @@ const handleKeyInput = (e) => {
 }
 
 const disconnectSSH = async () => {
+  manualDisconnectRequested.value = true
+  resetAutoReconnectState()
+  logger.info('Manual disconnect requested', {
+    event: 'ssh.disconnect.manual.renderer',
+    connectionId: connectionId.value
+  })
   try {
     const result = await api.disconnect({ id: connectionId.value })
     if (result.status === 'success') {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic SSH reconnection with exponential backoff, retry progress, countdowns, and clearer terminal status updates.
  * Network offline/online detection to pause/resume/retry reconnects and suppress reconnect after manual disconnects.
  * Shell-close events now provide structured reason and network-disconnect info to the UI.

* **Documentation**
  * Added auto-reconnect localization strings in 11 languages (en, de, fr, it, ja, ko, pt, ru, zh-CN, zh-TW, ar).

* **Tests**
  * Added tests covering disconnect classification (network/manual/unknown) and shell-close payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->