### PR TITLE
feat: restrict telemetry data capture to global edition

### DIFF
--- a/src/main/agent/services/telemetry/TelemetryService.ts
+++ b/src/main/agent/services/telemetry/TelemetryService.ts
@@ -12,7 +12,7 @@ import os from 'os'
 import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs'
-import { getUserDataPath, getEdition } from '../../../config/edition'
+import { getUserDataPath, getEdition, isGlobalEdition } from '../../../config/edition'
 const logger = createLogger('agent')
 
 /**
@@ -147,10 +147,11 @@ class PostHogClient {
 
   /**
    * Captures a telemetry event if telemetry is enabled
+   * Only sends data to PostHog for the global edition
    * @param event The event to capture with its properties
    */
   public capture(event: { event: string; properties?: any }): void {
-    if (this.telemetryEnabled) {
+    if (this.telemetryEnabled && isGlobalEdition()) {
       const propertiesWithVersion = {
         ...event.properties,
         extension_version: this.version,


### PR DESCRIPTION
Updated the TelemetryService to only send telemetry data to PostHog when the global edition is active. This change enhances data management by ensuring that telemetry events are captured selectively based on the edition type.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry event submission now includes an additional global edition check before sending analytics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->