### PR TITLE
feat: Extend handleWebviewAskResponse to include toolResult payload a…

### DIFF
--- a/src/main/agent/core/controller/__tests__/controller.test.ts
+++ b/src/main/agent/core/controller/__tests__/controller.test.ts
@@ -315,7 +315,7 @@ describe('Controller', () => {
     } as WebviewMessage)
 
     expect(clearTodosSpy).toHaveBeenCalledWith('new_user_input')
-    expect(handleResponseSpy).toHaveBeenCalledWith('messageResponse', 'response text', undefined, undefined)
+    expect(handleResponseSpy).toHaveBeenCalledWith('messageResponse', 'response text', undefined, undefined, undefined)
   })
 
   it('reloadSecurityConfigForAllTasks should reload config for all tasks', async () => {

--- a/src/main/agent/core/controller/index.ts
+++ b/src/main/agent/core/controller/index.ts
@@ -298,7 +298,13 @@ export class Controller {
               taskId: targetTask.taskId
             })
           }
-          await targetTask.handleWebviewAskResponse(message.askResponse!, message.text, message.truncateAtMessageTs, message.contentParts)
+          await targetTask.handleWebviewAskResponse(
+            message.askResponse!,
+            message.text,
+            message.truncateAtMessageTs,
+            message.contentParts,
+            message.toolResult
+          )
         }
         break
       case 'showTaskWithId':

--- a/src/main/agent/core/task/__tests__/task.dispatch-and-state.test.ts
+++ b/src/main/agent/core/task/__tests__/task.dispatch-and-state.test.ts
@@ -90,14 +90,16 @@ describe('Task dispatch and state flow', () => {
 
   it('handleWebviewAskResponse should persist payload and apply truncation', async () => {
     const contentParts = [{ type: 'chip', chipType: 'doc' }]
-    await task.handleWebviewAskResponse('yesButtonClicked', 'ok', 12345, contentParts)
+    const toolResult = { output: 'ls output', toolName: 'execute_command' }
+    await task.handleWebviewAskResponse('yesButtonClicked', 'ok', 12345, contentParts, toolResult)
 
     expect(task.truncateHistoryAtTimestamp).toHaveBeenCalledWith(12345)
     expect(task.setNextUserInputContentParts).toHaveBeenCalledWith(contentParts)
     expect(task.askResponsePayload).toEqual({
       response: 'yesButtonClicked',
       text: 'ok',
-      contentParts
+      contentParts,
+      toolResult
     })
   })
 

--- a/src/main/agent/core/task/__tests__/task.tool-results.test.ts
+++ b/src/main/agent/core/task/__tests__/task.tool-results.test.ts
@@ -65,6 +65,7 @@ describe('Task tool result helpers', () => {
     task.taskId = 'task-tool-result'
     task.pendingToolResults = []
     task.apiConversationHistory = []
+    task.chatermMessages = []
     task.userMessageContent = []
     task.messages = { userProvidedFeedback: 'feedback: {feedback}' }
     task.truncateCommandOutput = vi.fn((s: string) => s.trim())
@@ -183,6 +184,86 @@ describe('Task tool result helpers', () => {
     expect(task.pushToolResult).not.toHaveBeenCalled()
     expect(task.pushAdditionalToolFeedback).toHaveBeenCalledWith('continue')
     expect(task.saveUserMessage).toHaveBeenCalledWith('continue', [{ type: 'text', text: 'continue' }])
+  })
+
+  it('askApproval should convert command tool results into structured tool_result payloads', async () => {
+    task.ask = vi.fn().mockResolvedValue({
+      response: 'yesButtonClicked',
+      text: 'Terminal output:\n```\nls output\n```',
+      toolResult: {
+        output: 'ls output',
+        toolName: 'execute_command'
+      }
+    })
+    task.hosts = [{ host: '10.0.0.8', uuid: 'host-1', connection: 'ssh' }]
+    task.pushToolResult = vi.fn().mockResolvedValue(undefined)
+    task.pushAdditionalToolFeedback = vi.fn().mockResolvedValue(undefined)
+    task.saveUserMessage = vi.fn().mockResolvedValue(undefined)
+    task.saveCheckpoint = vi.fn().mockResolvedValue(undefined)
+
+    const approved = await task.askApproval('[execute_command]', 'command', 'ls')
+
+    expect(approved).toBe(true)
+    expect(task.pushToolResult).toHaveBeenCalledWith(
+      '[execute_command]',
+      'ls output',
+      expect.objectContaining({
+        toolName: 'execute_command',
+        hosts: task.hosts,
+        isError: undefined
+      })
+    )
+    expect(task.pushAdditionalToolFeedback).not.toHaveBeenCalled()
+    expect(task.saveUserMessage).toHaveBeenCalledWith('ls output', undefined, 'command_output')
+    expect(task.saveCheckpoint).toHaveBeenCalledTimes(1)
+  })
+
+  it('askApproval should enqueue command tool results for tool_result persistence', async () => {
+    task.ask = vi.fn().mockResolvedValue({
+      response: 'yesButtonClicked',
+      toolResult: {
+        output: 'ls output',
+        toolName: 'execute_command'
+      }
+    })
+    task.hosts = [{ host: '10.0.0.8', uuid: 'host-1', connection: 'ssh' }]
+    task.addToApiConversationHistory = vi.fn().mockResolvedValue(undefined)
+    task.saveCheckpoint = vi.fn().mockResolvedValue(undefined)
+
+    const approved = await task.askApproval('[execute_command]', 'command', 'ls')
+
+    expect(approved).toBe(true)
+    expect(task.pendingToolResults).toHaveLength(1)
+    expect(task.pendingToolResults[0]).toEqual(
+      expect.objectContaining({
+        toolName: 'execute_command',
+        toolDescription: '[execute_command]',
+        hosts: task.hosts,
+        result: 'ls output'
+      })
+    )
+    expect(task.chatermMessages[0]).toEqual(
+      expect.objectContaining({
+        type: 'say',
+        say: 'command_output',
+        text: 'ls output',
+        hosts: task.hosts
+      })
+    )
+
+    await task.flushPendingToolResults()
+
+    expect(task.addToApiConversationHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'user',
+        content: [
+          expect.objectContaining({
+            type: 'tool_result'
+          })
+        ]
+      })
+    )
+    expect(task.pendingToolResults).toHaveLength(0)
   })
 
   it('handleToolError should short-circuit when task is abandoned', async () => {

--- a/src/main/agent/core/task/index.ts
+++ b/src/main/agent/core/task/index.ts
@@ -101,7 +101,7 @@ import { SkillsManager } from '@services/skills'
 import { ChatermDatabaseService } from '../../../storage/db/chaterm.service'
 import type { McpTool } from '@shared/mcp'
 
-import type { ContentPart, ContextDocRef, ContextPastChatRef, ContextRefs, Host } from '@shared/WebviewMessage'
+import type { ContentPart, ContextDocRef, ContextPastChatRef, ContextRefs, Host, ToolResultPayload } from '@shared/WebviewMessage'
 import type { ToolResult } from '@shared/ToolResult'
 import { ExternalAssetCache } from '../../../plugin/pluginIpc'
 import type { InteractionType } from '../../services/interaction-detector/types'
@@ -242,7 +242,7 @@ export class Task {
   apiConversationHistory: Anthropic.MessageParam[] = []
   chatermMessages: ChatermMessage[] = []
   private commandSecurityManager: CommandSecurityManager
-  private askResponsePayload?: { response: ChatermAskResponse; text?: string; contentParts?: ContentPart[] }
+  private askResponsePayload?: { response: ChatermAskResponse; text?: string; contentParts?: ContentPart[]; toolResult?: ToolResultPayload }
   private nextUserInputContentParts?: ContentPart[]
   private lastMessageTs?: number
   private consecutiveAutoApprovedRequestsCount: number = 0
@@ -1322,6 +1322,7 @@ export class Task {
     response: ChatermAskResponse
     text?: string
     contentParts?: ContentPart[]
+    toolResult?: ToolResultPayload
   }> {
     if (this.abort) {
       throw new Error('Chaterm instance aborted')
@@ -1450,7 +1451,13 @@ export class Task {
     }
   }
 
-  async handleWebviewAskResponse(askResponse: ChatermAskResponse, text?: string, truncateAtMessageTs?: number, contentParts?: ContentPart[]) {
+  async handleWebviewAskResponse(
+    askResponse: ChatermAskResponse,
+    text?: string,
+    truncateAtMessageTs?: number,
+    contentParts?: ContentPart[],
+    toolResult?: ToolResultPayload
+  ) {
     logger.debug('Handling webview ask response', {
       event: 'agent.task.ask_response.received',
       askResponse,
@@ -1465,7 +1472,8 @@ export class Task {
     this.askResponsePayload = {
       response: askResponse,
       text,
-      contentParts
+      contentParts,
+      toolResult
     }
   }
 
@@ -3184,7 +3192,7 @@ export class Task {
   }
 
   private async askApproval(toolDescription: string, type: ChatermAsk, partialMessage?: string): Promise<boolean> {
-    const { response, text, contentParts } = await this.ask(type, partialMessage, false)
+    const { response, text, contentParts, toolResult } = await this.ask(type, partialMessage, false)
     const approved = response === 'yesButtonClicked' || response === 'autoApproveReadOnlyClicked'
 
     // If user clicked "auto-approve read-only" button, enable session-level auto-approval for subsequent read-only commands
@@ -3201,6 +3209,14 @@ export class Task {
         await this.saveCheckpoint()
       }
       this.didRejectTool = true
+    } else if (toolResult) {
+      await this.pushToolResult(toolDescription, toolResult.output, {
+        toolName: toolResult.toolName ?? 'execute_command',
+        hosts: this.hosts,
+        isError: toolResult.isError
+      })
+      await this.saveUserMessage(toolResult.output, undefined, 'command_output')
+      await this.saveCheckpoint()
     } else if (text) {
       await this.pushAdditionalToolFeedback(text)
       await this.saveUserMessage(text, contentParts)

--- a/src/main/agent/shared/WebviewMessage.ts
+++ b/src/main/agent/shared/WebviewMessage.ts
@@ -60,6 +60,12 @@ export type ImageContentPart = {
 }
 export type ContentPart = TextContentPart | ChipContentPart | ImageContentPart
 
+export type ToolResultPayload = {
+  output: string
+  toolName?: string
+  isError?: boolean
+}
+
 export type WebviewMessageType =
   | 'apiConfiguration'
   | 'newTask'
@@ -76,6 +82,7 @@ export type WebviewMessageType =
 export interface WebviewMessage {
   type: WebviewMessageType
   text?: string
+  toolResult?: ToolResultPayload
   apiConfiguration?: ApiConfiguration
   telemetrySetting?: TelemetrySetting
   askResponse?: ChatermAskResponse
@@ -112,6 +119,13 @@ export const WebviewMessageSchema = z
     tabId: z.string().optional(),
     taskId: z.string().optional(),
     text: z.string().optional(),
+    toolResult: z
+      .object({
+        output: z.string(),
+        toolName: z.string().optional(),
+        isError: z.boolean().optional()
+      })
+      .optional(),
     apiConfiguration: z.record(z.unknown()).optional()
   })
   .passthrough()

--- a/src/renderer/src/utils/eventBus.ts
+++ b/src/renderer/src/utils/eventBus.ts
@@ -1,5 +1,6 @@
 import mitt from 'mitt'
 import type { AssetInfo } from '@/views/components/AiTab/types'
+import type { ToolResultPayload } from '@shared/WebviewMessage'
 
 /**
  * Define event types
@@ -18,7 +19,7 @@ export interface AppEvents {
   apiProviderChanged: any
   activeTabChanged: any
   chatToAi: any
-  sendMessageToAi: { content: string; tabId?: string }
+  sendMessageToAi: { content: string; tabId?: string; toolResult?: ToolResultPayload }
   toggleMenu: any
   updateWatermark: string // Update watermark status
   updateSecretRedaction: string // Update secret redaction status

--- a/src/renderer/src/views/components/AiTab/components/format/markdownRenderer.vue
+++ b/src/renderer/src/views/components/AiTab/components/format/markdownRenderer.vue
@@ -2917,6 +2917,28 @@ body.has-custom-bg .monaco-editor .margin {
   font-weight: 500;
 }
 
+.kb-search-results {
+  margin: 4px 8px;
+}
+
+.kb-search-result-list {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 6px 8px 0;
+}
+
+.kb-search-result-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ant-primary-color, #1677ff);
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+}
+
 .command-output::-webkit-scrollbar-thumb {
   background: var(--bg-color-quaternary);
   border-radius: 1px;

--- a/src/renderer/src/views/components/AiTab/composables/__tests__/useChatMessages.test.ts
+++ b/src/renderer/src/views/components/AiTab/composables/__tests__/useChatMessages.test.ts
@@ -1352,6 +1352,58 @@ describe('useChatMessages', () => {
       expect(sent.askResponse).toBe('messageResponse')
       expect(sent.text).toBe('hello')
     })
+
+    it('sends structured toolResult for commandSend without overloading text', async () => {
+      const session = createMockSession()
+      session.chatHistory.push({
+        id: 'm1',
+        role: 'assistant',
+        content: 'Run ls',
+        type: 'ask',
+        ask: 'command',
+        say: '',
+        ts: Date.now()
+      })
+
+      const mockTab = createMockTab('test-tab-1', session)
+      const chatTabs = ref([mockTab])
+      const currentChatId = ref('test-tab-1')
+      const chatInputParts = ref([])
+      const hosts = ref<Host[]>([{ host: '127.0.0.1', uuid: 'localhost', connection: 'localhost' }])
+      const chatTypeValue = ref('cmd')
+
+      vi.mocked(useSessionState).mockReturnValue({
+        chatTabs,
+        currentChatId,
+        currentTab: ref(mockTab),
+        currentSession: ref(mockTab.session),
+        chatInputParts,
+        hosts,
+        chatTypeValue
+      } as any)
+
+      const { sendMessageWithContent } = useChatMessages(
+        mockScrollToBottom,
+        mockClearTodoState,
+        mockMarkLatestMessageWithTodoUpdate,
+        mockCurrentTodos,
+        mockCheckModelConfig
+      )
+
+      const toolResult = {
+        output: 'file1\nfile2',
+        toolName: 'execute_command'
+      }
+
+      await sendMessageWithContent('Terminal output:\n```\nfile1\nfile2\n```', 'commandSend', undefined, undefined, undefined, undefined, toolResult)
+
+      expect(mockSendToMain).toHaveBeenCalledTimes(1)
+      const sent = mockSendToMain.mock.calls[0][0]
+      expect(sent.type).toBe('askResponse')
+      expect(sent.askResponse).toBe('yesButtonClicked')
+      expect(sent.text).toBeUndefined()
+      expect(sent.toolResult).toEqual(toolResult)
+    })
   })
 
   describe('hosts parameter handling', () => {

--- a/src/renderer/src/views/components/AiTab/composables/useChatMessages.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useChatMessages.ts
@@ -7,7 +7,7 @@ import type { ChatMessage, Host } from '../types'
 import type { Todo } from '@/types/todo'
 import type { ChatTab } from './useSessionState'
 import type { ExtensionMessage } from '@shared/ExtensionMessage'
-import type { ContentPart, WebviewMessage } from '@shared/WebviewMessage'
+import type { ContentPart, ToolResultPayload, WebviewMessage } from '@shared/WebviewMessage'
 import { createNewMessage, parseMessageContent, pickHostInfo, isSwitchAssetType } from '../utils'
 import { Notice } from '@/views/components/Notice'
 import { useSessionState } from './useSessionState'
@@ -106,7 +106,8 @@ export function useChatMessages(
     tabId?: string,
     truncateAtMessageTs?: number,
     contentParts?: ContentPart[],
-    overrideHosts?: Host[]
+    overrideHosts?: Host[],
+    toolResult?: ToolResultPayload
   ) => {
     try {
       const targetTab = tabId ? chatTabs.value.find((tab) => tab.id === tabId) : currentTab.value
@@ -140,7 +141,7 @@ export function useChatMessages(
         message = {
           type: 'askResponse',
           askResponse: 'yesButtonClicked',
-          text: userContent,
+          ...(toolResult ? { toolResult } : { text: userContent }),
           hosts: hostsArray,
           contentParts
         }
@@ -244,7 +245,8 @@ export function useChatMessages(
     tabId?: string,
     truncateAtMessageTs?: number,
     contentParts?: ContentPart[],
-    overrideHosts?: Host[]
+    overrideHosts?: Host[],
+    toolResult?: ToolResultPayload
   ) => {
     const targetTab = tabId ? chatTabs.value.find((tab: ChatTab) => tab.id === tabId) : currentTab.value
 
@@ -256,7 +258,7 @@ export function useChatMessages(
     session.isCancelled = false
     // Strip Vue proxies before IPC to avoid structured clone failures.
     contentParts = contentParts ? contentParts.map((part) => (isProxy(part) ? (toRaw(part) as ContentPart) : part)) : undefined
-    await sendMessageToMain(userContent, sendType, tabId, truncateAtMessageTs, contentParts, overrideHosts)
+    await sendMessageToMain(userContent, sendType, tabId, truncateAtMessageTs, contentParts, overrideHosts, toolResult)
 
     const userMessage: ChatMessage = {
       id: uuidv4(),

--- a/src/renderer/src/views/components/AiTab/composables/useEventBusListeners.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useEventBusListeners.ts
@@ -3,7 +3,8 @@ import eventBus from '@/utils/eventBus'
 import { useSessionState } from './useSessionState'
 import { focusChatInput } from './useTabManagement'
 import { isFocusInAiTab } from '@/utils/domUtils'
-import type { AssetInfo } from '../types'
+import type { AssetInfo, Host } from '../types'
+import type { ContentPart, ToolResultPayload } from '@shared/WebviewMessage'
 import { isSwitchAssetType } from '../utils'
 import i18n from '@/locales'
 import { Notice } from '@/views/components/Notice'
@@ -11,7 +12,15 @@ import { Notice } from '@/views/components/Notice'
 const logger = createRendererLogger('aitab.eventBus')
 
 interface UseEventBusListenersParams {
-  sendMessageWithContent: (content: string, sendType: string, tabId?: string) => Promise<void>
+  sendMessageWithContent: (
+    content: string,
+    sendType: string,
+    tabId?: string,
+    truncateAtMessageTs?: number,
+    contentParts?: ContentPart[],
+    overrideHosts?: Host[],
+    toolResult?: ToolResultPayload
+  ) => Promise<void>
   initModel: () => Promise<void>
   getCurentTabAssetInfo: () => Promise<AssetInfo | null>
   updateHosts: (hostInfo: { ip: string; uuid: string; connection: string; assetType?: string } | null) => void
@@ -87,13 +96,13 @@ export function useEventBusListeners(params: UseEventBusListenersParams) {
     }
   }
 
-  const handleSendMessageToAi = async (payload: { content: string; tabId?: string }) => {
+  const handleSendMessageToAi = async (payload: { content: string; tabId?: string; toolResult?: ToolResultPayload }) => {
     if (isAgentMode) {
       logger.debug('Ignoring sendMessageToAi event in agent mode')
       return
     }
 
-    const { content, tabId } = payload
+    const { content, tabId, toolResult } = payload
 
     if (!content || content.trim() === '') {
       return
@@ -108,7 +117,7 @@ export function useEventBusListeners(params: UseEventBusListenersParams) {
     }
 
     await initAssetInfo()
-    await sendMessageWithContent(content.trim(), 'commandSend', tabId)
+    await sendMessageWithContent(content.trim(), 'commandSend', tabId, undefined, undefined, undefined, toolResult)
   }
 
   const handleChatToAi = async (text: string) => {

--- a/src/renderer/src/views/components/K8s/K8sConnect.vue
+++ b/src/renderer/src/views/components/K8s/K8sConnect.vue
@@ -246,12 +246,16 @@ const handleCommandOutput = (data: string) => {
 
       const outputLines = lines.slice(startIdx, endIdx)
       const finalOutput = outputLines.join('\n').trim()
+      const toolResult = {
+        output: finalOutput || 'Command executed successfully, no output returned',
+        toolName: 'execute_command'
+      }
 
       if (finalOutput) {
         const formattedOutput = `Terminal output:\n\`\`\`\n${finalOutput}\n\`\`\``
-        eventBus.emit('sendMessageToAi', { content: formattedOutput, tabId })
+        eventBus.emit('sendMessageToAi', { content: formattedOutput, tabId, toolResult })
       } else {
-        eventBus.emit('sendMessageToAi', { content: 'Command executed successfully, no output returned', tabId })
+        eventBus.emit('sendMessageToAi', { content: 'Command executed successfully, no output returned', tabId, toolResult })
       }
     }, 150)
   }

--- a/src/renderer/src/views/components/K8s/__tests__/K8sConnect.test.ts
+++ b/src/renderer/src/views/components/K8s/__tests__/K8sConnect.test.ts
@@ -511,7 +511,11 @@ describe('K8s Connect Component', () => {
         'sendMessageToAi',
         expect.objectContaining({
           tabId: 'tab-42',
-          content: expect.stringContaining('Terminal output:')
+          content: expect.stringContaining('Terminal output:'),
+          toolResult: expect.objectContaining({
+            output: expect.stringContaining('NAME'),
+            toolName: 'execute_command'
+          })
         })
       )
     })
@@ -542,6 +546,8 @@ describe('K8s Connect Component', () => {
       // The double-echo line should be stripped
       expect(content).not.toContain('kkubectl')
       expect(content).toContain('NAME')
+      expect(emitCall![1].toolResult.output).not.toContain('kkubectl')
+      expect(emitCall![1].toolResult.output).toContain('NAME')
     })
 
     it('should emit "Command executed successfully, no output returned" when output is empty', async () => {
@@ -564,6 +570,10 @@ describe('K8s Connect Component', () => {
       const emitCall = mockEventBus.emit.mock.calls.find((c) => c[0] === 'sendMessageToAi')
       expect(emitCall).toBeDefined()
       expect(emitCall![1].content).toBe('Command executed successfully, no output returned')
+      expect(emitCall![1].toolResult).toEqual({
+        output: 'Command executed successfully, no output returned',
+        toolName: 'execute_command'
+      })
     })
 
     it('should unregister executeTerminalCommand listener on unmount', async () => {

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -3948,13 +3948,18 @@ const handleCommandOutput = (data: string, isInitialCommand: boolean) => {
           finalOutput = finalOutput.replace(/\n{2,}/g, '\n')
         }
 
+        const toolResult = {
+          output: finalOutput || 'Command executed successfully, no output returned',
+          toolName: 'execute_command'
+        }
+
         if (finalOutput) {
           const formattedOutput = `Terminal output:\n\`\`\`\n${finalOutput}\n\`\`\``
-          eventBus.emit('sendMessageToAi', { content: formattedOutput, tabId })
+          eventBus.emit('sendMessageToAi', { content: formattedOutput, tabId, toolResult })
         } else {
           const output = 'Command executed successfully, no output returned'
           const messageToSend = isInitialCommand ? `Terminal output:\n\`\`\`\n${output}\n\`\`\`` : output
-          eventBus.emit('sendMessageToAi', { content: messageToSend, tabId })
+          eventBus.emit('sendMessageToAi', { content: messageToSend, tabId, toolResult })
         }
       } catch (error) {
         logger.error('Error processing command echo output', { error: error })


### PR DESCRIPTION
…nd update related tests

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced command execution handling to better track and transmit tool results, including output and error status information.
  * Improved visual styling for knowledge-base search results with better spacing and link presentation.

* **Tests**
  * Extended test coverage for command execution validation and result transmission accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->