### PR TITLE
feat: Implement recent connections feature and record connection logic

### DIFF
--- a/src/main/agent/core/task/index.ts
+++ b/src/main/agent/core/task/index.ts
@@ -4915,7 +4915,7 @@ USERNAME:${localSystemInfo.userName}`
         type: 'chip',
         chipType: 'doc',
         ref: {
-          absPath: path.join(kbRoot, relPath),
+          absPath: path.join(kbRoot, relPath).replace(/\\/g, '/'),
           relPath,
           name: path.basename(relPath),
           type: 'file',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1895,6 +1895,14 @@ ipcMain.handle('asset-route-local-get', async (_, data) => {
   }
 })
 
+ipcMain.handle('record-connection', async (_, data) => {
+  try {
+    chatermDbService.recordConnection(data)
+  } catch (error) {
+    logger.error('Record connection failed', { error: error })
+  }
+})
+
 ipcMain.handle('asset-route-local-update', async (_, data) => {
   try {
     const { uuid, label } = data

--- a/src/main/storage/db/chaterm.service.ts
+++ b/src/main/storage/db/chaterm.service.ts
@@ -26,7 +26,8 @@ import {
   createOrganizationAssetLogic,
   updateOrganizationAssetLogic,
   deleteOrganizationAssetLogic,
-  batchDeleteOrganizationAssetsLogic
+  batchDeleteOrganizationAssetsLogic,
+  recordConnectionLogic
 } from './chaterm/assets'
 import {
   deleteChatermHistoryByTaskIdLogic,
@@ -155,6 +156,18 @@ export class ChatermDatabaseService {
 
   async getLocalAssetRoute(searchType: string, params: any[] = []): Promise<any> {
     return await getLocalAssetRouteLogic(this.db, searchType, params)
+  }
+
+  recordConnection(params: {
+    assetUuid: string
+    assetIp: string
+    assetLabel?: string
+    assetPort?: number
+    assetUsername?: string
+    assetType: string
+    organizationId?: string
+  }): void {
+    recordConnectionLogic(this.db, params)
   }
 
   updateLocalAssetLabel(uuid: string, label: string): any {

--- a/src/main/storage/db/chaterm/__tests__/assets.routes.connection-history.test.ts
+++ b/src/main/storage/db/chaterm/__tests__/assets.routes.connection-history.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('better-sqlite3', () => ({
+  default: class {}
+}))
+
+vi.mock('../../../../ssh/capabilityRegistry', () => ({
+  capabilityRegistry: {
+    listBastionDefinitions: vi.fn(() => [])
+  }
+}))
+
+vi.mock('../../../../agent/core/storage/state', () => ({
+  getUserConfig: vi.fn().mockResolvedValue({ language: 'zh-CN' })
+}))
+
+describe('recordConnectionLogic', () => {
+  it('should insert connection record with all fields', async () => {
+    const { recordConnectionLogic } = await import('../assets.routes')
+
+    const runFn = vi.fn(() => ({ changes: 1 }))
+    const cleanupRunFn = vi.fn(() => ({ changes: 0 }))
+
+    const prepareMock = vi.fn((sql: string) => {
+      if (sql.includes('INSERT INTO t_connection_history')) {
+        return { run: runFn }
+      }
+      if (sql.includes('DELETE FROM t_connection_history')) {
+        return { run: cleanupRunFn }
+      }
+      return { run: vi.fn(), all: vi.fn(() => []) }
+    })
+
+    const mockDb = { prepare: prepareMock } as any
+
+    recordConnectionLogic(mockDb, {
+      assetUuid: 'uuid-123',
+      assetIp: '192.168.1.1',
+      assetLabel: 'test-host',
+      assetPort: 22,
+      assetUsername: 'root',
+      assetType: 'person',
+      organizationId: 'personal'
+    })
+
+    expect(runFn).toHaveBeenCalledWith('uuid-123', '192.168.1.1', 'test-host', 22, 'root', 'person', 'personal')
+    // Cleanup should also be called
+    expect(cleanupRunFn).toHaveBeenCalled()
+  })
+
+  it('should use default values for optional fields', async () => {
+    const { recordConnectionLogic } = await import('../assets.routes')
+
+    const runFn = vi.fn(() => ({ changes: 1 }))
+
+    const prepareMock = vi.fn((sql: string) => {
+      if (sql.includes('INSERT INTO t_connection_history')) {
+        return { run: runFn }
+      }
+      if (sql.includes('DELETE FROM t_connection_history')) {
+        return { run: vi.fn(() => ({ changes: 0 })) }
+      }
+      return { run: vi.fn(), all: vi.fn(() => []) }
+    })
+
+    const mockDb = { prepare: prepareMock } as any
+
+    recordConnectionLogic(mockDb, {
+      assetUuid: 'uuid-456',
+      assetIp: '10.0.0.1',
+      assetType: 'organization'
+    })
+
+    // assetLabel -> null, assetPort -> 22, assetUsername -> null, organizationId -> 'personal'
+    expect(runFn).toHaveBeenCalledWith('uuid-456', '10.0.0.1', null, 22, null, 'organization', 'personal')
+  })
+
+  it('should not throw when database error occurs', async () => {
+    const { recordConnectionLogic } = await import('../assets.routes')
+
+    const prepareMock = vi.fn(() => {
+      throw new Error('DB error')
+    })
+
+    const mockDb = { prepare: prepareMock } as any
+
+    // Should not throw - errors are caught internally
+    expect(() =>
+      recordConnectionLogic(mockDb, {
+        assetUuid: 'uuid-789',
+        assetIp: '10.0.0.1',
+        assetType: 'person'
+      })
+    ).not.toThrow()
+  })
+
+  it('should run cleanup after insert', async () => {
+    const { recordConnectionLogic } = await import('../assets.routes')
+
+    const callOrder: string[] = []
+    const prepareMock = vi.fn((sql: string) => {
+      if (sql.includes('INSERT INTO t_connection_history')) {
+        return {
+          run: vi.fn(() => {
+            callOrder.push('insert')
+            return { changes: 1 }
+          })
+        }
+      }
+      if (sql.includes('DELETE FROM t_connection_history')) {
+        return {
+          run: vi.fn(() => {
+            callOrder.push('cleanup')
+            return { changes: 0 }
+          })
+        }
+      }
+      return { run: vi.fn(), all: vi.fn(() => []) }
+    })
+
+    const mockDb = { prepare: prepareMock } as any
+
+    recordConnectionLogic(mockDb, {
+      assetUuid: 'uuid-abc',
+      assetIp: '10.0.0.1',
+      assetType: 'person'
+    })
+
+    expect(callOrder).toEqual(['insert', 'cleanup'])
+  })
+})
+
+describe('getLocalAssetRouteLogic - recent connections', () => {
+  let prepareMock: ReturnType<typeof vi.fn>
+
+  const recentConnectionRow = {
+    asset_uuid: 'recent-uuid',
+    asset_ip: '10.0.0.5',
+    asset_label: 'recent-host',
+    asset_port: 22,
+    asset_username: 'admin',
+    asset_type: 'person',
+    organization_id: 'personal',
+    last_connected: '2026-04-20 10:00:00'
+  }
+
+  beforeEach(() => {
+    prepareMock = vi.fn((sql: string) => {
+      // Migration checks
+      if (sql.includes('PRAGMA table_info')) {
+        return { all: () => [{ name: 'comment' }] }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_custom_folders')) {
+        return { get: () => ({ name: 't_custom_folders' }) }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_asset_folder_mapping')) {
+        return { get: () => ({ name: 't_asset_folder_mapping' }) }
+      }
+      // Recent connections query
+      if (sql.includes('t_connection_history') && sql.includes("organization_id = 'personal'")) {
+        return { all: () => [recentConnectionRow] }
+      }
+      if (sql.includes('t_connection_history') && sql.includes("organization_id != 'personal'")) {
+        return { all: () => [] }
+      }
+      // Favorites
+      if (sql.includes('favorite = 1')) {
+        return { all: () => [] }
+      }
+      // Groups
+      if (sql.includes('SELECT DISTINCT group_name')) {
+        return { all: () => [] }
+      }
+      return { all: () => [], get: () => undefined, run: () => ({ changes: 0 }) }
+    })
+  })
+
+  it('should include recent connections node before favorites for personal workspace', async () => {
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: prepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+
+    expect(result.code).toBe(200)
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeDefined()
+    expect(recentRouter.asset_type).toBe('recent_connections')
+    expect(recentRouter.children).toHaveLength(1)
+
+    const child = recentRouter.children[0]
+    expect(child.title).toBe('recent-host')
+    expect(child.ip).toBe('10.0.0.5')
+    expect(child.uuid).toBe('recent-uuid')
+    expect(child.port).toBe(22)
+    expect(child.username).toBe('admin')
+    expect(child.asset_type).toBe('person')
+    expect(child.organizationId).toBe('personal')
+  })
+
+  it('should place recent connections before favorites', async () => {
+    // Override prepareMock to also return favorites
+    prepareMock = vi.fn((sql: string) => {
+      if (sql.includes('PRAGMA table_info')) {
+        return { all: () => [{ name: 'comment' }] }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_custom_folders')) {
+        return { get: () => ({ name: 't_custom_folders' }) }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_asset_folder_mapping')) {
+        return { get: () => ({ name: 't_asset_folder_mapping' }) }
+      }
+      if (sql.includes('t_connection_history') && sql.includes("organization_id = 'personal'")) {
+        return { all: () => [recentConnectionRow] }
+      }
+      if (sql.includes('favorite = 1')) {
+        return {
+          all: () => [
+            {
+              label: 'fav-host',
+              asset_ip: '192.168.1.1',
+              uuid: 'fav-uuid',
+              group_name: 'default',
+              auth_type: 'password',
+              port: 22,
+              username: 'root',
+              password: '',
+              key_chain_id: 0,
+              asset_type: 'person'
+            }
+          ]
+        }
+      }
+      if (sql.includes('SELECT DISTINCT group_name')) {
+        return { all: () => [] }
+      }
+      return { all: () => [], get: () => undefined, run: () => ({ changes: 0 }) }
+    })
+
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: prepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+
+    // Recent connections should be first, favorites second
+    expect(result.data.routers.length).toBeGreaterThanOrEqual(2)
+    expect(result.data.routers[0].key).toBe('recent_connections')
+    expect(result.data.routers[1].key).toBe('favorite')
+  })
+
+  it('should not include recent connections when history is empty', async () => {
+    const emptyPrepareMock = vi.fn((sql: string) => {
+      if (sql.includes('PRAGMA table_info')) {
+        return { all: () => [{ name: 'comment' }] }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_custom_folders')) {
+        return { get: () => ({ name: 't_custom_folders' }) }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_asset_folder_mapping')) {
+        return { get: () => ({ name: 't_asset_folder_mapping' }) }
+      }
+      if (sql.includes('t_connection_history')) {
+        return { all: () => [] }
+      }
+      if (sql.includes('favorite = 1')) {
+        return { all: () => [] }
+      }
+      if (sql.includes('SELECT DISTINCT group_name')) {
+        return { all: () => [] }
+      }
+      return { all: () => [], get: () => undefined, run: () => ({ changes: 0 }) }
+    })
+
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: emptyPrepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeUndefined()
+  })
+
+  it('should not include recent connections for assetConfig search type', async () => {
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: prepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'assetConfig', ['person'])
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeUndefined()
+  })
+
+  it('should use zh-CN translation for recent connections title', async () => {
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: prepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeDefined()
+    expect(recentRouter.title).toBe('最近连接')
+  })
+
+  it('should use asset_ip as fallback title when asset_label is missing', async () => {
+    const noLabelPrepareMock = vi.fn((sql: string) => {
+      if (sql.includes('PRAGMA table_info')) {
+        return { all: () => [{ name: 'comment' }] }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_custom_folders')) {
+        return { get: () => ({ name: 't_custom_folders' }) }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_asset_folder_mapping')) {
+        return { get: () => ({ name: 't_asset_folder_mapping' }) }
+      }
+      if (sql.includes('t_connection_history') && sql.includes("organization_id = 'personal'")) {
+        return {
+          all: () => [
+            {
+              asset_uuid: 'uuid-no-label',
+              asset_ip: '172.16.0.1',
+              asset_label: null,
+              asset_port: 2222,
+              asset_username: null,
+              asset_type: 'person',
+              organization_id: 'personal',
+              last_connected: '2026-04-20 10:00:00'
+            }
+          ]
+        }
+      }
+      if (sql.includes('favorite = 1')) {
+        return { all: () => [] }
+      }
+      if (sql.includes('SELECT DISTINCT group_name')) {
+        return { all: () => [] }
+      }
+      return { all: () => [], get: () => undefined, run: () => ({ changes: 0 }) }
+    })
+
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: noLabelPrepareMock } as any
+
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeDefined()
+    const child = recentRouter.children[0]
+    expect(child.title).toBe('172.16.0.1')
+    expect(child.port).toBe(2222)
+    expect(child.username).toBe('')
+  })
+
+  it('should gracefully handle t_connection_history table not existing', async () => {
+    const errorPrepareMock = vi.fn((sql: string) => {
+      if (sql.includes('PRAGMA table_info')) {
+        return { all: () => [{ name: 'comment' }] }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_custom_folders')) {
+        return { get: () => ({ name: 't_custom_folders' }) }
+      }
+      if (sql.includes('SELECT name FROM sqlite_master') && sql.includes('t_asset_folder_mapping')) {
+        return { get: () => ({ name: 't_asset_folder_mapping' }) }
+      }
+      if (sql.includes('t_connection_history')) {
+        throw new Error('no such table: t_connection_history')
+      }
+      if (sql.includes('favorite = 1')) {
+        return { all: () => [] }
+      }
+      if (sql.includes('SELECT DISTINCT group_name')) {
+        return { all: () => [] }
+      }
+      return { all: () => [], get: () => undefined, run: () => ({ changes: 0 }) }
+    })
+
+    const { getLocalAssetRouteLogic } = await import('../assets.routes')
+    const mockDb = { prepare: errorPrepareMock } as any
+
+    // Should not throw - the error is caught silently
+    const result = await getLocalAssetRouteLogic(mockDb, 'tree', ['person'])
+    expect(result.code).toBe(200)
+
+    const recentRouter = result.data.routers.find((r: any) => r.key === 'recent_connections')
+    expect(recentRouter).toBeUndefined()
+  })
+})

--- a/src/main/storage/db/chaterm/assets.routes.ts
+++ b/src/main/storage/db/chaterm/assets.routes.ts
@@ -137,37 +137,48 @@ function buildQizhiGroupedChildren(orgUuid: string, orgAssetType: string, nodes:
 // Import language translations
 const translations = {
   'zh-CN': {
-    favoriteBar: '收藏栏'
+    favoriteBar: '收藏栏',
+    recentConnections: '最近连接'
   },
   'zh-TW': {
-    favoriteBar: '收藏欄'
+    favoriteBar: '收藏欄',
+    recentConnections: '最近連接'
   },
   'en-US': {
-    favoriteBar: 'Favorites'
+    favoriteBar: 'Favorites',
+    recentConnections: 'Recent Connections'
   },
   'ja-JP': {
-    favoriteBar: 'お気に入り'
+    favoriteBar: 'お気に入り',
+    recentConnections: '最近の接続'
   },
   'ko-KR': {
-    favoriteBar: '즐겨찾기'
+    favoriteBar: '즐겨찾기',
+    recentConnections: '최근 연결'
   },
   'de-DE': {
-    favoriteBar: 'Favoriten'
+    favoriteBar: 'Favoriten',
+    recentConnections: 'Letzte Verbindungen'
   },
   'fr-FR': {
-    favoriteBar: 'Favoris'
+    favoriteBar: 'Favoris',
+    recentConnections: 'Connexions r\u00e9centes'
   },
   'it-IT': {
-    favoriteBar: 'Preferiti'
+    favoriteBar: 'Preferiti',
+    recentConnections: 'Connessioni recenti'
   },
   'pt-PT': {
-    favoriteBar: 'Favoritos'
+    favoriteBar: 'Favoritos',
+    recentConnections: 'Conex\u00f5es recentes'
   },
   'ru-RU': {
-    favoriteBar: 'Избранное'
+    favoriteBar: 'Избранное',
+    recentConnections: 'Недавние подключения'
   },
   'ar-AR': {
-    favoriteBar: 'المفضلة'
+    favoriteBar: 'المفضلة',
+    recentConnections: 'الاتصالات الأخيرة'
   }
 }
 
@@ -325,6 +336,40 @@ export async function getLocalAssetRouteLogic(db: Database, searchType: string, 
 
     if (assetType === 'person') {
       if (searchType !== 'assetConfig') {
+        // Recent connections for personal workspace
+        try {
+          const recentStmt = db.prepare(`
+            SELECT asset_uuid, asset_ip, asset_label, asset_port, asset_username, asset_type, organization_id,
+                   MAX(connected_at) as last_connected
+            FROM t_connection_history
+            WHERE organization_id = 'personal'
+            GROUP BY asset_uuid, asset_ip
+            ORDER BY last_connected DESC
+            LIMIT 10
+          `)
+          const recentAssets = recentStmt.all() || []
+
+          if (recentAssets.length > 0) {
+            result.data.routers.push({
+              key: 'recent_connections',
+              title: await getTranslation('recentConnections'),
+              asset_type: 'recent_connections',
+              children: recentAssets.map((item: any) => ({
+                key: `recent_${item.asset_uuid}_${item.asset_ip}_${item.asset_username || 'no_user'}`,
+                title: item.asset_label || item.asset_ip || '',
+                ip: item.asset_ip || '',
+                uuid: item.asset_uuid || '',
+                port: item.asset_port || 22,
+                username: item.asset_username || '',
+                asset_type: item.asset_type || 'person',
+                organizationId: item.organization_id || 'personal'
+              }))
+            })
+          }
+        } catch {
+          // t_connection_history may not exist yet, skip silently
+        }
+
         const favoritesStmt = db.prepare(`
           SELECT label, asset_ip, uuid, group_name,label,auth_type,port,username,password,key_chain_id,asset_type
           FROM t_assets
@@ -408,6 +453,40 @@ export async function getLocalAssetRouteLogic(db: Database, searchType: string, 
 
       // Organization asset logic (JumpServer and Qizhi) - add favorites bar support
       if (searchType !== 'assetConfig') {
+        // Recent connections for enterprise workspace
+        try {
+          const recentStmt = db.prepare(`
+            SELECT asset_uuid, asset_ip, asset_label, asset_port, asset_username, asset_type, organization_id,
+                   MAX(connected_at) as last_connected
+            FROM t_connection_history
+            WHERE organization_id != 'personal'
+            GROUP BY asset_uuid, asset_ip
+            ORDER BY last_connected DESC
+            LIMIT 10
+          `)
+          const recentAssets = recentStmt.all() || []
+
+          if (recentAssets.length > 0) {
+            result.data.routers.push({
+              key: 'recent_connections',
+              title: await getTranslation('recentConnections'),
+              asset_type: 'recent_connections',
+              children: recentAssets.map((item: any) => ({
+                key: `recent_${item.asset_uuid}_${item.asset_ip}_${item.asset_username || 'no_user'}`,
+                title: item.asset_label || item.asset_ip || '',
+                ip: item.asset_ip || '',
+                uuid: item.asset_uuid || '',
+                port: item.asset_port || 22,
+                username: item.asset_username || '',
+                asset_type: item.asset_type || 'organization',
+                organizationId: item.organization_id || ''
+              }))
+            })
+          }
+        } catch {
+          // t_connection_history may not exist yet, skip silently
+        }
+
         const favoriteAssets: any[] = []
 
         // Favorite organizations (based on available types)
@@ -594,5 +673,51 @@ export async function getLocalAssetRouteLogic(db: Database, searchType: string, 
   } catch (error) {
     logger.error('Chaterm database query error', { error: error })
     throw error
+  }
+}
+
+/**
+ * Record a successful SSH connection for the "Recent Connections" feature.
+ * Inserts a row into t_connection_history and cleans up old entries.
+ */
+export function recordConnectionLogic(
+  db: Database.Database,
+  params: {
+    assetUuid: string
+    assetIp: string
+    assetLabel?: string
+    assetPort?: number
+    assetUsername?: string
+    assetType: string
+    organizationId?: string
+  }
+): void {
+  try {
+    const stmt = db.prepare(`
+      INSERT INTO t_connection_history
+        (asset_uuid, asset_ip, asset_label, asset_port, asset_username, asset_type, organization_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+    stmt.run(
+      params.assetUuid,
+      params.assetIp,
+      params.assetLabel || null,
+      params.assetPort || 22,
+      params.assetUsername || null,
+      params.assetType,
+      params.organizationId || 'personal'
+    )
+
+    // Cleanup: keep only the latest 100 rows to prevent unbounded growth
+    db.prepare(
+      `
+      DELETE FROM t_connection_history
+      WHERE id NOT IN (
+        SELECT id FROM t_connection_history ORDER BY connected_at DESC LIMIT 100
+      )
+    `
+    ).run()
+  } catch (error) {
+    logger.error('Failed to record connection history', { error: error })
   }
 }

--- a/src/main/storage/db/chaterm/assets.ts
+++ b/src/main/storage/db/chaterm/assets.ts
@@ -1,4 +1,4 @@
-export { getLocalAssetRouteLogic } from './assets.routes'
+export { getLocalAssetRouteLogic, recordConnectionLogic } from './assets.routes'
 
 export {
   updateLocalAssetLabelLogic,

--- a/src/main/storage/db/connection.ts
+++ b/src/main/storage/db/connection.ts
@@ -13,6 +13,7 @@ import { upgradeBastionCommentSupport } from './migrations/add-bastion-comment-s
 import { upgradeHostInfoSupport } from './migrations/add-host-info-support'
 import { upgradeTaskTitleSupport } from './migrations/add-task-title-support'
 import { upgradeK8sClustersSupport } from './migrations/add-k8s-clusters-support'
+import { upgradeConnectionHistorySupport } from './migrations/add-connection-history-support'
 import { IndexDBMigrator } from './indexdb-migrator'
 import { getUserDataPath } from '../../config/edition'
 const logger = createLogger('db')
@@ -326,6 +327,7 @@ async function applyAllMigrations(db: Database.Database): Promise<void> {
   await upgradeHostInfoSupport(db)
   await upgradeTaskTitleSupport(db)
   await upgradeK8sClustersSupport(db)
+  await upgradeConnectionHistorySupport(db)
 }
 
 export async function initDatabase(userId?: number): Promise<Database.Database> {

--- a/src/main/storage/db/migrations/__tests__/add-connection-history-support.test.ts
+++ b/src/main/storage/db/migrations/__tests__/add-connection-history-support.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import Database from 'better-sqlite3'
+
+vi.mock('@logging/index', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }))
+}))
+
+const { upgradeConnectionHistorySupport } = await import('../add-connection-history-support')
+
+type MockDb = {
+  prepare: (sql: string) => { get: () => unknown }
+  exec: (sql: string) => void
+}
+
+describe('upgradeConnectionHistorySupport', () => {
+  let db: MockDb
+  let execCalls: string[]
+  let tableExists: boolean
+
+  beforeEach(() => {
+    execCalls = []
+    tableExists = false
+
+    db = {
+      prepare(sql: string) {
+        const normalized = sql.trim().toLowerCase()
+        if (normalized.includes('sqlite_master') && normalized.includes('t_connection_history')) {
+          return {
+            get: () => (tableExists ? { name: 't_connection_history' } : undefined)
+          }
+        }
+        return { get: () => undefined }
+      },
+      exec(sql: string) {
+        execCalls.push(sql)
+      }
+    }
+  })
+
+  it('should create t_connection_history table when it does not exist', async () => {
+    tableExists = false
+
+    await upgradeConnectionHistorySupport(db as unknown as Database.Database)
+
+    expect(execCalls).toHaveLength(1)
+    expect(execCalls[0]).toContain('CREATE TABLE t_connection_history')
+    expect(execCalls[0]).toContain('asset_uuid TEXT NOT NULL')
+    expect(execCalls[0]).toContain('asset_ip TEXT NOT NULL')
+    expect(execCalls[0]).toContain('asset_label TEXT')
+    expect(execCalls[0]).toContain('asset_port INTEGER DEFAULT 22')
+    expect(execCalls[0]).toContain('asset_username TEXT')
+    expect(execCalls[0]).toContain('asset_type TEXT NOT NULL')
+    expect(execCalls[0]).toContain('organization_id TEXT')
+    expect(execCalls[0]).toContain('connected_at DATETIME DEFAULT CURRENT_TIMESTAMP')
+  })
+
+  it('should skip migration when table already exists', async () => {
+    tableExists = true
+
+    await upgradeConnectionHistorySupport(db as unknown as Database.Database)
+
+    expect(execCalls).toHaveLength(0)
+  })
+
+  it('should propagate database errors', async () => {
+    const errorDb = {
+      prepare() {
+        throw new Error('Database connection error')
+      }
+    }
+
+    await expect(upgradeConnectionHistorySupport(errorDb as unknown as Database.Database)).rejects.toThrow('Database connection error')
+  })
+})

--- a/src/main/storage/db/migrations/add-connection-history-support.ts
+++ b/src/main/storage/db/migrations/add-connection-history-support.ts
@@ -1,0 +1,35 @@
+import Database from 'better-sqlite3'
+const logger = createLogger('db')
+
+/**
+ * Add t_connection_history table to track recent SSH connections.
+ * Stores connection metadata for the "Recent Connections" feature in the Workspace sidebar.
+ */
+export async function upgradeConnectionHistorySupport(db: Database.Database): Promise<void> {
+  try {
+    const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='t_connection_history'").get()
+
+    if (!tableExists) {
+      logger.info('Creating t_connection_history table...')
+      db.exec(`
+        CREATE TABLE t_connection_history (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          asset_uuid TEXT NOT NULL,
+          asset_ip TEXT NOT NULL,
+          asset_label TEXT,
+          asset_port INTEGER DEFAULT 22,
+          asset_username TEXT,
+          asset_type TEXT NOT NULL,
+          organization_id TEXT,
+          connected_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+      `)
+      logger.info('t_connection_history table created successfully')
+    } else {
+      logger.info('t_connection_history table already exists, skipping migration')
+    }
+  } catch (error) {
+    logger.error('Failed to upgrade connection history support', { error: error })
+    throw error
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -171,6 +171,15 @@ interface ApiType {
   insertCommand: (data: { command: string; ip: string }) => Promise<any>
   aiSuggestCommand: (data: { command: string; osInfo?: string }) => Promise<{ command: string; explanation: string } | null>
   getLocalAssetRoute: (data: { searchType: string; params?: any[] }) => Promise<any>
+  recordConnection: (data: {
+    assetUuid: string
+    assetIp: string
+    assetLabel?: string
+    assetPort?: number
+    assetUsername?: string
+    assetType: string
+    organizationId?: string
+  }) => Promise<void>
   updateLocalAssetLabel: (data: { uuid: string; label: string }) => Promise<any>
   updateLocalAsseFavorite: (data: { uuid: string; status: number }) => Promise<any>
   chatermInsert: (data: { sql: string; params?: any[] }) => Promise<any>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -207,6 +207,22 @@ const getLocalAssetRoute = async (data: { searchType: string; params?: unknown[]
   }
 }
 
+const recordConnection = async (data: {
+  assetUuid: string
+  assetIp: string
+  assetLabel?: string
+  assetPort?: number
+  assetUsername?: string
+  assetType: string
+  organizationId?: string
+}) => {
+  try {
+    await ipcRenderer.invoke('record-connection', data)
+  } catch {
+    // Non-critical: silently ignore recording failures
+  }
+}
+
 const updateLocalAssetLabel = async (data: { uuid: string; label: string }) => {
   try {
     const result = await ipcRenderer.invoke('asset-route-local-update', data)
@@ -584,6 +600,7 @@ const api = {
   insertCommand,
   aiSuggestCommand,
   getLocalAssetRoute,
+  recordConnection,
   updateLocalAssetLabel,
   updateLocalAsseFavorite,
   getKeyChainSelect,

--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -86,6 +86,7 @@ export default {
     pleaseInputPrivateKey: 'الرجاء إدخال المفتاح الخاص',
     localhost: 'المضيف المحلي',
     favoriteBar: 'المفضلة',
+    recentConnections: 'الاتصالات الأخيرة',
     executeCommandToAllWindows: 'تنفيذ الأوامر في جميع النوافذ',
     broadcastTo: 'توصيل إلى {count} التبويبات',
     reloadAliasDataFailed: 'خطأ في تحديث بيانات الألياس',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Bitte geben Sie den privaten Schlüssel ein',
     localhost: 'Localhost',
     favoriteBar: 'Favoriten',
+    recentConnections: 'Letzte Verbindungen',
     executeCommandToAllWindows: 'Befehl an alle Fenster ausführen',
     broadcastTo: 'Broadcast an {count} Terminals',
     reloadAliasDataFailed: 'Alias-Daten konnten nicht neu geladen werden',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Please input private key',
     localhost: 'Localhost',
     favoriteBar: 'Favorites',
+    recentConnections: 'Recent Connections',
     executeCommandToAllWindows: 'Execute command to all windows',
     broadcastTo: 'Broadcast to {count} terminals',
     reloadAliasDataFailed: 'Failed to reload alias data',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Veuillez saisir la clé privée',
     localhost: 'Localhost',
     favoriteBar: 'Favoris',
+    recentConnections: 'Connexions r\u00e9centes',
     executeCommandToAllWindows: 'Exécuter la commande dans toutes les fenêtres',
     broadcastTo: 'Diffuser vers {count} terminaux',
     reloadAliasDataFailed: "Échec du rechargement des données d'alias",

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Inserisci la chiave privata',
     localhost: 'Localhost',
     favoriteBar: 'Favoriti',
+    recentConnections: 'Connessioni recenti',
     executeCommandToAllWindows: 'Esegui comando in tutte le finestre',
     broadcastTo: 'Trasmetti a {count} terminali',
     reloadAliasDataFailed: 'Ricaricamento dati alias fallito',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: '秘密鍵を入力してください',
     localhost: 'ローカルホスト',
     favoriteBar: 'お気に入り',
+    recentConnections: '最近の接続',
     executeCommandToAllWindows: 'すべてのウィンドウでコマンドを実行',
     broadcastTo: '{count} 個のターミナルにブロードキャスト',
     reloadAliasDataFailed: 'エイリアスデータの再読み込みに失敗しました',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: '비밀키를 입력해주세요',
     localhost: '로컬호스트',
     favoriteBar: '즐겨찾기',
+    recentConnections: '최근 연결',
     executeCommandToAllWindows: '모든 창에서 명령 실행',
     broadcastTo: '{count} 개의 터미널에 브로드캐스트',
     reloadAliasDataFailed: '별칭 데이터 다시 로드 실패',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Por favor, introduza a chave privada',
     localhost: 'Localhost',
     favoriteBar: 'Favoritos',
+    recentConnections: 'Conex\u00f5es recentes',
     executeCommandToAllWindows: 'Executar comando em todas as janelas',
     broadcastTo: 'Transmitir para {count} terminais',
     reloadAliasDataFailed: 'Falha ao recarregar dados de alias',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: 'Пожалуйста, введите приватный ключ',
     localhost: 'Локальный хост',
     favoriteBar: 'Избранное',
+    recentConnections: 'Недавние подключения',
     executeCommandToAllWindows: 'Выполнить команду во всех окнах',
     broadcastTo: 'Трансляция в {count} терминалов',
     reloadAliasDataFailed: 'Не удалось перезагрузить данные псевдонимов',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: '请输入私钥',
     localhost: '本地主机',
     favoriteBar: '收藏栏',
+    recentConnections: '最近连接',
     executeCommandToAllWindows: '执行命令到全部窗口',
     broadcastTo: '广播到 {count} 个终端',
     reloadAliasDataFailed: '重新加载别名数据失败',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -98,6 +98,7 @@ export default {
     pleaseInputPrivateKey: '請輸入私鑰',
     localhost: '本地主機',
     favoriteBar: '收藏欄',
+    recentConnections: '最近連接',
     executeCommandToAllWindows: '執行命令到全部視窗',
     broadcastTo: '廣播到 {count} 個終端',
     reloadAliasDataFailed: '重新加載別名數據失敗',

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -1711,7 +1711,21 @@ const connectSSH = async (_opts?: { isAutoReconnect?: boolean }) => {
           disconnectedByNetwork.value = false
           waitingForNetworkRestore.value = false
           autoReconnectAttempts.value = 0
+          // Record connection for "Recent Connections" feature (skip auto-reconnects)
           if (!isAutoReconnect) {
+            try {
+              api.recordConnection({
+                assetUuid: props.connectData.uuid || '',
+                assetIp: props.connectData.ip || connConnectHost || '',
+                assetLabel: props.serverInfo?.title || props.serverInfo?.label || props.connectData.hostname || connHostname || '',
+                assetPort: connPort || 22,
+                assetUsername: connUsername || '',
+                assetType: connAssetType || 'person',
+                organizationId: props.serverInfo?.organizationId || 'personal'
+              })
+            } catch {
+              // Non-critical: do not block connection flow
+            }
             const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
             const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
             terminal.value?.writeln('') // Add empty line separator
@@ -1967,6 +1981,20 @@ const connectLocalSSH = async () => {
 
     const result = await api.connectLocal(localConfig)
     if (result.success) {
+      // Record local connection for "Recent Connections" feature
+      try {
+        api.recordConnection({
+          assetUuid: props.connectData.uuid || props.serverInfo?.key || '',
+          assetIp: '127.0.0.1',
+          assetLabel: props.serverInfo?.title || props.connectData.hostname || 'localhost',
+          assetPort: 0,
+          assetUsername: '',
+          assetType: 'shell',
+          organizationId: 'personal'
+        })
+      } catch {
+        // Non-critical: do not block connection flow
+      }
       const welcomeName = email.split('@')[0] || userInfoStore().userInfo.name
       const welcome = '\x1b[38;2;22;119;255m' + t('ssh.welcomeMessage', { username: welcomeName }) + ' \x1b[m\r\n'
       terminal.value?.writeln('') // Add empty line separator

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -262,6 +262,7 @@
                       company !== 'personal_user_id' &&
                       dataRef.title !== t('common.favoriteBar') &&
                       dataRef.asset_type !== 'custom_folder' &&
+                      dataRef.asset_type !== 'recent_connections' &&
                       !dataRef.isAssetGroup
                     "
                     class="refresh-icon"


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Recent Connections panel showing recently accessed assets in personal and organization workspaces; capped at 100 entries.
  * Connections are recorded automatically after successful connections; recording is non-blocking and failures are silently ignored.

* **Localization**
  * Added "Recent Connections" translations for 11 languages.

* **Improvements**
  * Recent-connections nodes are excluded from per-node refresh controls for clearer UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->