### PR TITLE
fix: specify repository in GitHub Actions for release validation and asset download

### DIFF
--- a/.github/workflows/provenance-backfill.yml
+++ b/.github/workflows/provenance-backfill.yml
@@ -100,7 +100,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.prepare-subjects.outputs.hashes }}
       upload-assets: true

--- a/.github/workflows/provenance-backfill.yml
+++ b/.github/workflows/provenance-backfill.yml
@@ -24,21 +24,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_TAG: ${{ inputs.tag }}
+          TARGET_REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
-          gh release view "$TARGET_TAG" --json tagName --jq .tagName >/dev/null
+          gh release view "$TARGET_TAG" --repo "$TARGET_REPO" --json tagName --jq .tagName >/dev/null
           echo "Validated release tag: $TARGET_TAG"
 
       - name: Download release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_TAG: ${{ inputs.tag }}
+          TARGET_REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p backfill-release-assets
-          gh release download "$TARGET_TAG" --dir backfill-release-assets --clobber
+          gh release download "$TARGET_TAG" --repo "$TARGET_REPO" --dir backfill-release-assets --clobber
           echo "Downloaded assets for $TARGET_TAG"
           ls -la backfill-release-assets
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability by ensuring release validation and asset downloads target the correct repository and by adding stricter error handling.
* **Chores**
  * Pinned a referenced workflow to a specific commit to reduce ambiguity and increase reproducibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2166)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->