### PR TITLE
feat: Implement text selection copying functionality in markdownRenderer component

### DIFF
--- a/src/renderer/src/views/components/AiTab/components/format/__tests__/markdownRenderer.test.ts
+++ b/src/renderer/src/views/components/AiTab/components/format/__tests__/markdownRenderer.test.ts
@@ -97,6 +97,8 @@ vi.mock('@ant-design/icons-vue', () => ({
   QuestionCircleOutlined: { template: '<span />' }
 }))
 
+const clipboardWriteText = vi.fn().mockResolvedValue(undefined)
+
 const globalMountOptions = {
   global: {
     stubs: {
@@ -113,6 +115,11 @@ describe('markdownRenderer kb search results', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     document.documentElement.className = ''
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText: clipboardWriteText },
+      configurable: true
+    })
+    window.getSelection()?.removeAllRanges()
   })
 
   it('renders structured kb search results as clickable links', async () => {
@@ -179,5 +186,47 @@ describe('markdownRenderer kb search results', () => {
 
     expect(wrapper.find('.kb-search-result-link').exists()).toBe(false)
     expect(wrapper.text()).toContain('Plain text message')
+  })
+
+  it('copies selected markdown text with keyboard shortcut', async () => {
+    const content = 'Copy this text'
+    const wrapper = mount(MarkdownRenderer, {
+      ...globalMountOptions,
+      attachTo: document.body,
+      props: {
+        content,
+        say: 'text'
+      }
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    const paragraph = wrapper.find('.markdown-content p')
+    expect(paragraph.exists()).toBe(true)
+
+    const textNode = paragraph.element.firstChild
+    expect(textNode).not.toBeNull()
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(textNode!, 0)
+    range.setEnd(textNode!, content.length)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'c',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    document.dispatchEvent(event)
+    await flushPromises()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(clipboardWriteText).toHaveBeenCalledWith(content)
+
+    wrapper.unmount()
   })
 })

--- a/src/renderer/src/views/components/AiTab/components/format/markdownRenderer.vue
+++ b/src/renderer/src/views/components/AiTab/components/format/markdownRenderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="containerRef">
     <div
       v-if="props.ask === 'command' || props.say === 'command'"
       ref="editorContainer"
@@ -517,6 +517,7 @@ let thinkingMeasurementToken = 0
 const isCancelled = ref(false)
 const commandOutputActiveKey = ref<string[]>(['1'])
 const activeKey = ref<string[]>(['1'])
+const containerRef = ref<HTMLElement | null>(null)
 const contentRef = ref<HTMLElement | null>(null)
 // Template ref used in template
 // @ts-expect-error - Template ref, used in template via ref="editorContainer"
@@ -1113,6 +1114,7 @@ onMounted(async () => {
   })
 
   themeObserver.observe(document.documentElement, { attributes: true })
+  document.addEventListener('keydown', handleSelectedTextCopy, true)
 
   if (props.content) {
     if (props.ask === 'command' || props.say === 'command') {
@@ -1248,6 +1250,7 @@ watch(
 
 onBeforeUnmount(() => {
   themeObserver.disconnect()
+  document.removeEventListener('keydown', handleSelectedTextCopy, true)
 
   if (contentStableTimeout.value) {
     clearTimeout(contentStableTimeout.value)
@@ -1466,6 +1469,38 @@ const processContentLines = async (content: string) => {
 const contentLines = computed(() => {
   return processedContentLines.value
 })
+
+const isSelectionWithinContainer = (selection: Selection): boolean => {
+  const container = containerRef.value
+  if (!container || selection.rangeCount === 0) return false
+
+  for (let index = 0; index < selection.rangeCount; index++) {
+    const range = selection.getRangeAt(index)
+    if (container.contains(range.commonAncestorContainer)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const handleSelectedTextCopy = (event: KeyboardEvent) => {
+  const isCopyShortcut = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c'
+  if (!isCopyShortcut) return
+
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed) return
+  if (!isSelectionWithinContainer(selection)) return
+
+  const text = selection.toString()
+  if (!text.trim()) return
+
+  event.preventDefault()
+  event.stopPropagation()
+  navigator.clipboard.writeText(text).catch((error) => {
+    logger.error('Failed to copy selected markdown text', { error })
+  })
+}
 
 const copyEditorContent = () => {
   if (editor) {
@@ -1760,6 +1795,8 @@ code {
   word-wrap: break-word;
   word-break: break-word;
   overflow-wrap: break-word;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .markdown-content ul,


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (Cmd/Ctrl+C) to copy selected markdown text.

* **Improvements**
  * Markdown content is now selectable for user copying.

* **Tests**
  * Added unit tests for markdown copy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->