### PR TITLE
fix: forward terminal command results reliably

### DIFF
--- a/src/main/agent/core/controller/__tests__/controller.test.ts
+++ b/src/main/agent/core/controller/__tests__/controller.test.ts
@@ -315,7 +315,34 @@ describe('Controller', () => {
     } as WebviewMessage)
 
     expect(clearTodosSpy).toHaveBeenCalledWith('new_user_input')
-    expect(handleResponseSpy).toHaveBeenCalledWith('messageResponse', 'response text', undefined, undefined)
+    expect(handleResponseSpy).toHaveBeenCalledWith('messageResponse', 'response text', undefined, undefined, undefined)
+  })
+
+  it('handleWebviewMessage(askResponse) should forward command tool result to task', async () => {
+    const controller = new Controller(
+      async () => true,
+      async () => '/tmp/mcp_settings.json'
+    )
+
+    await controller.initTask([createMockHost('1')], 'task 1', 'task-1')
+
+    const task = controller.getAllTasks().find((t) => t.taskId === 'task-1')
+    expect(task).toBeDefined()
+
+    const handleResponseSpy = vi.spyOn(task!, 'handleWebviewAskResponse')
+    const toolResult = {
+      output: 'ProductName:\t\tmacOS\nProductVersion:\t\t14.6.1',
+      toolName: 'execute_command'
+    }
+
+    await controller.handleWebviewMessage({
+      type: 'askResponse',
+      taskId: 'task-1',
+      askResponse: 'yesButtonClicked',
+      toolResult
+    } as WebviewMessage)
+
+    expect(handleResponseSpy).toHaveBeenCalledWith('yesButtonClicked', undefined, undefined, undefined, toolResult)
   })
 
   it('reloadSecurityConfigForAllTasks should reload config for all tasks', async () => {

--- a/src/main/agent/core/controller/index.ts
+++ b/src/main/agent/core/controller/index.ts
@@ -306,7 +306,13 @@ export class Controller {
                 taskId: task.taskId
               })
             }
-            await task.handleWebviewAskResponse(message.askResponse!, message.text, message.truncateAtMessageTs, message.contentParts)
+            await task.handleWebviewAskResponse(
+              message.askResponse!,
+              message.text,
+              message.truncateAtMessageTs,
+              message.contentParts,
+              message.toolResult
+            )
           }
         }
         break

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -3764,22 +3764,12 @@ const handleCommandOutput = (data: string, isInitialCommand: boolean) => {
         case 'linux':
         case 'unknown': {
           // Linux/Git Bash terminal processing (Git Bash uses same logic as Linux)
-          const filteredLines = lines.filter((line) => line.trim())
+          const filteredLines = lines.map((line) => stripAnsiExtended(line).trimEnd()).filter((line) => line.trim())
 
           const isCommandEchoLine = (line: string): boolean => {
             // First, clean ANSI sequences to ensure command detection works correctly
             // Git Bash command echo may contain color codes (e.g., colored $ symbol)
-            let cleanedLine = line
-              .replace(/\x1b\[[0-9;]*m/g, '') // Color codes
-              .replace(/\x1b\[[0-9;]*[ABCDEFGJKST]/g, '') // Cursor movement
-              .replace(/\x1b\[[0-9]*[XK]/g, '') // Erase sequences
-              .replace(/\x1b\[[0-9;]*[Hf]/g, '') // Position sequences
-              .replace(/\x1b\[[?][0-9;]*[hl]/g, '') // Mode sequences
-              .replace(/\x1b\]0;[^\x07]*\x07/g, '') // Window title
-              .replace(/\x1b\]9;[^\x07]*\x07/g, '') // PowerShell sequences
-              .replace(/\x1b\[[?]25[hl]/g, '') // Cursor visibility
-              .replace(/\x1b\[[0-9;]*[JK]/g, '') // Erase in display/line
-              .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Control chars
+            const cleanedLine = stripAnsiExtended(line)
 
             const trimmed = cleanedLine.trim()
             if (!trimmed) return false
@@ -3834,18 +3824,7 @@ const handleCommandOutput = (data: string, isInitialCommand: boolean) => {
           // Helper function to clean ANSI sequences for prompt detection
           // This ensures prompts with ANSI color codes can be correctly identified
           const cleanLineForPromptCheck = (line: string): string => {
-            return line
-              .replace(/\x1b\[[0-9;]*m/g, '') // Color codes
-              .replace(/\x1b\[[0-9;]*[ABCDEFGJKST]/g, '') // Cursor movement
-              .replace(/\x1b\[[0-9]*[XK]/g, '') // Erase sequences
-              .replace(/\x1b\[[0-9;]*[Hf]/g, '') // Position sequences
-              .replace(/\x1b\[[?][0-9;]*[hl]/g, '') // Mode sequences
-              .replace(/\x1b\]0;[^\x07]*\x07/g, '') // Window title
-              .replace(/\x1b\]9;[^\x07]*\x07/g, '') // PowerShell sequences
-              .replace(/\x1b\[[?]25[hl]/g, '') // Cursor visibility
-              .replace(/\x1b\[[0-9;]*[JK]/g, '') // Erase in display/line
-              .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Control chars
-              .trim()
+            return stripAnsiExtended(line).trim()
           }
 
           // Remove all consecutive prompt lines from the end

--- a/src/renderer/src/views/components/Ssh/utils/__tests__/terminalPrompt.test.ts
+++ b/src/renderer/src/views/components/Ssh/utils/__tests__/terminalPrompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getLastNonEmptyLine, isTerminalPromptLine, matchPrompt } from '../terminalPrompt'
+import { stripAnsiBasic } from '../ansiUtils'
 
 describe('terminalPrompt utils', () => {
   describe('getLastNonEmptyLine', () => {
@@ -50,6 +51,22 @@ describe('terminalPrompt utils', () => {
       const output = 'checksum $ '
       expect(getLastNonEmptyLine(output)).toBe('$')
     })
+
+    it('extracts zsh theme prompt after macOS redraw sequences', () => {
+      const output =
+        'ProductName:\t\tmacOS\r\n' +
+        '\x1b[1m\x1b[7m%\x1b[27m\x1b[1m\x1b[0m     \r \r' +
+        '\x1b]2;user@host:~\x07\x1b]1;~\x07' +
+        '\x1b]7;file://host/Users/test\x1b\\' +
+        '\r\x1b[0m\x1b[27m\x1b[24m\x1b[J(base) \x1b[01;32m➜  \x1b[36m~\x1b[00m \x1b[K\x1b[?1h\x1b=\x1b[?2004h'
+
+      expect(getLastNonEmptyLine(output)).toBe('(base) ➜  ~')
+    })
+
+    it('does not extract zsh prompt markers from ordinary output text', () => {
+      expect(getLastNonEmptyLine('Deploy ➜ production')).toBe('Deploy ➜ production')
+      expect(getLastNonEmptyLine('Next ❯ done')).toBe('Next ❯ done')
+    })
   })
 
   describe('isTerminalPromptLine', () => {
@@ -92,6 +109,12 @@ describe('terminalPrompt utils', () => {
       expect(isTerminalPromptLine('~ $')).toBe(true)
       expect(isTerminalPromptLine('./src $')).toBe(true)
       expect(isTerminalPromptLine('(venv) ~/code $')).toBe(true)
+    })
+
+    it('matches zsh theme prompts', () => {
+      expect(isTerminalPromptLine('(base) ➜  ~')).toBe(true)
+      expect(isTerminalPromptLine('➜  Chaterm git:(main) ✗')).toBe(true)
+      expect(isTerminalPromptLine('❯  ~/code')).toBe(true)
     })
 
     it('matches fish shell prompts', () => {
@@ -138,6 +161,7 @@ describe('terminalPrompt utils', () => {
       expect(isTerminalPromptLine('Info: The max number of VTY users is 5')).toBe(false)
       expect(isTerminalPromptLine('Compiled Tue 23-Apr-19 02:38 by mmen')).toBe(false)
       expect(isTerminalPromptLine('ROM: Bootstrap program is Linux')).toBe(false)
+      expect(isTerminalPromptLine('Deploy ➜ production')).toBe(false)
       expect(
         isTerminalPromptLine(
           '["aliyun_sandbox","aliyun_autom","sandbox","secautom","uc_sandbox","autom","nx_autom","us_autom","us_sandbox"][xuhong_yao@AutomConsulSitC-172-16-158-235 ~]$'
@@ -161,6 +185,16 @@ describe('terminalPrompt utils', () => {
       const result = matchPrompt('Not a prompt line')
       expect(result.isPrompt).toBe(false)
       expect(result.type).toBe('unknown')
+    })
+  })
+
+  describe('ANSI cleanup for prompt and command echo parsing', () => {
+    it('strips OSC title sequences used by macOS zsh', () => {
+      expect(stripAnsiBasic('\x1b]2;sw_vers\x07\x1b]1;sw_vers\x07ProductName:\t\tmacOS')).toBe('ProductName:\t\tmacOS')
+    })
+
+    it('applies backspace redraws before comparing command echo', () => {
+      expect(stripAnsiBasic('s\x08sw_vers\x1b[?1l\x1b>\x1b[?2004l')).toBe('sw_vers')
     })
   })
 })

--- a/src/renderer/src/views/components/Ssh/utils/ansiUtils.ts
+++ b/src/renderer/src/views/components/Ssh/utils/ansiUtils.ts
@@ -6,6 +6,8 @@ const ANSI_CURSOR_MOVE_RE = /\x1b\[[0-9;]*[ABCDEFGJKST]/g
 const ANSI_ERASE_RE = /\x1b\[[0-9]*[XK]/g
 const ANSI_POSITION_RE = /\x1b\[[0-9;]*[Hf]/g
 const ANSI_MODE_RE = /\x1b\[[?][0-9;]*[hl]/g
+const ANSI_KEYPAD_MODE_RE = /\x1b[=>]/g
+const OSC_SEQUENCE_RE = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g
 const OSC_TITLE_RE = /\x1b\]0;[^\x07]*\x07/g
 const OSC_PS_RE = /\x1b\]9;[^\x07]*\x07/g
 const CONTROL_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g
@@ -15,21 +17,38 @@ const ANSI_CURSOR_VISIBILITY_RE = /\x1b\[[?]25[hl]/g
 const ANSI_ERASE_DISPLAY_RE = /\x1b\[[0-9;]*[JK]/g
 const CONTROL_CHARS_EXTENDED_RE = /[\x00-\x07\x0B\x0C\x0E-\x1F\x7F]/g
 
+const processBackspaces = (str: string): string => {
+  const result: string[] = []
+
+  for (const char of str) {
+    if (char === '\x08') {
+      result.pop()
+      continue
+    }
+    result.push(char)
+  }
+
+  return result.join('')
+}
+
 /**
  * Strip basic ANSI sequences: color, cursor movement, erase, position, mode,
  * OSC title/PowerShell sequences, and control characters.
- * This is the most commonly used variant (8-pattern chain).
+ * This is the most commonly used variant.
  */
 export const stripAnsiBasic = (str: string): string =>
-  str
-    .replace(ANSI_COLOR_RE, '')
-    .replace(ANSI_CURSOR_MOVE_RE, '')
-    .replace(ANSI_ERASE_RE, '')
-    .replace(ANSI_POSITION_RE, '')
-    .replace(ANSI_MODE_RE, '')
-    .replace(OSC_TITLE_RE, '')
-    .replace(OSC_PS_RE, '')
-    .replace(CONTROL_CHARS_RE, '')
+  processBackspaces(
+    str
+      .replace(OSC_SEQUENCE_RE, '')
+      .replace(ANSI_KEYPAD_MODE_RE, '')
+      .replace(ANSI_COLOR_RE, '')
+      .replace(ANSI_CURSOR_MOVE_RE, '')
+      .replace(ANSI_ERASE_RE, '')
+      .replace(ANSI_POSITION_RE, '')
+      .replace(ANSI_MODE_RE, '')
+      .replace(OSC_TITLE_RE, '')
+      .replace(OSC_PS_RE, '')
+  ).replace(CONTROL_CHARS_RE, '')
 
 /**
  * Strip extended ANSI sequences: everything in stripAnsiBasic plus cursor
@@ -38,14 +57,17 @@ export const stripAnsiBasic = (str: string): string =>
  * Used for prompt detection and detailed output cleaning.
  */
 export const stripAnsiExtended = (str: string): string =>
-  str
-    .replace(ANSI_COLOR_RE, '')
-    .replace(ANSI_CURSOR_MOVE_RE, '')
-    .replace(ANSI_ERASE_RE, '')
-    .replace(ANSI_POSITION_RE, '')
-    .replace(ANSI_MODE_RE, '')
-    .replace(OSC_TITLE_RE, '')
-    .replace(OSC_PS_RE, '')
-    .replace(ANSI_CURSOR_VISIBILITY_RE, '')
-    .replace(ANSI_ERASE_DISPLAY_RE, '')
-    .replace(CONTROL_CHARS_EXTENDED_RE, '')
+  processBackspaces(
+    str
+      .replace(OSC_SEQUENCE_RE, '')
+      .replace(ANSI_KEYPAD_MODE_RE, '')
+      .replace(ANSI_COLOR_RE, '')
+      .replace(ANSI_CURSOR_MOVE_RE, '')
+      .replace(ANSI_ERASE_RE, '')
+      .replace(ANSI_POSITION_RE, '')
+      .replace(ANSI_MODE_RE, '')
+      .replace(OSC_TITLE_RE, '')
+      .replace(OSC_PS_RE, '')
+      .replace(ANSI_CURSOR_VISIBILITY_RE, '')
+      .replace(ANSI_ERASE_DISPLAY_RE, '')
+  ).replace(CONTROL_CHARS_EXTENDED_RE, '')

--- a/src/renderer/src/views/components/Ssh/utils/terminalPrompt.ts
+++ b/src/renderer/src/views/components/Ssh/utils/terminalPrompt.ts
@@ -10,6 +10,7 @@ type PromptMatchResult = {
 // Optional prefix pattern for conda/virtualenv environments like (base), (myenv), etc.
 // Only allow zero or one space after the environment prefix (input is already trimmed)
 const ENV_PREFIX = /(?:\([^)]+\) ?)?/
+const ZSH_THEME_PROMPT_PATTERN = new RegExp(`^${ENV_PREFIX.source}[➜❯❮➤➔λ]\\s+\\S+(?:\\s+git:\\([^)]*\\))?(?:\\s+[✗✔✘!*+?-]+)?\\s*$`)
 
 const PROMPT_PATTERNS: Array<{ type: PromptType; pattern: RegExp }> = [
   // Linux prompts with optional environment prefix (e.g., (base) [user@host]$)
@@ -26,6 +27,8 @@ const PROMPT_PATTERNS: Array<{ type: PromptType; pattern: RegExp }> = [
   { type: 'linux', pattern: new RegExp(`^${ENV_PREFIX.source}[a-zA-Z][a-zA-Z0-9_-]*:[^\\s]*[$#]\\s*$`) },
   // Path only format (e.g., ~/projects $, /var/log #, ~ $)
   { type: 'linux', pattern: new RegExp(`^${ENV_PREFIX.source}[~./][^\\s]*\\s+[$#]\\s*$`) },
+  // Common zsh themes such as oh-my-zsh robbyrussell: "(base) ➜  ~"
+  { type: 'linux', pattern: ZSH_THEME_PROMPT_PATTERN },
   // Fish shell format (e.g., user@host ~/path>, hostname ~>)
   { type: 'linux', pattern: new RegExp(`^${ENV_PREFIX.source}([^@]+@)?[^\\s]+\\s+[^\\s]*>\\s*$`) },
   { type: 'linux', pattern: new RegExp(`^${ENV_PREFIX.source}>\\s*$`) },
@@ -73,6 +76,11 @@ const extractTrailingPrompt = (line: string): string | null => {
     const previousChar = candidateStart > 0 ? trimmed[candidateStart - 1] : ''
     const hasAlphaNumericBoundary = candidateStart > 0 && /[A-Za-z0-9]/.test(previousChar)
     const isLikelyUserHostPrompt = /@[^:\s]+:[^$#\s]*\s*[$#]\s*$/.test(candidate)
+    const isLikelyZshThemePrompt = ZSH_THEME_PROMPT_PATTERN.test(candidate)
+
+    if (isLikelyZshThemePrompt && candidateStart > 0) {
+      continue
+    }
 
     // Avoid matching inside ordinary words unless candidate clearly looks like a shell prompt.
     if (hasAlphaNumericBoundary && !isLikelyUserHostPrompt) {


### PR DESCRIPTION
Forward structured command tool results through the controller and tighten SSH prompt parsing so ANSI-heavy zsh prompts are handled without misclassifying ordinary output.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SSH terminal output processing to more reliably detect and remove command echoes, with enhanced ANSI sequence handling.
  * Added support for Zsh theme prompt recognition (e.g., oh-my-zsh formats) during terminal output parsing.
  * Enhanced backspace character processing in terminal output to correctly render cleaned content.

* **Tests**
  * Expanded test coverage for terminal prompt detection and ANSI cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->