### PR TITLE
feat: enhance remote terminal connection management with stale connection detection

### DIFF
--- a/src/main/agent/integrations/remote-terminal/__tests__/remote-terminal-bastion-manager.test.ts
+++ b/src/main/agent/integrations/remote-terminal/__tests__/remote-terminal-bastion-manager.test.ts
@@ -17,10 +17,14 @@ vi.mock('electron', () => ({
   webContents: { getFocusedWebContents: vi.fn(() => ({ executeJavaScript: vi.fn(() => Promise.resolve(null)) })) }
 }))
 
+const remoteSshConnectMock = vi.fn()
+const isRemoteConnectionAliveMock = vi.fn()
+
 vi.mock('../../../../ssh/agentHandle', () => ({
-  remoteSshConnect: vi.fn(),
+  remoteSshConnect: remoteSshConnectMock,
   remoteSshExecStream: vi.fn().mockResolvedValue({ success: true }),
   remoteSshDisconnect: vi.fn(),
+  isRemoteConnectionAlive: isRemoteConnectionAliveMock,
   isWakeupSession: vi.fn().mockReturnValue(false),
   openWakeupShell: vi.fn(),
   findWakeupConnectionInfoByHost: vi.fn().mockReturnValue(null)
@@ -34,16 +38,23 @@ vi.mock('../../../../ssh/capabilityRegistry', () => ({
   }
 }))
 
+const handleJumpServerConnectionMock = vi.fn()
+const jumpserverShellStreams = new Map()
+
 vi.mock('../jumpserverHandle', () => ({
-  handleJumpServerConnection: vi.fn(),
-  jumpserverShellStreams: new Map(),
+  handleJumpServerConnection: handleJumpServerConnectionMock,
+  jumpserverShellStreams,
   jumpserverMarkedCommands: new Map(),
   jumpServerDisconnect: vi.fn()
 }))
 
 describe('RemoteTerminalManager plugin bastion routing', () => {
   beforeEach(() => {
+    remoteSshConnectMock.mockReset()
+    isRemoteConnectionAliveMock.mockReset()
     getBastionMock.mockReset()
+    handleJumpServerConnectionMock.mockReset()
+    jumpserverShellStreams.clear()
   })
 
   it('uses bastion capability for create/disconnect when sshType is plugin-based', async () => {
@@ -110,5 +121,57 @@ describe('RemoteTerminalManager plugin bastion routing', () => {
     const calls = connectMock.mock.calls as unknown as Array<[{ targetAsset?: string }]>
     const connectArgs = calls[0]?.[0]
     expect(connectArgs?.targetAsset).toBe('ext-22b7275c90-1020-1(10.30.5.14:22|Linux_10.30.5.14)')
+  })
+
+  it('reconnects instead of reusing a stale SSH terminal', async () => {
+    remoteSshConnectMock.mockResolvedValueOnce({ id: 'ssh-session-1' }).mockResolvedValueOnce({ id: 'ssh-session-2' })
+    isRemoteConnectionAliveMock.mockReturnValue(false)
+
+    const { RemoteTerminalManager } = await import('../index')
+    const manager = new RemoteTerminalManager()
+
+    manager.setConnectionInfo({
+      sshType: 'ssh',
+      host: '172.16.0.10',
+      port: 22,
+      username: 'root',
+      password: 'secret',
+      needProxy: false
+    })
+
+    const firstTerminal = await manager.createTerminal()
+    const secondTerminal = await manager.createTerminal()
+
+    expect(firstTerminal.sessionId).toBe('ssh-session-1')
+    expect(secondTerminal.sessionId).toBe('ssh-session-2')
+    expect(remoteSshConnectMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('reconnects instead of reusing a stale JumpServer terminal', async () => {
+    handleJumpServerConnectionMock
+      .mockResolvedValueOnce({ status: 'connected', message: 'ok' })
+      .mockResolvedValueOnce({ status: 'connected', message: 'ok' })
+
+    const { RemoteTerminalManager } = await import('../index')
+    const manager = new RemoteTerminalManager()
+
+    manager.setConnectionInfo({
+      sshType: 'jumpserver',
+      asset_ip: '10.0.0.2',
+      host: '172.16.0.10',
+      port: 22,
+      username: 'root',
+      password: 'secret',
+      needProxy: false
+    })
+
+    const firstTerminal = await manager.createTerminal()
+    jumpserverShellStreams.set(firstTerminal.sessionId, { writable: true })
+    jumpserverShellStreams.clear()
+
+    const secondTerminal = await manager.createTerminal()
+
+    expect(secondTerminal.sessionId).not.toBe(firstTerminal.sessionId)
+    expect(handleJumpServerConnectionMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/agent/integrations/remote-terminal/index.ts
+++ b/src/main/agent/integrations/remote-terminal/index.ts
@@ -5,7 +5,14 @@
 // Licensed under the Apache License, Version 2.0
 
 import { BrownEventEmitter } from './event'
-import { remoteSshConnect, remoteSshExecStream, remoteSshDisconnect, isWakeupSession, openWakeupShell } from '../../../ssh/agentHandle'
+import {
+  remoteSshConnect,
+  remoteSshExecStream,
+  remoteSshDisconnect,
+  isRemoteConnectionAlive,
+  isWakeupSession,
+  openWakeupShell
+} from '../../../ssh/agentHandle'
 import { handleJumpServerConnection, jumpserverShellStreams } from './jumpserverHandle'
 import { capabilityRegistry, BastionErrorCode } from '../../../ssh/capabilityRegistry'
 import { runMarkerBasedCommand, type MarkerStream } from './marker-based-runner'
@@ -936,13 +943,31 @@ export class RemoteTerminalManager {
     )
 
     if (existingTerminal) {
-      logger.debug('Reusing existing remote terminal connection', {
-        event: 'remote-terminal.connect.reuse',
-        terminalId: existingTerminal.id,
-        sessionId: existingTerminal.sessionId,
-        sshType
-      })
-      return existingTerminal
+      let isAlive = true
+      if (sshType === 'jumpserver') {
+        isAlive = jumpserverShellStreams.has(existingTerminal.sessionId)
+      } else if (sshType === 'ssh') {
+        isAlive = isRemoteConnectionAlive(existingTerminal.sessionId)
+      }
+
+      if (!isAlive) {
+        logger.info('Stale terminal detected, removing and reconnecting', {
+          event: 'remote-terminal.connect.stale',
+          terminalId: existingTerminal.id,
+          sessionId: existingTerminal.sessionId,
+          sshType
+        })
+        this.processes.delete(existingTerminal.id)
+        this.terminals.delete(existingTerminal.id)
+      } else {
+        logger.debug('Reusing existing remote terminal connection', {
+          event: 'remote-terminal.connect.reuse',
+          terminalId: existingTerminal.id,
+          sessionId: existingTerminal.sessionId,
+          sshType
+        })
+        return existingTerminal
+      }
     }
 
     try {

--- a/src/main/ssh/agentHandle.ts
+++ b/src/main/ssh/agentHandle.ts
@@ -371,6 +371,10 @@ export async function remoteSshDisconnect(sessionId: string): Promise<{ success?
   return { success: false, error: 'No active remote connection' }
 }
 
+export function isRemoteConnectionAlive(sessionId: string): boolean {
+  return remoteConnections.has(sessionId)
+}
+
 // ============================================================================
 // Wakeup Agent Reuse — Session Detection & Shell Execution
 // ============================================================================


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote terminals now detect stale connections and automatically reconnect instead of reusing inactive sessions.

* **Tests**
  * Enhanced test coverage for terminal reconnection behavior across SSH and JumpServer connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->