### PR TITLE
refactor(terminalOutputRenderer): remove redundant ANSI code replacements for improved clarity

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,15 +9,17 @@ on:
     - cron: '20 2 * * 1'
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze (JavaScript / TypeScript)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code

--- a/src/main/agent/integrations/remote-terminal/index.ts
+++ b/src/main/agent/integrations/remote-terminal/index.ts
@@ -199,8 +199,6 @@ function processAnsiCodes(text: string): string {
   if (!text.includes('\u001b[') && !text.includes('\x1B[')) return text
 
   let result = text
-    // Normalize escape sequences
-    .replace(/\x1B/g, '\u001b')
     // Remove cursor/screen control sequences
     .replace(/\u001b\[[\d;]*[HfABCDEFGJKSTijklmnpqrsu]/g, '')
     .replace(/\u001b\[\?[0-9;]*[hl]/g, '')

--- a/src/main/storage/data_sync/envelope_encryption/utils/tempFileStorage.ts
+++ b/src/main/storage/data_sync/envelope_encryption/utils/tempFileStorage.ts
@@ -165,8 +165,8 @@ class TempFileStorageProvider {
    * Restore original key name from safe key name
    */
   private restoreKeyFromSafeKey(safeKey: string): string {
-    // This is a simplified restoration method, actual applications may need more complex mapping
-    return safeKey.replace(/_/g, '_')
+    // Lossy round-trip: getFilePath() maps disallowed chars to '_'; full inverse is not stored
+    return safeKey
   }
 
   /**

--- a/src/renderer/src/services/shortcutService.ts
+++ b/src/renderer/src/services/shortcutService.ts
@@ -487,7 +487,7 @@ export class ShortcutService {
         .replace(/Command/g, '⌘')
         .replace(/Option/g, '⌥')
         .replace(/Alt/g, '⌥')
-        .replace(/Shift/g, 'Shift')
+        .replace(/Shift/g, '⇧')
         .replace(/Control/g, '⌃')
         .replace(/Ctrl/g, '⌃')
     } else {

--- a/src/renderer/src/views/components/AiTab/components/format/terminalOutputRenderer.vue
+++ b/src/renderer/src/views/components/AiTab/components/format/terminalOutputRenderer.vue
@@ -1323,48 +1323,7 @@ const processAnsiCodes = (str: string): string => {
     .replace(/\x08/g, '')
     .replace(/\x0B/g, '')
     .replace(/\x0C/g, '')
-    .replace(/\u001b\[0m/g, '\x1b[0m') // Reset
-    .replace(/\u001b\[1m/g, '\x1b[1m') // Bold
-    .replace(/\u001b\[2m/g, '\x1b[2m') // Dim
-    .replace(/\u001b\[3m/g, '\x1b[3m') // Italic
-    .replace(/\u001b\[4m/g, '\x1b[4m') // Underline
-    .replace(/\u001b\[5m/g, '\x1b[5m') // Blink
-    .replace(/\u001b\[6m/g, '\x1b[6m') // Rapid blink
-    .replace(/\u001b\[7m/g, '\x1b[7m') // Reverse
-    .replace(/\u001b\[8m/g, '\x1b[8m') // Conceal
-    .replace(/\u001b\[9m/g, '\x1b[9m') // Strikethrough
-    .replace(/\u001b\[30m/g, '\x1b[30m') // Black
-    .replace(/\u001b\[31m/g, '\x1b[31m') // Red
-    .replace(/\u001b\[32m/g, '\x1b[32m') // Green
-    .replace(/\u001b\[33m/g, '\x1b[33m') // Yellow
-    .replace(/\u001b\[34m/g, '\x1b[34m') // Blue
-    .replace(/\u001b\[35m/g, '\x1b[35m') // Magenta
-    .replace(/\u001b\[36m/g, '\x1b[36m') // Cyan
-    .replace(/\u001b\[37m/g, '\x1b[37m') // White
-    .replace(/\u001b\[90m/g, '\x1b[90m') // Bright Black
-    .replace(/\u001b\[91m/g, '\x1b[91m') // Bright Red
-    .replace(/\u001b\[92m/g, '\x1b[92m') // Bright Green
-    .replace(/\u001b\[93m/g, '\x1b[93m') // Bright Yellow
-    .replace(/\u001b\[94m/g, '\x1b[94m') // Bright Blue
-    .replace(/\u001b\[95m/g, '\x1b[95m') // Bright Magenta
-    .replace(/\u001b\[96m/g, '\x1b[96m') // Bright Cyan
-    .replace(/\u001b\[97m/g, '\x1b[97m') // Bright White
-    .replace(/\u001b\[40m/g, '\x1b[40m') // Black background
-    .replace(/\u001b\[41m/g, '\x1b[41m') // Red background
-    .replace(/\u001b\[42m/g, '\x1b[42m') // Green background
-    .replace(/\u001b\[43m/g, '\x1b[43m') // Yellow background
-    .replace(/\u001b\[44m/g, '\x1b[44m') // Blue background
-    .replace(/\u001b\[45m/g, '\x1b[45m') // Magenta background
-    .replace(/\u001b\[46m/g, '\x1b[46m') // Cyan background
-    .replace(/\u001b\[47m/g, '\x1b[47m') // White background
-    .replace(/\u001b\[100m/g, '\x1b[100m') // Bright Black background
-    .replace(/\u001b\[101m/g, '\x1b[101m') // Bright Red background
-    .replace(/\u001b\[102m/g, '\x1b[102m') // Bright Green background
-    .replace(/\u001b\[103m/g, '\x1b[103m') // Bright Yellow background
-    .replace(/\u001b\[104m/g, '\x1b[104m') // Bright Blue background
-    .replace(/\u001b\[105m/g, '\x1b[105m') // Bright Magenta background
-    .replace(/\u001b\[106m/g, '\x1b[106m') // Bright Cyan background
-    .replace(/\u001b\[107m/g, '\x1b[107m') // Bright White background
+  // In JS, \u001b and \x1b are the same ESC code point; chained identity replaces were removed.
 
   // Process 256 colors and RGB colors
   result = result.replace(/\u001b\[38;5;(\d+)m/g, (_, colorCode) => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated macOS keyboard shortcuts to display the Shift modifier as the ⇧ symbol instead of text.

* **Refactor**
  * Simplified ANSI escape code processing logic.
  * Optimized temporary file storage key handling.
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->