### PR TITLE
feat: add functionality to show and hide hidden files in the file explorer

### DIFF
--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1189,6 +1189,8 @@ export default {
     transferSuccess: 'تحويل ناجح',
     transferFailed: 'تحويل غير ناجح',
     openFolder: 'فتح المجلد',
+    showHiddenFiles: 'إظهار الملفات المخفية',
+    hideHiddenFiles: 'إخفاء الملفات المخفية',
     uploadSkipped: 'رفع ملغي',
     transferSkipped: 'تحويل ملغي',
     transferCancel: 'تحويل ملغي',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1218,6 +1218,8 @@ export default {
     transferSuccess: 'Übertragung abgeschlossen',
     transferFailed: 'Übertragung fehlgeschlagen',
     openFolder: 'Ordner öffnen',
+    showHiddenFiles: 'Versteckte Dateien anzeigen',
+    hideHiddenFiles: 'Versteckte Dateien ausblenden',
     uploadSkipped: 'Upload wurde übersprungen',
     transferSkipped: 'Übertragung übersprungen',
     transferCancel: 'Übertragung abgebrochen',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -1213,6 +1213,8 @@ export default {
     transferSuccess: 'Transfer completed',
     transferFailed: 'Transfer failed',
     openFolder: 'Open Folder',
+    showHiddenFiles: 'Show Hidden Files',
+    hideHiddenFiles: 'Hide Hidden Files',
     uploadSkipped: 'Upload skipped',
     transferSkipped: 'Transfer skipped',
     transferCancel: 'Transfer canceled',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1223,6 +1223,8 @@ export default {
     transferSuccess: 'Transmission terminée',
     transferFailed: 'Échec de la transmission',
     openFolder: 'Ouvrir le dossier',
+    showHiddenFiles: 'Afficher les fichiers cachés',
+    hideHiddenFiles: 'Masquer les fichiers cachés',
     uploadSkipped: 'Téléchargement ignoré',
     transferSkipped: 'Transfert ignoré',
     transferCancel: 'Transfert annulé',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1217,6 +1217,8 @@ export default {
     transferSuccess: 'Trasferimento completato',
     transferFailed: 'Trasferimento fallito',
     openFolder: 'Apri cartella',
+    showHiddenFiles: 'Mostra file nascosti',
+    hideHiddenFiles: 'Nascondi file nascosti',
     uploadSkipped: 'Caricamento ignorato',
     transferSkipped: 'Trasferimento ignorato',
     transferCancel: 'Trasferimento annullato',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1207,6 +1207,8 @@ export default {
     transferSuccess: '転送完了',
     transferFailed: '転送失敗',
     openFolder: 'フォルダを開く',
+    showHiddenFiles: '隠しファイルを表示',
+    hideHiddenFiles: '隠しファイルを非表示',
     uploadSkipped: 'アップロードをスキップしました',
     transferSkipped: '転送をスキップしました',
     transferCancel: '転送がキャンセルされました',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1202,6 +1202,8 @@ export default {
     transferSuccess: '전송 완료',
     transferFailed: '전송 실패',
     openFolder: '폴더 열기',
+    showHiddenFiles: '숨김 파일 표시',
+    hideHiddenFiles: '숨김 파일 숨기기',
     uploadSkipped: '업로드를 건너뛰었습니다',
     transferSkipped: '전송을 건너뛰었습니다',
     transferCancel: '전송이 취소되었습니다',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1215,6 +1215,8 @@ export default {
     transferSuccess: 'Transferência concluída',
     transferFailed: 'A transferência falhou',
     openFolder: 'Abrir pasta',
+    showHiddenFiles: 'Mostrar ficheiros ocultos',
+    hideHiddenFiles: 'Ocultar ficheiros ocultos',
     uploadSkipped: 'O upload foi pulado',
     transferSkipped: 'Transmissão ignorada',
     transferCancel: 'Transmissão cancelada',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1215,6 +1215,8 @@ export default {
     transferSuccess: 'Передача завершена',
     transferFailed: 'Передача не удалась',
     openFolder: 'Открыть папку',
+    showHiddenFiles: 'Показать скрытые файлы',
+    hideHiddenFiles: 'Скрыть скрытые файлы',
     uploadSkipped: 'Загрузка пропущена',
     transferSkipped: 'Передача пропущена',
     transferCancel: 'Передача отменена',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -1196,6 +1196,8 @@ export default {
     transferSuccess: '传输完成',
     transferFailed: '传输失败',
     openFolder: '打开文件夹',
+    showHiddenFiles: '显示隐藏文件',
+    hideHiddenFiles: '隐藏隐藏文件',
     uploadSkipped: '已跳过上传',
     transferSkipped: '已跳过传输',
     transferCancel: '已取消传输',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -1196,6 +1196,8 @@ export default {
     transferSuccess: '傳輸完成',
     transferFailed: '傳輸失敗',
     openFolder: '打開文件夾',
+    showHiddenFiles: '顯示隱藏檔案',
+    hideHiddenFiles: '隱藏隱藏檔案',
     uploadSkipped: '已跳過上傳',
     transferSkipped: '已跳過傳輸',
     transferCancel: '已取消傳輸',

--- a/src/renderer/src/views/components/Files/__tests__/files.test.ts
+++ b/src/renderer/src/views/components/Files/__tests__/files.test.ts
@@ -46,6 +46,8 @@ const i18n = createI18n({
         write: 'Write',
         exec: 'Execute',
         rollback: 'Rollback',
+        showHiddenFiles: 'Show Hidden Files',
+        hideHiddenFiles: 'Hide Hidden Files',
 
         // upload
         uploadSuccess: 'Upload success',
@@ -124,6 +126,8 @@ const iconStubs = {
   DownloadOutlined: true,
   EditOutlined: true,
   EllipsisOutlined: true,
+  EyeOutlined: true,
+  EyeInvisibleOutlined: true,
   FileFilled: true,
   FolderFilled: true,
   FolderOpenOutlined: true,
@@ -772,5 +776,133 @@ describe('files.vue (enhanced)', () => {
     expect(vm.currentRecord).toBe(null)
 
     wrapper.unmount()
+  })
+
+  describe('hidden files toggle', () => {
+    const dotFilesListing = [
+      { name: '.bashrc', path: '/home/u/.bashrc', isDir: false, mode: '0644', isLink: false, modTime: '', size: 1 },
+      { name: '.ssh', path: '/home/u/.ssh', isDir: true, mode: '0700', isLink: false, modTime: '', size: 0 },
+      { name: 'notes.txt', path: '/home/u/notes.txt', isDir: false, mode: '0644', isLink: false, modTime: '', size: 2 },
+      { name: 'docs', path: '/home/u/docs', isDir: true, mode: '0755', isLink: false, modTime: '', size: 0 }
+    ]
+
+    it('defaults to showing hidden files (showHidden = true)', async () => {
+      api.sshSftpList.mockResolvedValueOnce(dotFilesListing as any)
+      const wrapper = mountView({ currentDirectoryInput: '/home/u' })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.showHidden).toBe(true)
+
+      const names = vm.visibleFiles.map((f: any) => f.name)
+      // includes parent ("..") + dot entries + regular entries
+      expect(names).toContain('..')
+      expect(names).toContain('.bashrc')
+      expect(names).toContain('.ssh')
+      expect(names).toContain('notes.txt')
+      expect(names).toContain('docs')
+
+      wrapper.unmount()
+    })
+
+    it('toggleHidden flips the state and filters dot-prefixed files/dirs while keeping parent ".."', async () => {
+      api.sshSftpList.mockResolvedValueOnce(dotFilesListing as any)
+      const wrapper = mountView({ currentDirectoryInput: '/home/u' })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+
+      // hide hidden
+      vm.toggleHidden()
+      await flushPromises()
+      expect(vm.showHidden).toBe(false)
+
+      const hiddenOffNames = vm.visibleFiles.map((f: any) => f.name)
+      expect(hiddenOffNames).toContain('..')
+      expect(hiddenOffNames).toContain('docs')
+      expect(hiddenOffNames).toContain('notes.txt')
+      expect(hiddenOffNames).not.toContain('.bashrc')
+      expect(hiddenOffNames).not.toContain('.ssh')
+
+      // underlying files array is NOT mutated
+      const rawNames = vm.files.map((f: any) => f.name)
+      expect(rawNames).toContain('.bashrc')
+      expect(rawNames).toContain('.ssh')
+
+      // toggle back on
+      vm.toggleHidden()
+      await flushPromises()
+      expect(vm.showHidden).toBe(true)
+      const restored = vm.visibleFiles.map((f: any) => f.name)
+      expect(restored).toContain('.bashrc')
+      expect(restored).toContain('.ssh')
+
+      wrapper.unmount()
+    })
+
+    it('visibleFiles stays reactive when files list is reloaded while hidden is off', async () => {
+      api.sshSftpList.mockResolvedValueOnce(dotFilesListing as any)
+      const wrapper = mountView({ currentDirectoryInput: '/home/u' })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.toggleHidden()
+      await flushPromises()
+      expect(vm.showHidden).toBe(false)
+
+      // refresh with a new listing that contains a new dot-entry and a new regular entry
+      api.sshSftpList.mockResolvedValueOnce([
+        { name: '.env', path: '/home/u/.env', isDir: false, mode: '0644', isLink: false, modTime: '', size: 3 },
+        { name: 'readme.md', path: '/home/u/readme.md', isDir: false, mode: '0644', isLink: false, modTime: '', size: 4 }
+      ] as any)
+      await vm.refresh()
+      await flushPromises()
+
+      const names = vm.visibleFiles.map((f: any) => f.name)
+      expect(names).toContain('readme.md')
+      expect(names).not.toContain('.env')
+      // parent ".." is injected for non-root paths
+      expect(names).toContain('..')
+
+      wrapper.unmount()
+    })
+
+    it('parent entry ".." is always visible regardless of toggle state', async () => {
+      api.sshSftpList.mockResolvedValueOnce([
+        { name: '.secret', path: '/home/u/.secret', isDir: false, mode: '0600', isLink: false, modTime: '', size: 1 }
+      ] as any)
+      const wrapper = mountView({ currentDirectoryInput: '/home/u' })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      // hide
+      vm.toggleHidden()
+      await flushPromises()
+      const names = vm.visibleFiles.map((f: any) => f.name)
+      expect(names).toContain('..')
+      expect(names).not.toContain('.secret')
+
+      wrapper.unmount()
+    })
+
+    it('does nothing visible when there are no dot-prefixed files', async () => {
+      api.sshSftpList.mockResolvedValueOnce([
+        { name: 'a.txt', path: '/home/u/a.txt', isDir: false, mode: '0644', isLink: false, modTime: '', size: 1 },
+        { name: 'b', path: '/home/u/b', isDir: true, mode: '0755', isLink: false, modTime: '', size: 0 }
+      ] as any)
+      const wrapper = mountView({ currentDirectoryInput: '/home/u' })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      const before = vm.visibleFiles.map((f: any) => f.name)
+
+      vm.toggleHidden()
+      await flushPromises()
+      const after = vm.visibleFiles.map((f: any) => f.name)
+
+      expect(after).toEqual(before)
+
+      wrapper.unmount()
+    })
   })
 })

--- a/src/renderer/src/views/components/Files/files.vue
+++ b/src/renderer/src/views/components/Files/files.vue
@@ -88,6 +88,23 @@
           </a-space>
           <a-space>
             <div class="fs-header-right-item">
+              <a-tooltip :title="showHidden ? $t('files.hideHiddenFiles') : $t('files.showHiddenFiles')">
+                <a-button
+                  type="primary"
+                  size="small"
+                  ghost
+                  @click="toggleHidden"
+                >
+                  <template #icon>
+                    <EyeOutlined v-if="showHidden" />
+                    <EyeInvisibleOutlined v-else />
+                  </template>
+                </a-button>
+              </a-tooltip>
+            </div>
+          </a-space>
+          <a-space>
+            <div class="fs-header-right-item">
               <a-tooltip :title="$t('common.refresh')">
                 <a-button
                   type="primary"
@@ -124,7 +141,7 @@
           ref="tableRef"
           :row-key="(record: FileRecord) => record.name"
           :columns="tableColumns"
-          :data-source="files"
+          :data-source="visibleFiles"
           size="small"
           :pagination="false"
           :loading="loading"
@@ -463,6 +480,8 @@ import {
   EditOutlined,
   EllipsisOutlined,
   ExclamationCircleOutlined,
+  EyeOutlined,
+  EyeInvisibleOutlined,
   FileFilled,
   FolderFilled,
   LinkOutlined,
@@ -563,6 +582,14 @@ const panelSide = computed(() => props.panelSide as PanelSide)
 const localCurrentDirectoryInput = ref(props.currentDirectoryInput)
 const basePath = ref(props.basePath)
 const files = ref<FileRecord[]>([])
+const showHidden = ref(true)
+const visibleFiles = computed(() => {
+  if (showHidden.value) return files.value
+  return files.value.filter((f) => f.key === '..' || !f.name.startsWith('.'))
+})
+const toggleHidden = () => {
+  showHidden.value = !showHidden.value
+}
 const loading = ref(false)
 const showErr = ref(false)
 const errTips = ref('')


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #2133 

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle hidden files visibility in the file manager with a dedicated UI control.

* **Localization**
  * Added support for show/hide hidden files labels in 11 additional languages (Arabic, German, French, Italian, Japanese, Korean, Portuguese, Russian, Simplified Chinese, Traditional Chinese, and English).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->