### PR TITLE
fix: update KNOWN_HASH for ffmpeg validation

### DIFF
--- a/scripts/verify-ffmpeg.js
+++ b/scripts/verify-ffmpeg.js
@@ -7,7 +7,7 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-const KNOWN_HASH = '2256D0112A047EC96E67B9F41FC8E7A692136F0DB6A756CCFE4B525826C5F240'
+const KNOWN_HASH = '925C6E1F3BC3A5A0214AA69F7DC1B2FFF8026A4CCEB8EEEF3640E7740BF07564'
 
 const ffmpegPath = path.join(__dirname, '../node_modules/electron/dist/ffmpeg.dll')
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -171,7 +171,7 @@ app.whenReady().then(async () => {
       try {
         const crypto = require('crypto')
         const ffmpegPath = path.join(path.dirname(process.execPath), 'ffmpeg.dll')
-        const KNOWN_HASH = '2256D0112A047EC96E67B9F41FC8E7A692136F0DB6A756CCFE4B525826C5F240'
+        const KNOWN_HASH = '925C6E1F3BC3A5A0214AA69F7DC1B2FFF8026A4CCEB8EEEF3640E7740BF07564'
 
         try {
           await fs.access(ffmpegPath)


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal integrity verification constants to maintain security validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->