### PR TITLE
fix: extend timeout duration for two-factor authentication to 3 minutes

### DIFF
--- a/src/main/ssh/jumpserver/mfa.ts
+++ b/src/main/ssh/jumpserver/mfa.ts
@@ -14,7 +14,7 @@ export const handleJumpServerKeyboardInteractive = (event, id, prompts, finish) 
       finish([])
       event.sender.send('ssh:keyboard-interactive-timeout', { id })
       reject(new Error('Two-factor authentication timeout'))
-    }, 30000)
+    }, 180000)
 
     ipcMain.once(`ssh:keyboard-interactive-response:${id}`, (_evt, responses) => {
       clearTimeout(timeoutId)


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for keyboard-interactive multi-factor authentication during SSH jump server connections, giving users more time to complete two-factor authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->