### PR TITLE
fix: pin SLSA generator workflow to a version tag to ensure proper binary lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,4 +384,3 @@ jobs:
       upload-assets: true
       upload-tag-name: ${{ github.ref_name }}
       draft-release: true
-      compile-generator: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,9 +374,14 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: SLSA generator reusable workflow must be pinned to a tag, not a commit SHA.
+    # The detect-env step uses the tag to download the matching prebuilt builder binary
+    # from the generator's GitHub release; pinning to a SHA breaks that lookup and
+    # causes "slsa-generator-generic-linux-amd64: No such file or directory" (exit 127).
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}
       upload-assets: true
       upload-tag-name: ${{ github.ref_name }}
       draft-release: true
+      compile-generator: true


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md) and linked the related issue above if any.
- [x] `npm run lint && npm run format && npm run typecheck && npm test` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use a version-tagged workflow reference instead of pinning to a specific commit.
  * Added inline documentation explaining why commit-based pinning can interfere with environment detection and prebuilt tooling resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2161)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2161)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->