### PR TITLE
feat: enhance auto-scroll functionality to ensure visibility of inline approval buttons during streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 </div>
 <br>
 
-
 <!-- Vote for Chaterm on DevHunt! -->
 <br>
 <p align="center">
@@ -16,7 +15,6 @@
   </a>
 </p>
 <br><br>
-
 
 <p align="center">
   <a href="https://www.tbench.ai/leaderboard/terminal-bench/1.0"><img src="https://img.shields.io/badge/Terminal--Bench-Ranked_%232-00D94E?style=for-the-badge&logo=github&logoColor=white" alt="Terminal-Bench"></a>
@@ -42,7 +40,6 @@
   <a href="https://aws.amazon.com/marketplace/"><img src="https://img.shields.io/badge/AWS-Marketplace-FF9900?style=for-the-badge&logo=amazon-aws&logoColor=white&labelColor=232F3E" alt="AWS Marketplace"></a>
   <p align="center">
 </p>
-
 
 ## Table of Contents
 

--- a/src/renderer/src/views/components/AiTab/composables/useAutoScroll.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useAutoScroll.ts
@@ -114,10 +114,23 @@ export function useAutoScroll(options: AutoScrollOptions = {}) {
   const scrollToBottomWithRetry = (maxRetries = 5, delay = 50) => {
     let retryCount = 0
     let lastScrollHeight = 0
+    isProgrammaticScroll.value = true
+
+    const finish = () => {
+      // Release the flag after the last scroll event has had a chance to fire.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          isProgrammaticScroll.value = false
+        }, 100)
+      })
+    }
 
     const attemptScroll = () => {
       const el = getElement(chatContainer.value)
-      if (!(el instanceof HTMLElement)) return
+      if (!(el instanceof HTMLElement)) {
+        finish()
+        return
+      }
 
       const currentScrollHeight = el.scrollHeight
       const clientHeight = el.clientHeight
@@ -131,6 +144,7 @@ export function useAutoScroll(options: AutoScrollOptions = {}) {
       const scrollHeightChanged = currentScrollHeight !== lastScrollHeight
 
       if (isReallyAtBottom && !scrollHeightChanged && retryCount > 0) {
+        finish()
         return
       }
 
@@ -141,6 +155,8 @@ export function useAutoScroll(options: AutoScrollOptions = {}) {
         setTimeout(() => {
           requestAnimationFrame(attemptScroll)
         }, delay)
+      } else {
+        finish()
       }
     }
 
@@ -275,7 +291,10 @@ export function useAutoScroll(options: AutoScrollOptions = {}) {
       if (isTerminalToggleMutation(mutations, responseEl)) return
 
       if (shouldStickToBottom.value) {
-        executeScroll()
+        // Use retry-based scroll so late-rendered children (e.g. approval
+        // buttons with async icons / tooltips) that grow scrollHeight after
+        // the initial frame still get pinned to the bottom.
+        scrollToBottomWithRetry()
       }
     })
 

--- a/src/renderer/src/views/components/AiTab/index.vue
+++ b/src/renderer/src/views/components/AiTab/index.vue
@@ -885,6 +885,7 @@ const {
   isLastMessage,
   messageFeedbacks,
   buttonsDisabled,
+  shouldStickToBottom,
   getTabUserAssistantPairs,
   getTabHasOlderHistory,
   getTabChatTypeValue,
@@ -904,15 +905,22 @@ const { currentTodos, shouldShowTodoAfterMessage, getTodosForMessage, markLatest
 // Host state management
 const { updateHosts, updateHostsForCommandMode, getCurentTabAssetInfo } = useHostState()
 // Auto scroll
-const { chatContainer, chatResponse, historyTopSentinel, scrollToBottom, initializeAutoScroll, handleTabSwitch, getMessagePairStyle } = useAutoScroll(
-  {
-    onReachHistoryTop: (container) => {
-      const tabId = currentChatId.value
-      if (!tabId) return
-      void loadOlderHistoryForTab(tabId, { container })
-    }
+const {
+  chatContainer,
+  chatResponse,
+  historyTopSentinel,
+  scrollToBottom,
+  scrollToBottomWithRetry,
+  initializeAutoScroll,
+  handleTabSwitch,
+  getMessagePairStyle
+} = useAutoScroll({
+  onReachHistoryTop: (container) => {
+    const tabId = currentChatId.value
+    if (!tabId) return
+    void loadOlderHistoryForTab(tabId, { container })
   }
-)
+})
 
 // AI chat search
 const {
@@ -1144,6 +1152,27 @@ watch(
   () => localStorage.getItem('login-skipped'),
   (newValue) => {
     isSkippedLogin.value = newValue === 'true'
+  }
+)
+
+// When a streaming response finishes and the last message is awaiting user
+// approval (command / mcp_tool_call), the inline approval buttons mount in
+// the next tick. If the user drifted from bottom during streaming,
+// shouldStickToBottom may have been cleared and the MutationObserver won't
+// re-pin. Force a sticky scroll so the buttons stay visible.
+watch(
+  () => currentSession.value?.responseLoading,
+  (loading, prevLoading) => {
+    if (prevLoading && !loading) {
+      const session = currentSession.value
+      if (!session) return
+      const history = session.chatHistory
+      const last = history?.[history.length - 1]
+      if (last && (last.ask === 'command' || last.ask === 'mcp_tool_call')) {
+        shouldStickToBottom.value = true
+        nextTick(() => scrollToBottomWithRetry())
+      }
+    }
   }
 )
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #2130 

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable auto-scroll to keep conversations pinned to the bottom as content grows or updates.
  * Ensures approval/action buttons for command/tool responses remain visible after responses finish loading.
  * Prevents unexpected scroll jumps and sticky-bottom state inconsistencies during active chat sessions.

* **Documentation**
  * Minor README whitespace cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->