### PR TITLE
chore(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/first-time-contributor-welcome.yml
+++ b/.github/workflows/first-time-contributor-welcome.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   welcome-contributor:
     name: Welcome First Time Contributor

--- a/.github/workflows/first-time-contributor-welcome.yml
+++ b/.github/workflows/first-time-contributor-welcome.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check if first time contributor
         id: check
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9.0.0
         with:
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({
@@ -33,7 +33,7 @@ jobs:
 
       - name: Welcome first time contributor
         if: steps.check.outputs.isFirstTime == 'true'
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Auto Comment on Issues Closed
         if: github.event.issue.state == 'closed'
-        uses: wow-actions/auto-comment@v1
+        uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issuesClosed: |
@@ -33,7 +33,7 @@ jobs:
 
       - name: Auto Comment on Pull Request Merged
         if: github.event.pull_request.merged == true
-        uses: actions-cool/pr-welcome@v1
+        uses: actions-cool/pr-welcome@db204e23d550b47b449c97f19ddd13367936ffd7 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Remove inactive label
         if: github.event.issue.state == 'open' && github.actor == github.event.issue.user.login
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'remove-labels'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Welcome message
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   welcome:
     name: Welcome New Issues

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -4,10 +4,15 @@ on:
   pull_request:
     types: [opened, edited, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     name: pr-title-checker
+    permissions:
+      pull-requests: write
     steps:
       - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
         with:

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: pr-title-checker
     steps:
-      - uses: thehanimo/pr-title-checker@v1.4.3
+      - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           configuration_path: '.github/pr-title-checker-config.json'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: '30 1 * * 1'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.0.0
         with:
           node-version: 20.x
 
@@ -31,7 +31,7 @@ jobs:
         run: npm audit --json > audit-report.json || true
 
       - name: Upload audit report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         if: always()
         with:
           name: npm-audit-report
@@ -44,17 +44,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Full history for better detection
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TruffleHog (OSS)
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@794a6e5211d8b9c554a27a582c68e71189c5c33a # main
         with:
           extra_args: --only-verified
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # Dependency vulnerability audit
   dependency-audit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Enable long paths for Windows (filenames > 260 chars)
           config: core.longpaths=true
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.0.0
         with:
           node-version: 22.x
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
         shell: bash
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.2.3
         id: playwright-cache
         with:
           path: ${{ steps.playwright-path.outputs.path }}
@@ -92,7 +92,7 @@ jobs:
           CI: true
 
       - name: Save Coverage Reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         # Only upload artifacts on macOS - We only need coverage from one OS
         if: runner.os == 'macOS'
         with:
@@ -100,7 +100,7 @@ jobs:
           path: coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.1
         if: runner.os == 'macOS'
         with:
           files: ./coverage/coverage-final.json


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions security by implementing explicit workflow-level permissions and pinning third-party action dependencies to specific commit versions instead of floating tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->