### PR TITLE
refactor: rename 'extensions' to 'plugins' in localization files and update UI references

### DIFF
--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -497,7 +497,7 @@ export default {
     saveBackgroundFailed: 'فشل حفظ صورة الخلفية'
   },
   extensions: {
-    plugins: 'الامتدادات',
+    plugins: 'الإضافات',
     alias: 'الاسم المستعار',
     aliasDescription: 'إعدادات الاسم المستعار العالمية',
     fuzzySearch: 'البحث الضبابي',

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -497,7 +497,7 @@ export default {
     saveBackgroundFailed: 'فشل حفظ صورة الخلفية'
   },
   extensions: {
-    extensions: 'الامتدادات',
+    plugins: 'الامتدادات',
     alias: 'الاسم المستعار',
     aliasDescription: 'إعدادات الاسم المستعار العالمية',
     fuzzySearch: 'البحث الضبابي',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -517,7 +517,7 @@ export default {
     saveBackgroundFailed: 'Hintergrundbild speichern fehlgeschlagen'
   },
   extensions: {
-    extensions: 'Erweiterungen',
+    plugins: 'Plugins',
     alias: 'Alias',
     aliasDescription: 'Globale Alias-Konfiguration',
     fuzzySearch: 'Fuzzy-Suche',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -513,7 +513,7 @@ export default {
     saveBackgroundFailed: 'Failed to save background image'
   },
   extensions: {
-    extensions: 'Extensions',
+    plugins: 'Plugins',
     alias: 'Alias',
     aliasDescription: 'Global alias config',
     fuzzySearch: 'Fuzzy Search',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -517,7 +517,7 @@ export default {
     saveBackgroundFailed: "Échec de la sauvegarde de l'image de fond"
   },
   extensions: {
-    extensions: 'Extensions',
+    plugins: 'Plugins',
     alias: 'Alias',
     aliasDescription: 'Configuration globale des alias',
     fuzzySearch: 'Recherche floue',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -517,7 +517,7 @@ export default {
     saveBackgroundFailed: 'Salvataggio immagine di sfondo fallito'
   },
   extensions: {
-    extensions: 'Estensioni',
+    plugins: 'Plugins',
     alias: 'Alias',
     aliasDescription: 'Configurazione alias globale',
     fuzzySearch: 'Ricerca approssimativa',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -512,7 +512,7 @@ export default {
     saveBackgroundFailed: '背景画像の保存に失敗しました'
   },
   extensions: {
-    extensions: '拡張機能',
+    plugins: 'プラグイン',
     alias: 'エイリアス',
     aliasDescription: 'グローバルエイリアス設定',
     fuzzySearch: 'あいまい検索',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -507,7 +507,7 @@ export default {
     saveBackgroundFailed: '배경 이미지 저장 실패'
   },
   extensions: {
-    extensions: '확장 기능',
+    plugins: '플러그인',
     alias: '별칭',
     aliasDescription: '전역 별칭 설정',
     fuzzySearch: '모호한 검색',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -516,7 +516,7 @@ export default {
     saveBackgroundFailed: 'Falha ao guardar imagem de fundo'
   },
   extensions: {
-    extensions: 'Extensões',
+    plugins: 'Plugins',
     alias: 'Alias',
     aliasDescription: 'Configuração global de alias',
     fuzzySearch: 'Pesquisa difusa',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -516,7 +516,7 @@ export default {
     saveBackgroundFailed: 'Не удалось сохранить фоновое изображение'
   },
   extensions: {
-    extensions: 'Расширения',
+    plugins: 'Плагины',
     alias: 'Псевдоним',
     aliasDescription: 'Глобальная конфигурация псевдонимов',
     fuzzySearch: 'Поиск похожих',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -505,7 +505,7 @@ export default {
     saveBackgroundFailed: '保存背景图片失败'
   },
   extensions: {
-    extensions: '扩展',
+    plugins: '插件',
     alias: '别名',
     fuzzySearch: '模糊搜索',
     aliasDescription: '全局Alias配置',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -507,7 +507,7 @@ export default {
     saveBackgroundFailed: '保存背景圖片失敗'
   },
   extensions: {
-    extensions: '擴展',
+    plugins: '插件',
     alias: '別名',
     fuzzySearch: '模糊搜尋',
     aliasDescription: '全局Alias設置',

--- a/src/renderer/src/views/components/Extensions/__tests__/index.test.ts
+++ b/src/renderer/src/views/components/Extensions/__tests__/index.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+import ExtensionsComponent from '../index.vue'
+import { notification } from 'ant-design-vue'
+import { userConfigStore } from '@/services/userConfigStoreService'
+import { getPluginDownload, getPluginIconUrl } from '@/api/plugin/plugin'
+import { usePluginStore } from '../usePlugins'
+
+const pluginListRef = ref<any[]>([])
+const loadPluginsMock = vi.fn()
+const loadStorePluginsMock = vi.fn()
+const uninstallLocalPluginMock = vi.fn()
+
+const apiMock = {
+  getPathForFile: vi.fn(),
+  installPlugin: vi.fn(),
+  installPluginFromBuffer: vi.fn(),
+  getInstallHint: vi.fn()
+}
+
+Object.defineProperty(globalThis, 'createRendererLogger', {
+  configurable: true,
+  writable: true,
+  value: vi.fn(() => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  }))
+})
+
+Object.defineProperty(window, 'api', {
+  configurable: true,
+  writable: true,
+  value: apiMock
+})
+
+Object.defineProperty(window, 'open', {
+  configurable: true,
+  writable: true,
+  value: vi.fn()
+})
+
+vi.mock('@/assets/img/alias.svg', () => ({ default: '/mock/alias.svg' }))
+vi.mock('@/assets/img/jumpserver.svg', () => ({ default: '/mock/jumpserver.svg' }))
+
+vi.mock('@/locales', () => {
+  const mockT = (key: string) => key
+  return {
+    default: {
+      global: {
+        t: mockT
+      }
+    }
+  }
+})
+
+vi.mock('ant-design-vue', () => ({
+  notification: {
+    open: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+vi.mock('@/utils/eventBus', () => ({
+  default: {
+    on: vi.fn(),
+    off: vi.fn()
+  }
+}))
+
+vi.mock('@/services/userConfigStoreService', () => ({
+  userConfigStore: {
+    getConfig: vi.fn()
+  }
+}))
+
+vi.mock('@/api/plugin/plugin', () => ({
+  getPluginDownload: vi.fn(),
+  getPluginIconUrl: vi.fn()
+}))
+
+vi.mock('../usePlugins', () => ({
+  usePluginStore: vi.fn()
+}))
+
+describe('Extensions index.vue', () => {
+  let wrapper: VueWrapper<any>
+
+  const createWrapper = () =>
+    mount(ExtensionsComponent, {
+      global: {
+        stubs: {
+          'search-outlined': true,
+          CloudDownloadOutlined: true,
+          CloudSyncOutlined: true,
+          CrownOutlined: true,
+          'a-input': {
+            template: `
+              <input
+                class="a-input"
+                :value="value"
+                :placeholder="placeholder"
+                @input="$emit('update:value', $event.target.value)"
+              />
+            `,
+            props: ['value', 'placeholder'],
+            emits: ['update:value']
+          },
+          'a-menu': {
+            template: '<div class="a-menu"><slot /></div>'
+          },
+          'a-menu-item': {
+            template: '<div class="a-menu-item"><slot /></div>'
+          },
+          'a-button': {
+            template: '<button class="a-button" @click="$emit(\'click\', $event)"><slot name="icon" /><slot /></button>',
+            props: ['loading'],
+            emits: ['click']
+          },
+          'a-tooltip': {
+            template: '<div class="a-tooltip"><slot /></div>'
+          },
+          'a-tag': {
+            template: '<span class="a-tag"><slot /></span>'
+          }
+        },
+        mocks: {
+          $t: (key: string) => key
+        }
+      }
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pluginListRef.value = []
+    ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      aliasStatus: 1,
+      theme: 'dark'
+    })
+    ;(usePluginStore as ReturnType<typeof vi.fn>).mockReturnValue({
+      pluginList: pluginListRef,
+      loadPlugins: loadPluginsMock,
+      loadStorePlugins: loadStorePluginsMock,
+      uninstallLocalPlugin: uninstallLocalPluginMock
+    })
+    ;(getPluginIconUrl as ReturnType<typeof vi.fn>).mockResolvedValue('https://cdn.example/icon.png')
+    ;(getPluginDownload as ReturnType<typeof vi.fn>).mockResolvedValue({
+      headers: {
+        'content-disposition': 'attachment; filename="pluginA-1.0.0.chaterm"'
+      }
+    })
+    apiMock.getInstallHint.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('renders built-in and store plugins', async () => {
+    pluginListRef.value = [
+      {
+        name: 'Plugin A',
+        description: 'desc',
+        iconKey: '',
+        iconUrl: '',
+        tabName: 'Plugin A',
+        show: true,
+        isPlugin: true,
+        pluginId: 'pluginA',
+        installed: false,
+        hasUpdate: false,
+        latestVersion: '1.0.0',
+        installable: true
+      }
+    ]
+
+    wrapper = createWrapper()
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Jumpserver Support')
+    expect(wrapper.text()).toContain('Alias')
+    expect(wrapper.text()).toContain('Plugin A')
+  })
+
+  it('hides Alias when aliasStatus is disabled', async () => {
+    ;(userConfigStore.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      aliasStatus: 2,
+      theme: 'dark'
+    })
+
+    wrapper = createWrapper()
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Alias')
+  })
+
+  it('emits special route for Alias item', async () => {
+    wrapper = createWrapper()
+    await nextTick()
+
+    wrapper.vm.handleSelect({ key: 'Alias' })
+    await nextTick()
+
+    expect(wrapper.emitted('open-user-tab')?.[0]).toEqual(['aliasConfig'])
+  })
+
+  it('emits plugin payload for plugin item', async () => {
+    pluginListRef.value = [
+      {
+        name: 'Plugin A',
+        description: 'desc',
+        iconKey: '',
+        iconUrl: '',
+        tabName: 'Plugin A',
+        show: true,
+        isPlugin: true,
+        pluginId: 'pluginA',
+        installed: true,
+        hasUpdate: false,
+        installedVersion: '1.0.0',
+        latestVersion: '1.0.0'
+      }
+    ]
+
+    wrapper = createWrapper()
+    await nextTick()
+
+    wrapper.vm.handleSelect({ key: 'pluginA' })
+    await nextTick()
+
+    expect(wrapper.emitted('open-user-tab')?.[0]).toEqual([
+      {
+        key: 'plugins:Plugin A',
+        fromLocal: true,
+        pluginId: 'pluginA'
+      }
+    ])
+  })
+
+  it('shows error notification when dropped file path cannot be resolved', async () => {
+    apiMock.getPathForFile.mockReturnValue(undefined)
+    wrapper = createWrapper()
+    await nextTick()
+
+    await wrapper.vm.onDrop({
+      dataTransfer: { files: [{}] }
+    })
+
+    expect(notification.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows warning for non-chaterm dropped file', async () => {
+    apiMock.getPathForFile.mockReturnValue('/tmp/test.zip')
+    wrapper = createWrapper()
+    await nextTick()
+
+    await wrapper.vm.onDrop({
+      dataTransfer: { files: [{}] }
+    })
+
+    expect(notification.warning).toHaveBeenCalledTimes(1)
+  })
+
+  it('installs plugin from store when install button clicked', async () => {
+    pluginListRef.value = [
+      {
+        name: 'Plugin A',
+        description: 'desc',
+        iconKey: '',
+        iconUrl: '',
+        tabName: 'Plugin A',
+        show: true,
+        isPlugin: true,
+        pluginId: 'pluginA',
+        installed: false,
+        hasUpdate: false,
+        latestVersion: '1.0.0',
+        installable: true
+      }
+    ]
+
+    wrapper = createWrapper()
+    await nextTick()
+
+    const button = wrapper.find('.a-button')
+    await button.trigger('click')
+    await nextTick()
+    await Promise.resolve()
+
+    expect(getPluginDownload).toHaveBeenCalledWith('pluginA', '1.0.0')
+    expect(apiMock.installPluginFromBuffer).toHaveBeenCalled()
+    expect(loadPluginsMock).toHaveBeenCalled()
+    expect(notification.success).toHaveBeenCalled()
+  })
+
+  it('opens pricing url for non-installable plugin subscribe action', async () => {
+    pluginListRef.value = [
+      {
+        name: 'Private Plugin',
+        description: 'desc',
+        iconKey: '',
+        iconUrl: '',
+        tabName: 'Private Plugin',
+        show: true,
+        isPlugin: true,
+        pluginId: 'private-plugin',
+        installed: false,
+        hasUpdate: false,
+        latestVersion: '1.0.0',
+        installable: false
+      }
+    ]
+
+    wrapper = createWrapper()
+    await nextTick()
+
+    const button = wrapper.find('.a-button')
+    await button.trigger('click')
+
+    expect(window.open).toHaveBeenCalledWith('https://github.com/chaterm/Chaterm/discussions/1521', '_blank')
+  })
+})

--- a/src/renderer/src/views/components/Extensions/index.vue
+++ b/src/renderer/src/views/components/Extensions/index.vue
@@ -5,7 +5,7 @@
     @drop.prevent="onDrop"
   >
     <div class="panel_header">
-      <span class="panel_title">{{ t('extensions.extensions') }}</span>
+      <span class="panel_title">{{ t('extensions.plugins') }}</span>
     </div>
 
     <div class="search_box">

--- a/src/renderer/src/views/components/LeftTab/constants/data.ts
+++ b/src/renderer/src/views/components/LeftTab/constants/data.ts
@@ -25,7 +25,7 @@ const menuTabsData = [
     icon: new URL('@/assets/menu/doc.svg', import.meta.url).href
   },
   {
-    name: 'Extensions',
+    name: 'Plugins',
     key: 'extensions',
     icon: new URL('@/assets/menu/extensions.svg', import.meta.url).href
   },


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Rebranded "Extensions" to "Plugins" across the UI in all supported languages.
  * Left navigation and panel headers updated to the new terminology.

* **Tests**
  * Added comprehensive tests for the Plugins component covering rendering, interactions, drop/install flows, notifications, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->