### PR TITLE
feat: add stripHtmlLikeTags function for HTML tag removal and refactor related usages in remote-terminal and web-fetch modules

### DIFF
--- a/src/main/agent/integrations/remote-terminal/__tests__/marker-based-runner.test.ts
+++ b/src/main/agent/integrations/remote-terminal/__tests__/marker-based-runner.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
 import { runMarkerBasedCommand, type MarkerStream, type MarkerRunnerConfig } from '../marker-based-runner'
 
+function stripHtmlLikeTags(text: string): string {
+  let result = ''
+  let inTag = false
+
+  for (const char of text) {
+    if (char === '<') {
+      inTag = true
+      continue
+    }
+    if (char === '>' && inTag) {
+      inTag = false
+      continue
+    }
+    if (!inTag) {
+      result += char
+    }
+  }
+
+  return result
+}
+
 // Create a mock stream
 const createMockStream = (): MarkerStream & { emitData: (data: string) => void } => {
   const emitter = new EventEmitter()
@@ -23,7 +44,7 @@ const createConfig = (stream: MarkerStream, overrides: Partial<MarkerRunnerConfi
   logPrefix: 'test',
   timeoutMs: 5000,
   isListening: () => true,
-  stripForDetect: (v) => v.replace(/<[^>]*>/g, ''),
+  stripForDetect: stripHtmlLikeTags,
   renderForDisplay: (v) => v,
   shouldFilterEcho: () => false,
   onLine: vi.fn(),

--- a/src/main/agent/integrations/remote-terminal/index.ts
+++ b/src/main/agent/integrations/remote-terminal/index.ts
@@ -58,6 +58,10 @@ try {
   packageInfo = { name: 'chaterm', version: 'unknown' }
 }
 
+const createSecureIdSegment = (length = 12): string => {
+  return randomUUID().replace(/-/g, '').slice(0, length)
+}
+
 export interface RemoteTerminalProcessEvents extends Record<string, any[]> {
   line: [line: string]
   continue: []
@@ -432,7 +436,7 @@ export class RemoteTerminalProcess extends BrownEventEmitter<RemoteTerminalProce
   private buildJumpServerWrappedCommand(command: string, cleanCwd?: string): { wrappedCommand: string; startMarker: string; endMarker: string } {
     // Generate unique markers for output tracking
     const timestamp = Date.now()
-    const randomId = randomUUID().replace(/-/g, '').slice(0, 12)
+    const randomId = createSecureIdSegment()
     const startMarker = `===CHATERM_START_${timestamp}_${randomId}===`
     const endMarker = `===CHATERM_END_${timestamp}_${randomId}===`
 
@@ -939,7 +943,7 @@ export class RemoteTerminalManager {
       // Choose connection method based on sshType
       if (sshType === 'jumpserver') {
         // Use JumpServer connection
-        const jumpServerSessionId = `jumpserver_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`
+        const jumpServerSessionId = `jumpserver_${Date.now()}_${createSecureIdSegment()}`
         const assetUuid = this.connectionInfo.assetUuid || this.connectionInfo.id || jumpServerSessionId
         const jumpServerConnectionInfo = {
           id: jumpServerSessionId,
@@ -969,7 +973,7 @@ export class RemoteTerminalManager {
         if (!bastionCapability) {
           throw new Error(`${sshType} plugin not installed`)
         }
-        const bastionSessionId = `${sshType}_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 12)}`
+        const bastionSessionId = `${sshType}_${Date.now()}_${createSecureIdSegment()}`
         const bastionHost = this.connectionInfo.asset_ip || this.connectionInfo.host
         if (!bastionHost) {
           throw new Error(`${sshType} bastion host is missing`)

--- a/src/main/agent/integrations/remote-terminal/index.ts
+++ b/src/main/agent/integrations/remote-terminal/index.ts
@@ -168,6 +168,27 @@ function stripAnsiSimple(text: string): string {
     .replace(/\r/g, '')
 }
 
+function stripHtmlLikeTags(text: string): string {
+  let result = ''
+  let inTag = false
+
+  for (const char of text) {
+    if (char === '<') {
+      inTag = true
+      continue
+    }
+    if (char === '>' && inTag) {
+      inTag = false
+      continue
+    }
+    if (!inTag) {
+      result += char
+    }
+  }
+
+  return result
+}
+
 // ANSI color name lookup
 const ANSI_COLOR_NAMES = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white']
 
@@ -720,9 +741,7 @@ export class RemoteTerminalProcess extends BrownEventEmitter<RemoteTerminalProce
 
     // JumpServer-specific command echo detection
     const isCommandEcho = (line: string): boolean => {
-      const cleanLine = processAnsiCodes(line)
-        .replace(/<[^>]*>/g, '')
-        .trim()
+      const cleanLine = stripHtmlLikeTags(processAnsiCodes(line)).trim()
 
       return (
         cleanLine.startsWith('bash -l -c') ||
@@ -740,7 +759,7 @@ export class RemoteTerminalProcess extends BrownEventEmitter<RemoteTerminalProce
       logPrefix,
       timeoutMs: this.JUMPSERVER_COMMAND_TIMEOUT,
       isListening: () => this.isListening,
-      stripForDetect: (v) => processAnsiCodes(v).replace(/<[^>]*>/g, ''),
+      stripForDetect: (v) => stripHtmlLikeTags(processAnsiCodes(v)),
       renderForDisplay: processAnsiCodes,
       shouldFilterEcho: isCommandEcho,
       onLine: (line) => this.emit('line', line),

--- a/src/main/agent/services/web-fetch/__tests__/web-fetch-visibility.test.ts
+++ b/src/main/agent/services/web-fetch/__tests__/web-fetch-visibility.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeHtml, stripInvisibleUnicode } from '../web-fetch-visibility'
+
+describe('web-fetch-visibility', () => {
+  it('removes comment nodes through DOM traversal', async () => {
+    const sanitized = await sanitizeHtml('<div>safe<!-- hidden --><span>text</span></div>')
+
+    expect(sanitized).toContain('safe')
+    expect(sanitized).toContain('text')
+    expect(sanitized).not.toContain('hidden')
+    expect(sanitized).not.toContain('<!--')
+  })
+
+  it('removes invisible unicode characters until stable', () => {
+    const text = `a\u200Bb\u2060c\uFEFFd`
+
+    expect(stripInvisibleUnicode(text)).toBe('abcd')
+  })
+})

--- a/src/main/agent/services/web-fetch/web-fetch-utils.ts
+++ b/src/main/agent/services/web-fetch/web-fetch-utils.ts
@@ -59,29 +59,29 @@ function normalizeWhitespace(value: string): string {
 }
 
 export function htmlToMarkdown(html: string): { text: string; title?: string } {
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title\s*>/i)
   const title = titleMatch ? normalizeWhitespace(stripTags(titleMatch[1])) : undefined
   let text = html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<noscript[\s\S]*?<\/noscript>/gi, '')
-  text = text.replace(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_, href, body) => {
+    .replace(/<script[\s\S]*?<\/script\s*>/gi, '')
+    .replace(/<style[\s\S]*?<\/style\s*>/gi, '')
+    .replace(/<noscript[\s\S]*?<\/noscript\s*>/gi, '')
+  text = text.replace(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a\s*>/gi, (_, href, body) => {
     const label = normalizeWhitespace(stripTags(body))
     if (!label) {
       return href
     }
     return `[${label}](${href})`
   })
-  text = text.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, body) => {
+  text = text.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1\s*>/gi, (_, level, body) => {
     const prefix = '#'.repeat(Math.max(1, Math.min(6, Number.parseInt(level, 10))))
     const label = normalizeWhitespace(stripTags(body))
     return `\n${prefix} ${label}\n`
   })
-  text = text.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, body) => {
+  text = text.replace(/<li[^>]*>([\s\S]*?)<\/li\s*>/gi, (_, body) => {
     const label = normalizeWhitespace(stripTags(body))
     return label ? `\n- ${label}` : ''
   })
-  text = text.replace(/<(br|hr)\s*\/?>/gi, '\n').replace(/<\/(p|div|section|article|header|footer|table|tr|ul|ol)>/gi, '\n')
+  text = text.replace(/<(br|hr)\s*\/?>/gi, '\n').replace(/<\/(p|div|section|article|header|footer|table|tr|ul|ol)\s*>/gi, '\n')
   text = stripTags(text)
   text = normalizeWhitespace(text)
   return { text, title }

--- a/src/main/agent/services/web-fetch/web-fetch-utils.ts
+++ b/src/main/agent/services/web-fetch/web-fetch-utils.ts
@@ -45,8 +45,29 @@ function decodeEntities(value: string): string {
     .replace(/&amp;/gi, '&')
 }
 
+function stripHtmlTags(value: string): string {
+  let result = ''
+  let inTag = false
+
+  for (const char of value) {
+    if (char === '<') {
+      inTag = true
+      continue
+    }
+    if (char === '>' && inTag) {
+      inTag = false
+      continue
+    }
+    if (!inTag) {
+      result += char
+    }
+  }
+
+  return result
+}
+
 function stripTags(value: string): string {
-  return decodeEntities(value.replace(/<[^>]+>/g, ''))
+  return decodeEntities(stripHtmlTags(value))
 }
 
 function normalizeWhitespace(value: string): string {

--- a/src/main/agent/services/web-fetch/web-fetch-visibility.ts
+++ b/src/main/agent/services/web-fetch/web-fetch-visibility.ts
@@ -1,6 +1,8 @@
 // HTML visibility sanitization - removes hidden elements and invisible Unicode
 // Ported from openclaw/src/agents/tools/web-fetch-visibility.ts
 
+import { parseHTML } from 'linkedom'
+
 // CSS property values that indicate an element is hidden
 const HIDDEN_STYLE_PATTERNS: Array<[string, RegExp]> = [
   ['display', /^\s*none\s*$/i],
@@ -123,17 +125,26 @@ function shouldRemoveElement(element: Element): boolean {
   return false
 }
 
-export async function sanitizeHtml(html: string): Promise<string> {
-  // Strip HTML comments
-  let sanitized = html.replace(/<!--[\s\S]*?-->/g, '')
+function removeCommentNodes(node: Node): void {
+  const childNodes = Array.from(node.childNodes)
+  for (const child of childNodes) {
+    if (child.nodeType === 8) {
+      child.parentNode?.removeChild(child)
+      continue
+    }
+    removeCommentNodes(child)
+  }
+}
 
+export async function sanitizeHtml(html: string): Promise<string> {
   let document: Document
   try {
-    const { parseHTML } = await import('linkedom')
-    ;({ document } = parseHTML(sanitized) as { document: Document })
+    ;({ document } = parseHTML(html) as { document: Document })
   } catch {
-    return sanitized
+    return html
   }
+
+  removeCommentNodes(document)
 
   // Walk all elements and remove hidden ones (bottom-up to avoid re-walking removed subtrees)
   const all = Array.from(document.querySelectorAll('*'))
@@ -151,5 +162,11 @@ export async function sanitizeHtml(html: string): Promise<string> {
 const INVISIBLE_UNICODE_RE = /[\u200B-\u200F\u202A-\u202E\u2060-\u2064\u206A-\u206F\uFEFF\u{E0000}-\u{E007F}]/gu
 
 export function stripInvisibleUnicode(text: string): string {
-  return text.replace(INVISIBLE_UNICODE_RE, '')
+  let sanitized = text
+  let previous = ''
+  while (sanitized !== previous) {
+    previous = sanitized
+    sanitized = sanitized.replace(INVISIBLE_UNICODE_RE, '')
+  }
+  return sanitized
 }

--- a/src/main/ssh/agentHandle.ts
+++ b/src/main/ssh/agentHandle.ts
@@ -12,6 +12,7 @@ import {
 import { LEGACY_ALGORITHMS } from './algorithms'
 import net from 'net'
 import tls from 'tls'
+import { randomUUID } from 'crypto'
 import { getUserConfigFromRenderer } from '../index'
 const logger = createLogger('ssh')
 
@@ -32,7 +33,7 @@ function isSystemError(_command: string, exitCode: number | null): boolean {
 
 export async function remoteSshConnect(connectionInfo: ConnectionInfo): Promise<{ id?: string; error?: string }> {
   const { host, port, username, password, privateKey, passphrase } = connectionInfo
-  const connectionId = `ssh_${Date.now()}_${Math.random().toString(36).substr(2, 12)}`
+  const connectionId = `ssh_${randomUUID()}`
   const normalizedHost = host ?? ''
   const normalizedUsername = username ?? ''
   const normalizedPort = port || 22

--- a/src/main/ssh/jumpserver/executor.ts
+++ b/src/main/ssh/jumpserver/executor.ts
@@ -2,6 +2,8 @@
  * JumpServer command execution and output parsing utilities
  */
 
+import { randomUUID } from 'crypto'
+
 /**
  * Output parser - cleans control characters and echo from command output
  */
@@ -74,7 +76,7 @@ export class OutputParser {
    */
   static generateMarkers(): { marker: string; exitCodeMarker: string } {
     const timestamp = Date.now()
-    const randomId = Math.random().toString(36).substring(7)
+    const randomId = randomUUID().replace(/-/g, '').slice(0, 12)
 
     return {
       marker: `__CHATERM_EXEC_END_${timestamp}_${randomId}__`,


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [ ] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTML sanitization to properly remove HTML comments and invisible Unicode characters through DOM traversal and iterative cleaning.
  * Enhanced HTML-to-Markdown conversion to handle optional whitespace in tag parsing for better reliability.

* **Improvements**
  * Updated session and connection ID generation to use UUID-based identifiers for improved security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->