### PR TITLE
feat: enhance context truncation notifications and UI

### DIFF
--- a/src/main/agent/core/task/index.ts
+++ b/src/main/agent/core/task/index.ts
@@ -1458,7 +1458,7 @@ export class Task {
           ...(hostInfo ?? {})
         })
         await this.postStateToWebview()
-        if (type === 'command_output') {
+        if (type === 'command_output' || type === 'context_truncated') {
           const newMsg = this.chatermMessages.at(-1)!
           await this.postMessageToWebview({
             type: 'partialMessage',
@@ -2046,9 +2046,10 @@ export class Task {
     const userLocale = await this.getUserLocale()
     this.contextManager.setLanguage(userLocale)
 
-    // Notify the user before the potentially slow truncation + summarization process
-    if (this.contextManager.needsTruncation(this.chatermMessages, this.api, previousApiReqIndex)) {
-      await this.say('context_truncated', JSON.stringify({ contextWindow: this.api.getModel().info.contextWindow }), false)
+    // Notify the user before the potentially slow truncation + summarization process.
+    const needsContextTruncation = this.contextManager.needsTruncation(this.chatermMessages, this.api, previousApiReqIndex)
+    if (needsContextTruncation) {
+      await this.say('context_truncated', JSON.stringify({ status: 'compressing', contextWindow: this.api.getModel().info.contextWindow }), true)
     }
 
     const contextManagementMetadata = await this.contextManager.getNewContextMessagesAndMetadata(
@@ -2068,6 +2069,10 @@ export class Task {
         taskId: this.taskId,
         deletedRange: contextManagementMetadata.conversationHistoryDeletedRange
       })
+    }
+
+    if (needsContextTruncation) {
+      await this.say('context_truncated', JSON.stringify({ status: 'completed', contextWindow: this.api.getModel().info.contextWindow }), false)
     }
 
     // Apply summarizeUpToTs filter if specified

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -958,7 +958,8 @@ export default {
     clearSelection: 'مسح الاختيار',
     addSelected: 'إضافة المختار ({count})',
     switchNotSupportAgent: 'الأجهزة الشبكية لا تدعم وضع الذكاء الاصطناعي, تم التبديل تلقائيا إلى وضع الأمر',
-    contextTruncated: 'جارٍ ضغط الرسائل السابقة لتحرير مساحة السياق. تم الاحتفاظ بالرسائل الأخيرة.'
+    contextTruncating: 'يجري ضغط معلومات السياق تلقائياً',
+    contextTruncated: 'تم ضغط معلومات السياق تلقائياً'
   },
   keyChain: {
     keyChain: 'مفتاح الكي',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -986,7 +986,8 @@ export default {
     clearSelection: 'Auswahl löschen',
     addSelected: 'Ausgewählte hinzufügen({count})',
     switchNotSupportAgent: 'Netzwerkgeräte unterstützen kein Agent-Modus, automatisch zum Command-Modus gewechselt',
-    contextTruncated: 'Frühere Nachrichten werden komprimiert, um Kontextplatz freizugeben. Aktuelle Nachrichten bleiben erhalten.'
+    contextTruncating: 'Kontextinformationen werden automatisch komprimiert',
+    contextTruncated: 'Kontextinformationen wurden automatisch komprimiert'
   },
   keyChain: {
     keyChain: 'Schlüsselkette',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -981,7 +981,8 @@ export default {
     clearSelection: 'Clear',
     addSelected: 'Add selected({count})',
     switchNotSupportAgent: 'Network devices do not support Agent mode, automatically switched to Command mode',
-    contextTruncated: 'Compressing earlier messages to free up context space. Recent messages are preserved.'
+    contextTruncating: 'Compressing context automatically',
+    contextTruncated: 'Context compressed automatically'
   },
   keyChain: {
     keyChain: 'KeyChain',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -991,7 +991,8 @@ export default {
     clearSelection: 'Effacer',
     addSelected: 'Ajouter la sélection({count})',
     switchNotSupportAgent: 'Les appareils réseau ne prennent en charge que le mode de commande, automatiquement basculé vers le mode de commande',
-    contextTruncated: "Compression des messages anciens pour libérer de l'espace contextuel. Les messages récents sont conservés."
+    contextTruncating: 'Compression automatique des informations de contexte en cours',
+    contextTruncated: 'Les informations de contexte ont été compressées automatiquement'
   },
   keyChain: {
     keyChain: 'Trousseau de clés',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -985,7 +985,8 @@ export default {
     clearSelection: 'Cancella',
     addSelected: 'Aggiungi selezionati({count})',
     switchNotSupportAgent: 'Dispositivi di rete non supportano modalità Agent, automaticamente cambiato a modalità Comando',
-    contextTruncated: 'Compressione dei messaggi precedenti per liberare spazio nel contesto. I messaggi recenti sono conservati.'
+    contextTruncating: 'Compressione automatica delle informazioni di contesto in corso',
+    contextTruncated: 'Le informazioni di contesto sono state compresse automaticamente'
   },
   keyChain: {
     keyChain: 'Keychain',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -976,7 +976,8 @@ export default {
     clearSelection: 'クリア',
     addSelected: '選択項目を追加({count})',
     switchNotSupportAgent: 'ネットワーク機器はAgentモードをサポートしていません。Commandモードに自動切り替えしました',
-    contextTruncated: 'コンテキスト領域を確保するため、以前のメッセージを圧縮しています。最近のメッセージは保持されます。'
+    contextTruncating: 'コンテキスト情報を自動圧縮しています',
+    contextTruncated: 'コンテキスト情報は自動圧縮されました'
   },
   keyChain: {
     keyChain: 'キーチェーン',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -971,7 +971,8 @@ export default {
     clearSelection: '선택 지우기',
     addSelected: '선택 추가({count})',
     switchNotSupportAgent: '네트워크 장치는 Agent 모드를 지원하지 않습니다. Command 모드로 자동 전환되었습니다',
-    contextTruncated: '컨텍스트 공간 확보를 위해 이전 메시지를 압축하고 있습니다. 최근 메시지는 유지됩니다.'
+    contextTruncating: '컨텍스트 정보를 자동으로 압축하는 중입니다',
+    contextTruncated: '컨텍스트 정보가 자동으로 압축되었습니다'
   },
   keyChain: {
     keyChain: '키체인',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -984,7 +984,8 @@ export default {
     clearSelection: 'Limpar',
     addSelected: 'Adicionar selecionados({count})',
     switchNotSupportAgent: 'Dispositivos de rede não suportam modo Agent, automaticamente mudado para modo Command',
-    contextTruncated: 'A comprimir mensagens anteriores para libertar espaço de contexto. As mensagens recentes foram preservadas.'
+    contextTruncating: 'A comprimir automaticamente a informação de contexto',
+    contextTruncated: 'A informação de contexto foi comprimida automaticamente'
   },
   keyChain: {
     keyChain: 'Keychain',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -983,7 +983,8 @@ export default {
     clearSelection: 'Очистить',
     addSelected: 'Добавить выбранные({count})',
     switchNotSupportAgent: 'Сетевые устройства не поддерживают режим Agent, автоматически переключен на режим Command',
-    contextTruncated: 'Сжатие ранних сообщений для освобождения контекстного пространства. Недавние сообщения сохранены.'
+    contextTruncating: 'Идёт автоматическое сжатие контекстной информации',
+    contextTruncated: 'Контекстная информация автоматически сжата'
   },
   keyChain: {
     keyChain: 'KeyChain',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -966,7 +966,8 @@ export default {
     clearSelection: '清空',
     addSelected: '添加所选({count})',
     switchNotSupportAgent: '网络设备不支持 Agent 模式，已自动切换为 Command 模式',
-    contextTruncated: '为释放上下文空间，较早的对话内容正在压缩，近期消息已保留。'
+    contextTruncating: '正在自动压缩上下文信息',
+    contextTruncated: '上下文信息已自动压缩'
   },
   keyChain: {
     keyChain: '密钥',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -967,7 +967,8 @@ export default {
     clearSelection: '清空',
     addSelected: '新增所選({count})',
     switchNotSupportAgent: '網路設備不支持 Agent 模式，已自動切換為 Command 模式',
-    contextTruncated: '為釋放上下文空間，較早的對話內容正在壓縮，近期訊息已保留。'
+    contextTruncating: '正在自動壓縮上下文資訊',
+    contextTruncated: '上下文資訊已自動壓縮'
   },
   keyChain: {
     keyChain: '密鑰',

--- a/src/renderer/src/views/components/AiTab/composables/useChatMessages.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useChatMessages.ts
@@ -559,12 +559,12 @@ export function useChatMessages(
       }
     } else if (message?.type === 'state') {
       const chatermMessages = message.state?.chatermMessages ?? []
+      const lastStateChatermMessages = chatermMessages.at(-1)
       // Cache chatermMessages so contextUsage remains stable when
       // partialMessage overwrites lastStreamMessage during streaming.
       if (chatermMessages.length > 0) {
         session.lastStateChatermMessages = chatermMessages
       }
-      const lastStateChatermMessages = chatermMessages.at(-1)
       const isWaitingForUserResponse =
         lastStateChatermMessages?.type === 'ask' ||
         lastStateChatermMessages?.say === 'command_blocked' ||

--- a/src/renderer/src/views/components/AiTab/composables/useExportChat.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useExportChat.ts
@@ -9,6 +9,22 @@ export function useExportChat() {
   const { chatHistory, currentChatTitle } = useSessionState()
   const { t } = i18n.global
 
+  const getContextTruncationText = (msg: ChatMessage): string => {
+    const text = extractContent(msg.content)
+    try {
+      const parsed = JSON.parse(text) as { status?: 'compressing' | 'completed' }
+      if (parsed.status === 'compressing') {
+        return t('ai.contextTruncating')
+      }
+      if (parsed.status === 'completed') {
+        return t('ai.contextTruncated')
+      }
+    } catch {
+      // Keep compatibility with legacy plain-text exports.
+    }
+    return msg.partial ? t('ai.contextTruncating') : text || t('ai.contextTruncated')
+  }
+
   const generateFileName = (): string => {
     const title = (currentChatTitle.value || 'chat').slice(0, 30)
     const safeTitle = title.replace(/[/\\?%*:|"<>]/g, '-').trim()
@@ -62,6 +78,11 @@ export function useExportChat() {
 
     if (msg.say === 'search_result') {
       return text ? `${role}\n\n**Search Result**\n\`\`\`\n${text}\n\`\`\`\n` : ''
+    }
+
+    if (msg.say === 'context_truncated') {
+      const truncationText = getContextTruncationText(msg)
+      return truncationText ? `${role}\n\n${truncationText}\n` : ''
     }
 
     if (msg.action === 'approved') return `${role}\n\n✅ Approved\n`

--- a/src/renderer/src/views/components/AiTab/index.less
+++ b/src/renderer/src/views/components/AiTab/index.less
@@ -1371,19 +1371,49 @@
 }
 
 .context-truncated-notice {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 6px;
-  margin: 4px 8px;
-  padding: 4px 10px;
-  border-radius: 4px;
-  background-color: rgba(59, 130, 246, 0.1);
-  border: 1px solid rgba(59, 130, 246, 0.25);
-  font-size: 12px;
-  line-height: 1.5;
-  color: #3b82f6;
+  gap: 12px;
+  width: 100%;
+  margin: 8px 0 12px;
+  color: var(--text-color-tertiary);
+  font-size: 13px;
+  line-height: 1.4;
+
+  .context-truncated-line {
+    flex: 1;
+    min-width: 24px;
+    height: 1px;
+    background: var(--border-color-light);
+  }
+
+  .context-truncated-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
 
   .context-truncated-icon {
     font-size: 14px;
+    color: currentColor;
+  }
+
+  &.is-compressing {
+    color: var(--text-color-secondary);
+
+    .context-truncated-icon {
+      animation: context-truncated-spin 1.4s linear infinite;
+    }
+  }
+}
+
+@keyframes context-truncated-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/renderer/src/views/components/AiTab/index.vue
+++ b/src/renderer/src/views/components/AiTab/index.vue
@@ -143,9 +143,14 @@
                   <div
                     v-if="message.say === 'context_truncated'"
                     class="context-truncated-notice"
+                    :class="{ 'is-compressing': isContextTruncationInProgress(message) }"
                   >
-                    <CompressOutlined class="context-truncated-icon" />
-                    <span>{{ $t('ai.contextTruncated') }}</span>
+                    <span class="context-truncated-line" />
+                    <span class="context-truncated-content">
+                      <CompressOutlined class="context-truncated-icon" />
+                      <span>{{ getContextTruncationNotice(message) }}</span>
+                    </span>
+                    <span class="context-truncated-line" />
                   </div>
                   <div
                     v-else
@@ -1003,6 +1008,40 @@ const {
 // i18n
 const { t } = i18n.global
 const favoriteLabel = computed(() => t('ai.favorite'))
+
+type ContextTruncationStatus = 'compressing' | 'completed'
+
+interface ContextTruncationNoticeMessage {
+  text?: string
+  content?: string | MessageContent
+  partial?: boolean
+}
+
+const parseContextTruncationStatus = (message: ContextTruncationNoticeMessage): ContextTruncationStatus => {
+  const rawText = typeof message.content === 'string' ? message.content : message.text
+  if (!rawText) {
+    return message.partial ? 'compressing' : 'completed'
+  }
+
+  try {
+    const parsed = JSON.parse(rawText) as { status?: ContextTruncationStatus }
+    if (parsed.status === 'compressing' || parsed.status === 'completed') {
+      return parsed.status
+    }
+  } catch {
+    // Keep compatibility with legacy persisted plain-text messages.
+  }
+
+  return message.partial ? 'compressing' : 'completed'
+}
+
+const isContextTruncationInProgress = (message: ContextTruncationNoticeMessage): boolean => {
+  return parseContextTruncationStatus(message) === 'compressing'
+}
+
+const getContextTruncationNotice = (message: ContextTruncationNoticeMessage): string => {
+  return isContextTruncationInProgress(message) ? t('ai.contextTruncating') : t('ai.contextTruncated')
+}
 
 // Event bus listeners
 useEventBusListeners({


### PR DESCRIPTION
Updated the context truncation handling in the Task class to include additional message types and improved user notifications. The UI now reflects the context truncation status with new styles and animations, providing clearer feedback during the compression process. Localization files have been updated to support the new context messages across multiple languages.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context compression now displays real-time progress, with distinct notifications distinguishing between in-progress compression and completion states.

* **Internationalization**
  * Updated context compression messages across 11 languages to reflect two-phase compression states.

* **Style**
  * Enhanced context compression notice design with progress animation during active compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->