### PR TITLE
feat: add localization for transfer list collapse and expand actions in multiple languages

### DIFF
--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -1163,6 +1163,8 @@ export default {
     uploadCancel: 'رفع ملغي',
     downloadSkipped: 'تحميل ملغي',
     taskList: 'قائمة التحويل',
+    collapseTransferList: 'طي قائمة النقل',
+    expandTransferList: 'توسيع قائمة النقل',
     upload: 'رفع',
     copyFileSuccess: 'نسخة ناجحة',
     copyFileFailed: 'نسخة غير ناجحة',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -1193,6 +1193,8 @@ export default {
     uploadCancel: 'Upload abgebrochen',
     downloadSkipped: 'download übersprungen',
     taskList: 'Übertragungsliste',
+    collapseTransferList: 'Übertragungsliste einklappen',
+    expandTransferList: 'Übertragungsliste ausklappen',
     upload: 'Upload',
     copyFileSuccess: 'Datei erfolgreich kopiert',
     copyFileFailed: 'Datei kopieren fehlgeschlagen',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -1188,6 +1188,8 @@ export default {
     uploadCancel: 'Upload Cancelled',
     downloadSkipped: 'download Skipped',
     taskList: 'Transmission List',
+    collapseTransferList: 'Collapse transfer list',
+    expandTransferList: 'Expand transfer list',
     upload: 'Upload',
     copyFileSuccess: 'File Copied Successfully',
     copyFileFailed: 'File Copy Failed',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -1197,6 +1197,8 @@ export default {
     uploadCancel: 'Téléchargement annulé',
     downloadSkipped: 'Téléchargement ignoré',
     taskList: 'Liste de transmission',
+    collapseTransferList: 'Réduire la liste de transfert',
+    expandTransferList: 'Développer la liste de transfert',
     upload: 'Télécharger',
     copyFileSuccess: 'Fichier copié avec succès',
     copyFileFailed: 'Copie échouée',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -1191,6 +1191,8 @@ export default {
     uploadCancel: 'Upload annullato',
     downloadSkipped: 'download saltato',
     taskList: 'Lista trasmissioni',
+    collapseTransferList: 'Comprimi elenco trasferimenti',
+    expandTransferList: 'Espandi elenco trasferimenti',
     upload: 'Upload',
     copyFileSuccess: 'File copiato con successo',
     copyFileFailed: 'File copia fallito',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -1187,6 +1187,8 @@ export default {
     uploadCancel: 'アップロードがキャンセルされました',
     downloadSkipped: 'ダウンロードをスキップしました',
     taskList: '転送リスト',
+    collapseTransferList: '転送リストを折りたたむ',
+    expandTransferList: '転送リストを展開',
     upload: 'アップロード',
     modifyFilePermissionsSuccess: 'ファイル権限の修正成功',
     modifyFilePermissionsFailed: 'ファイル権限の修正に失敗しました',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -1182,6 +1182,8 @@ export default {
     uploadCancel: '업로드가 취소되었습니다',
     downloadSkipped: '다운로드 건너뛰기',
     taskList: '전송 목록',
+    collapseTransferList: '전송 목록 접기',
+    expandTransferList: '전송 목록 펼치기',
     upload: '업로드',
     modifyFilePermissionsSuccess: '파일 권한 수정 성공',
     modifyFilePermissionsFailed: '파일 권한 수정 실패',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -1189,6 +1189,8 @@ export default {
     uploadCancel: 'Upload cancelado',
     downloadSkipped: 'download pulado',
     taskList: 'Lista de transferência',
+    collapseTransferList: 'Recolher lista de transferências',
+    expandTransferList: 'Expandir lista de transferências',
     upload: 'Upload',
     copyFileSuccess: 'Arquivo copiado com sucesso',
     copyFileFailed: 'Arquivo copiado falhou',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -1189,6 +1189,8 @@ export default {
     uploadCancel: 'Загрузка отменена',
     downloadSkipped: 'Скачивание пропущено',
     taskList: 'Список передач',
+    collapseTransferList: 'Свернуть список передач',
+    expandTransferList: 'Развернуть список передач',
     upload: 'Загрузить',
     copyFileSuccess: 'Файл скопирован успешно',
     copyFileFailed: 'Ошибка копирования файла',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -1194,6 +1194,8 @@ export default {
     download: '下载',
     upload: '上传',
     taskList: '传输列表',
+    collapseTransferList: '收起传输列表',
+    expandTransferList: '展开传输列表',
     doubleClickToOpen: '双击打开',
     sftpConnectFailed: 'SFTP连接失败',
     noDataAvailable: '暂无数据，请先连接到服务器',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -1193,6 +1193,8 @@ export default {
     download: '下載',
     upload: '上傳',
     taskList: '傳輸列表',
+    collapseTransferList: '收起傳輸列表',
+    expandTransferList: '展開傳輸列表',
     doubleClickToOpen: '雙擊打開',
     sftpConnectFailed: 'SFTP連接失敗',
     noDataAvailable: '暫無數據，請先連接到服務器',

--- a/src/renderer/src/views/components/Files/__tests__/fileTransferProgress.test.ts
+++ b/src/renderer/src/views/components/Files/__tests__/fileTransferProgress.test.ts
@@ -1,6 +1,8 @@
 // fileTransfer.spec.ts
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 
 describe('fileTransfer.ts', () => {
   beforeEach(() => {
@@ -151,5 +153,250 @@ describe('fileTransfer.ts', () => {
 
     vi.advanceTimersByTime(8000)
     expect(mod.transferTasks.value['k7']).toBeUndefined()
+  })
+})
+
+vi.mock('@store/userConfigStore', () => ({
+  userConfigStore: () => ({
+    getUserConfig: { theme: 'dark', background: { image: '' } }
+  })
+}))
+
+vi.mock('@/utils/themeUtils', () => ({
+  addSystemThemeListener: vi.fn(() => () => {}),
+  getActualTheme: vi.fn(() => 'dark')
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      files: {
+        taskList: 'Transfer List',
+        collapseTransferList: 'Collapse',
+        expandTransferList: 'Expand',
+        download: 'Download',
+        upload: 'Upload',
+        dragTransfer: 'Drag Transfer',
+        scanning: 'Scanning',
+        waiting: 'Waiting'
+      }
+    }
+  }
+})
+
+const stubs = {
+  'a-progress': {
+    name: 'AProgress',
+    props: ['percent', 'type', 'size', 'strokeWidth', 'showInfo', 'status'],
+    template: `<div class="a-progress" :data-percent="percent" :data-type="type"></div>`
+  },
+  'a-button': {
+    name: 'AButton',
+    props: ['type', 'danger', 'title'],
+    emits: ['click'],
+    template: `<button class="a-button" :title="title" @click="$emit('click', $event)"><slot name="icon" /><slot /></button>`
+  },
+  'a-row': { name: 'ARow', template: `<div class="a-row"><slot /></div>` },
+  'a-col': { name: 'ACol', template: `<div class="a-col"><slot /></div>` },
+  ArrowUpOutlined: { template: '<span class="icon-up" />' },
+  ArrowDownOutlined: { template: '<span class="icon-down" />' },
+  SwapOutlined: { template: '<span class="icon-swap" />' },
+  MinusOutlined: { template: '<span class="icon-minus" />' },
+  CloseOutlined: { template: '<span class="icon-close" />' },
+  DownOutlined: { template: '<span class="icon-down-arrow" />' },
+  RightOutlined: { template: '<span class="icon-right-arrow" />' }
+}
+
+describe('fileTransferProgress.vue', () => {
+  beforeEach(() => {
+    ;(window as any).api = {
+      onTransferProgress: vi.fn(),
+      cancelFileTask: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).api
+  })
+
+  const importComp = async () => {
+    vi.resetModules()
+    const mod = await import('../fileTransfer')
+    mod.transferTasks.value = {}
+    const Comp = (await import('../fileTransferProgress.vue')).default
+    return { Comp, mod }
+  }
+
+  const seedTask = (mod: any, overrides: Partial<any> = {}) => {
+    const taskKey = overrides.taskKey ?? `t-${Math.random().toString(36).slice(2, 8)}`
+    mod.transferTasks.value[taskKey] = {
+      id: taskKey,
+      taskKey,
+      name: overrides.name ?? 'file.bin',
+      progress: overrides.progress ?? 0,
+      remotePath: '/x/file.bin',
+      speed: '0 KB/s',
+      type: overrides.type ?? 'upload',
+      lastBytes: 0,
+      lastTime: 0,
+      status: overrides.status ?? 'running',
+      createdAt: Date.now(),
+      sortIndex: 0,
+      ...overrides
+    }
+    return taskKey
+  }
+
+  const mountComp = (Comp: any) =>
+    mount(Comp, {
+      global: {
+        plugins: [i18n],
+        stubs
+      },
+      attachTo: document.body
+    })
+
+  it('renders nothing when there are no transfer tasks', async () => {
+    const { Comp } = await importComp()
+    const wrapper = mountComp(Comp)
+    expect(wrapper.find('.transfer-fab').exists()).toBe(false)
+    expect(wrapper.find('.transfer-panel').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders expanded panel by default when there are tasks', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { type: 'upload', progress: 50 })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+
+    expect(wrapper.find('.transfer-panel').exists()).toBe(true)
+    expect(wrapper.find('.transfer-fab').exists()).toBe(false)
+    expect(wrapper.find('.collapse-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('collapses to FAB when collapse button is clicked, and expands again on FAB click', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { type: 'upload', progress: 25 })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+
+    await wrapper.find('.collapse-btn').trigger('click')
+    expect(wrapper.find('.transfer-panel').exists()).toBe(false)
+    expect(wrapper.find('.transfer-fab').exists()).toBe(true)
+
+    await wrapper.find('.transfer-fab').trigger('click')
+    expect(wrapper.find('.transfer-panel').exists()).toBe(true)
+    expect(wrapper.find('.transfer-fab').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('FAB shows badge with the count of parent tasks', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { taskKey: 'a', type: 'upload', progress: 10 })
+    seedTask(mod, { taskKey: 'b', type: 'download', progress: 30 })
+    seedTask(mod, { taskKey: 'c', type: 'upload', progress: 50 })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+
+    await wrapper.find('.collapse-btn').trigger('click')
+    const badge = wrapper.find('.fab-badge')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('3')
+    wrapper.unmount()
+  })
+
+  it('FAB badge clamps to 99+ when there are more than 99 tasks', async () => {
+    const { Comp, mod } = await importComp()
+    for (let i = 0; i < 101; i++) {
+      seedTask(mod, { taskKey: `k${i}`, type: 'upload', progress: 0 })
+    }
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+
+    await wrapper.find('.collapse-btn').trigger('click')
+    expect(wrapper.find('.fab-badge').text()).toBe('99+')
+    wrapper.unmount()
+  })
+
+  it('FAB progress ring reflects average progress across parent tasks', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { taskKey: 'a', type: 'upload', progress: 20 })
+    seedTask(mod, { taskKey: 'b', type: 'download', progress: 80 })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+
+    await wrapper.find('.collapse-btn').trigger('click')
+    const ring = wrapper.find('.fab-ring')
+    expect(ring.exists()).toBe(true)
+    expect(ring.attributes('data-percent')).toBe('50')
+    wrapper.unmount()
+  })
+
+  it('FAB shows ArrowUp icon when only uploads are active', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { type: 'upload' })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+    await wrapper.find('.collapse-btn').trigger('click')
+
+    expect(wrapper.find('.icon-up').exists()).toBe(true)
+    expect(wrapper.find('.icon-down').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('FAB shows ArrowDown icon when only downloads are active', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { type: 'download' })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+    await wrapper.find('.collapse-btn').trigger('click')
+
+    expect(wrapper.find('.icon-down').exists()).toBe(true)
+    expect(wrapper.find('.icon-up').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('FAB shows Swap icon when both uploads and downloads are active', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { taskKey: 'a', type: 'upload' })
+    seedTask(mod, { taskKey: 'b', type: 'download' })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+    await wrapper.find('.collapse-btn').trigger('click')
+
+    expect(wrapper.find('.icon-swap').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('FAB toggles via keyboard (Enter/Space)', async () => {
+    const { Comp, mod } = await importComp()
+    seedTask(mod, { type: 'upload' })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+    await wrapper.find('.collapse-btn').trigger('click')
+
+    await wrapper.find('.transfer-fab').trigger('keydown.enter')
+    expect(wrapper.find('.transfer-panel').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('hides the entire UI when the last task disappears', async () => {
+    const { Comp, mod } = await importComp()
+    const key = seedTask(mod, { type: 'upload' })
+    const wrapper = mountComp(Comp)
+    await flushPromises()
+    expect(wrapper.find('.transfer-panel').exists()).toBe(true)
+
+    delete mod.transferTasks.value[key]
+    await flushPromises()
+
+    expect(wrapper.find('.transfer-panel').exists()).toBe(false)
+    expect(wrapper.find('.transfer-fab').exists()).toBe(false)
+    wrapper.unmount()
   })
 })

--- a/src/renderer/src/views/components/Files/fileTransferProgress.vue
+++ b/src/renderer/src/views/components/Files/fileTransferProgress.vue
@@ -1,394 +1,439 @@
 <template>
-  <div
-    v-if="downloadGroups.length || uploadGroups.length || r2rTaskGroups.length"
-    class="transfer-panel"
-    :style="transferPanelStyle"
-  >
-    <div class="header">{{ $t('files.taskList') }}</div>
-
-    <div class="transferBody">
-      <div
-        v-if="downloadGroups.length"
-        class="group"
+  <template v-if="downloadGroups.length || uploadGroups.length || r2rTaskGroups.length">
+    <div
+      v-if="collapsed"
+      class="transfer-fab"
+      :title="$t('files.expandTransferList')"
+      role="button"
+      tabindex="0"
+      @click="collapsed = false"
+      @keydown.enter.space.prevent="collapsed = false"
+    >
+      <a-progress
+        type="circle"
+        :percent="overallPercent"
+        :size="48"
+        :stroke-width="8"
+        :show-info="false"
+        class="fab-ring"
+      />
+      <div class="fab-icon">
+        <SwapOutlined v-if="r2rTaskGroups.length && !uploadGroups.length && !downloadGroups.length" />
+        <ArrowUpOutlined v-else-if="uploadGroups.length && !downloadGroups.length" />
+        <ArrowDownOutlined v-else-if="downloadGroups.length && !uploadGroups.length" />
+        <SwapOutlined v-else />
+      </div>
+      <span
+        v-if="totalTaskCount > 0"
+        class="fab-badge"
       >
-        <div class="label">{{ $t('files.download') }}：</div>
+        {{ totalTaskCount > 99 ? '99+' : totalTaskCount }}
+      </span>
+    </div>
 
-        <div
-          v-for="group in downloadGroups"
-          :key="group.parent.taskKey"
-          class="dir-group"
+    <div
+      v-else
+      class="transfer-panel"
+      :style="transferPanelStyle"
+    >
+      <div class="header">
+        <span>{{ $t('files.taskList') }}</span>
+        <a-button
+          type="text"
+          class="collapse-btn"
+          :title="$t('files.collapseTransferList')"
+          @click="collapsed = true"
         >
-          <div class="parent-item">
-            <div class="meta-row">
-              <span
-                class="file-name"
-                :title="group.parent.destPath || group.parent.remotePath"
-              >
-                {{ group.parent.name }}
-              </span>
+          <template #icon>
+            <MinusOutlined />
+          </template>
+        </a-button>
+      </div>
 
-              <span class="speed">
-                <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                <template v-else>
-                  {{ formatSummary(group.parent) }}
-                </template>
-              </span>
-            </div>
-
-            <div class="progress-row">
-              <div
-                v-if="showExpand(group)"
-                class="left-actions"
-              >
-                <a-button
-                  type="text"
-                  class="expand-btn"
-                  @click.stop="toggleExpand(group.parent.taskKey)"
-                >
-                  <template #icon>
-                    <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
-                    <RightOutlined v-else />
-                  </template>
-                </a-button>
-              </div>
-
-              <div class="progress-container parent-progress-container">
-                <a-progress
-                  :percent="group.parent.progress"
-                  size="small"
-                  class="file-progress"
-                  :status="mapAntdStatus(group.parent.status, group.parent.progress)"
-                />
-              </div>
-
-              <a-button
-                type="link"
-                danger
-                class="cancel-btn"
-                @click="cancel(group.parent.taskKey)"
-              >
-                <template #icon>
-                  <CloseOutlined />
-                </template>
-              </a-button>
-            </div>
-          </div>
+      <div class="transferBody">
+        <div
+          v-if="downloadGroups.length"
+          class="group"
+        >
+          <div class="label">{{ $t('files.download') }}：</div>
 
           <div
-            v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
-            class="children"
+            v-for="group in downloadGroups"
+            :key="group.parent.taskKey"
+            class="dir-group"
           >
-            <div class="children-scroll">
-              <div
-                v-for="task in group.children"
-                :key="task.taskKey"
-                class="child-item"
-              >
-                <div class="meta-row">
-                  <span
-                    class="file-name"
-                    :title="task.destPath || task.remotePath"
-                  >
-                    {{ task.name }}
-                  </span>
+            <div class="parent-item">
+              <div class="meta-row">
+                <span
+                  class="file-name"
+                  :title="group.parent.destPath || group.parent.remotePath"
+                >
+                  {{ group.parent.name }}
+                </span>
 
-                  <span class="speed">
-                    <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                    <template v-else-if="task.stage === 'pending' || task.speed === 'pending'"> {{ $t('files.waiting') }}... </template>
-                    <template v-else>
-                      {{ task.speed }}
-                    </template>
-                  </span>
-                </div>
+                <span class="speed">
+                  <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                  <template v-else>
+                    {{ formatSummary(group.parent) }}
+                  </template>
+                </span>
+              </div>
 
-                <div class="progress-row child-progress-row">
-                  <div class="progress-container">
-                    <a-progress
-                      :percent="task.progress"
-                      size="small"
-                      class="file-progress"
-                      :status="mapAntdStatus(task.status, task.progress)"
-                    />
-                  </div>
-
+              <div class="progress-row">
+                <div
+                  v-if="showExpand(group)"
+                  class="left-actions"
+                >
                   <a-button
-                    type="link"
-                    danger
-                    class="cancel-btn"
-                    @click="cancel(task.taskKey)"
+                    type="text"
+                    class="expand-btn"
+                    @click.stop="toggleExpand(group.parent.taskKey)"
                   >
                     <template #icon>
-                      <CloseOutlined />
+                      <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
+                      <RightOutlined v-else />
                     </template>
                   </a-button>
                 </div>
 
-                <div
-                  v-if="task.message"
-                  class="message-row"
+                <div class="progress-container parent-progress-container">
+                  <a-progress
+                    :percent="group.parent.progress"
+                    size="small"
+                    class="file-progress"
+                    :status="mapAntdStatus(group.parent.status, group.parent.progress)"
+                  />
+                </div>
+
+                <a-button
+                  type="link"
+                  danger
+                  class="cancel-btn"
+                  @click="cancel(group.parent.taskKey)"
                 >
-                  {{ task.message }}
+                  <template #icon>
+                    <CloseOutlined />
+                  </template>
+                </a-button>
+              </div>
+            </div>
+
+            <div
+              v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
+              class="children"
+            >
+              <div class="children-scroll">
+                <div
+                  v-for="task in group.children"
+                  :key="task.taskKey"
+                  class="child-item"
+                >
+                  <div class="meta-row">
+                    <span
+                      class="file-name"
+                      :title="task.destPath || task.remotePath"
+                    >
+                      {{ task.name }}
+                    </span>
+
+                    <span class="speed">
+                      <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                      <template v-else-if="task.stage === 'pending' || task.speed === 'pending'"> {{ $t('files.waiting') }}... </template>
+                      <template v-else>
+                        {{ task.speed }}
+                      </template>
+                    </span>
+                  </div>
+
+                  <div class="progress-row child-progress-row">
+                    <div class="progress-container">
+                      <a-progress
+                        :percent="task.progress"
+                        size="small"
+                        class="file-progress"
+                        :status="mapAntdStatus(task.status, task.progress)"
+                      />
+                    </div>
+
+                    <a-button
+                      type="link"
+                      danger
+                      class="cancel-btn"
+                      @click="cancel(task.taskKey)"
+                    >
+                      <template #icon>
+                        <CloseOutlined />
+                      </template>
+                    </a-button>
+                  </div>
+
+                  <div
+                    v-if="task.message"
+                    class="message-row"
+                  >
+                    {{ task.message }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-
-      <div
-        v-if="uploadGroups.length"
-        class="group"
-      >
-        <div class="label">{{ $t('files.upload') }}：</div>
 
         <div
-          v-for="group in uploadGroups"
-          :key="group.parent.taskKey"
-          class="dir-group"
+          v-if="uploadGroups.length"
+          class="group"
         >
-          <div class="parent-item">
-            <div class="meta-row">
-              <span
-                class="file-name"
-                :title="group.parent.destPath || group.parent.remotePath"
-              >
-                {{ group.parent.name }}
-              </span>
-
-              <span class="speed">
-                <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                <template v-else>
-                  {{ formatSummary(group.parent) }}
-                </template>
-              </span>
-            </div>
-
-            <div class="progress-row">
-              <div
-                v-if="showExpand(group)"
-                class="left-actions"
-              >
-                <a-button
-                  type="text"
-                  class="expand-btn"
-                  @click.stop="toggleExpand(group.parent.taskKey)"
-                >
-                  <template #icon>
-                    <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
-                    <RightOutlined v-else />
-                  </template>
-                </a-button>
-              </div>
-
-              <div class="progress-container parent-progress-container">
-                <a-progress
-                  :percent="group.parent.progress"
-                  size="small"
-                  class="file-progress"
-                  :status="mapAntdStatus(group.parent.status, group.parent.progress)"
-                />
-              </div>
-
-              <a-button
-                type="link"
-                danger
-                class="cancel-btn"
-                @click="cancel(group.parent.taskKey)"
-              >
-                <template #icon>
-                  <CloseOutlined />
-                </template>
-              </a-button>
-            </div>
-          </div>
+          <div class="label">{{ $t('files.upload') }}：</div>
 
           <div
-            v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
-            class="children"
+            v-for="group in uploadGroups"
+            :key="group.parent.taskKey"
+            class="dir-group"
           >
-            <div class="children-scroll">
-              <div
-                v-for="task in group.children"
-                :key="task.taskKey"
-                class="child-item"
-              >
-                <div class="meta-row">
-                  <span
-                    class="file-name"
-                    :title="task.destPath || task.remotePath"
-                  >
-                    {{ task.name }}
-                  </span>
+            <div class="parent-item">
+              <div class="meta-row">
+                <span
+                  class="file-name"
+                  :title="group.parent.destPath || group.parent.remotePath"
+                >
+                  {{ group.parent.name }}
+                </span>
 
-                  <span class="speed">
-                    <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                    <template v-else-if="task.stage === 'pending' || task.speed === 'pending'"> {{ $t('files.waiting') }}... </template>
-                    <template v-else>
-                      {{ task.speed }}
-                    </template>
-                  </span>
-                </div>
+                <span class="speed">
+                  <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                  <template v-else>
+                    {{ formatSummary(group.parent) }}
+                  </template>
+                </span>
+              </div>
 
-                <div class="progress-row child-progress-row">
-                  <div class="progress-container">
-                    <a-progress
-                      :percent="task.progress"
-                      size="small"
-                      class="file-progress"
-                      :status="mapAntdStatus(task.status, task.progress)"
-                    />
-                  </div>
-
+              <div class="progress-row">
+                <div
+                  v-if="showExpand(group)"
+                  class="left-actions"
+                >
                   <a-button
-                    type="link"
-                    danger
-                    class="cancel-btn"
-                    @click="cancel(task.taskKey)"
+                    type="text"
+                    class="expand-btn"
+                    @click.stop="toggleExpand(group.parent.taskKey)"
                   >
                     <template #icon>
-                      <CloseOutlined />
+                      <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
+                      <RightOutlined v-else />
                     </template>
                   </a-button>
                 </div>
 
-                <div
-                  v-if="task.message"
-                  class="message-row"
+                <div class="progress-container parent-progress-container">
+                  <a-progress
+                    :percent="group.parent.progress"
+                    size="small"
+                    class="file-progress"
+                    :status="mapAntdStatus(group.parent.status, group.parent.progress)"
+                  />
+                </div>
+
+                <a-button
+                  type="link"
+                  danger
+                  class="cancel-btn"
+                  @click="cancel(group.parent.taskKey)"
                 >
-                  {{ task.message }}
+                  <template #icon>
+                    <CloseOutlined />
+                  </template>
+                </a-button>
+              </div>
+            </div>
+
+            <div
+              v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
+              class="children"
+            >
+              <div class="children-scroll">
+                <div
+                  v-for="task in group.children"
+                  :key="task.taskKey"
+                  class="child-item"
+                >
+                  <div class="meta-row">
+                    <span
+                      class="file-name"
+                      :title="task.destPath || task.remotePath"
+                    >
+                      {{ task.name }}
+                    </span>
+
+                    <span class="speed">
+                      <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                      <template v-else-if="task.stage === 'pending' || task.speed === 'pending'"> {{ $t('files.waiting') }}... </template>
+                      <template v-else>
+                        {{ task.speed }}
+                      </template>
+                    </span>
+                  </div>
+
+                  <div class="progress-row child-progress-row">
+                    <div class="progress-container">
+                      <a-progress
+                        :percent="task.progress"
+                        size="small"
+                        class="file-progress"
+                        :status="mapAntdStatus(task.status, task.progress)"
+                      />
+                    </div>
+
+                    <a-button
+                      type="link"
+                      danger
+                      class="cancel-btn"
+                      @click="cancel(task.taskKey)"
+                    >
+                      <template #icon>
+                        <CloseOutlined />
+                      </template>
+                    </a-button>
+                  </div>
+
+                  <div
+                    v-if="task.message"
+                    class="message-row"
+                  >
+                    {{ task.message }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Transfer -->
-      <div
-        v-if="r2rTaskGroups.length"
-        class="group"
-      >
-        <div class="label">{{ $t('files.dragTransfer') }}：</div>
-
+        <!-- Transfer -->
         <div
-          v-for="group in r2rTaskGroups"
-          :key="group.parent.taskKey"
-          class="dir-group"
+          v-if="r2rTaskGroups.length"
+          class="group"
         >
-          <div class="subgroup-title">
-            {{ parseGroupTitle(group.parent) }}
-          </div>
-
-          <div class="parent-item">
-            <div class="meta-row">
-              <span
-                class="file-name"
-                :title="group.parent.destPath || group.parent.remotePath"
-              >
-                {{ group.parent.name }}
-              </span>
-
-              <span class="speed">
-                <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                <template v-else>
-                  {{ formatSummary(group.parent) }}
-                </template>
-              </span>
-            </div>
-
-            <div class="progress-row">
-              <div
-                v-if="showExpand(group)"
-                class="left-actions"
-              >
-                <a-button
-                  type="text"
-                  class="expand-btn"
-                  @click.stop="toggleExpand(group.parent.taskKey)"
-                >
-                  <template #icon>
-                    <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
-                    <RightOutlined v-else />
-                  </template>
-                </a-button>
-              </div>
-
-              <div class="progress-container parent-progress-container">
-                <a-progress
-                  :percent="group.parent.progress"
-                  size="small"
-                  class="file-progress"
-                  :status="mapAntdStatus(group.parent.status, group.parent.progress)"
-                />
-              </div>
-
-              <a-button
-                type="link"
-                danger
-                class="cancel-btn"
-                @click="cancel(group.parent.taskKey)"
-              >
-                <template #icon>
-                  <CloseOutlined />
-                </template>
-              </a-button>
-            </div>
-          </div>
+          <div class="label">{{ $t('files.dragTransfer') }}：</div>
 
           <div
-            v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
-            class="children"
+            v-for="group in r2rTaskGroups"
+            :key="group.parent.taskKey"
+            class="dir-group"
           >
-            <div class="children-scroll">
-              <div
-                v-for="task in group.children"
-                :key="task.taskKey"
-                class="child-item"
-              >
-                <div class="meta-row">
-                  <span
-                    class="file-name"
-                    :title="task.destPath || task.remotePath"
-                  >
-                    {{ task.name }}
-                  </span>
+            <div class="subgroup-title">
+              {{ parseGroupTitle(group.parent) }}
+            </div>
 
-                  <span class="speed">
-                    <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
-                    <template v-else-if="task.stage === 'pending' || task.speed === 'pending'">{{ $t('files.waiting') }}... </template>
-                    <template v-else>
-                      {{ task.speed }}
-                    </template>
-                  </span>
-                </div>
+            <div class="parent-item">
+              <div class="meta-row">
+                <span
+                  class="file-name"
+                  :title="group.parent.destPath || group.parent.remotePath"
+                >
+                  {{ group.parent.name }}
+                </span>
 
-                <div class="progress-row child-progress-row">
-                  <div class="progress-container">
-                    <a-progress
-                      :percent="task.progress"
-                      size="small"
-                      class="file-progress"
-                      :status="mapAntdStatus(task.status, task.progress)"
-                    />
-                  </div>
+                <span class="speed">
+                  <template v-if="group.parent.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                  <template v-else>
+                    {{ formatSummary(group.parent) }}
+                  </template>
+                </span>
+              </div>
 
+              <div class="progress-row">
+                <div
+                  v-if="showExpand(group)"
+                  class="left-actions"
+                >
                   <a-button
-                    type="link"
-                    danger
-                    class="cancel-btn"
-                    @click="cancel(task.taskKey)"
+                    type="text"
+                    class="expand-btn"
+                    @click.stop="toggleExpand(group.parent.taskKey)"
                   >
                     <template #icon>
-                      <CloseOutlined />
+                      <DownOutlined v-if="isExpanded(group.parent.taskKey)" />
+                      <RightOutlined v-else />
                     </template>
                   </a-button>
                 </div>
 
-                <div
-                  v-if="task.message"
-                  class="message-row"
+                <div class="progress-container parent-progress-container">
+                  <a-progress
+                    :percent="group.parent.progress"
+                    size="small"
+                    class="file-progress"
+                    :status="mapAntdStatus(group.parent.status, group.parent.progress)"
+                  />
+                </div>
+
+                <a-button
+                  type="link"
+                  danger
+                  class="cancel-btn"
+                  @click="cancel(group.parent.taskKey)"
                 >
-                  {{ task.message }}
+                  <template #icon>
+                    <CloseOutlined />
+                  </template>
+                </a-button>
+              </div>
+            </div>
+
+            <div
+              v-if="showExpand(group) && isExpanded(group.parent.taskKey)"
+              class="children"
+            >
+              <div class="children-scroll">
+                <div
+                  v-for="task in group.children"
+                  :key="task.taskKey"
+                  class="child-item"
+                >
+                  <div class="meta-row">
+                    <span
+                      class="file-name"
+                      :title="task.destPath || task.remotePath"
+                    >
+                      {{ task.name }}
+                    </span>
+
+                    <span class="speed">
+                      <template v-if="task.stage === 'scanning'"> {{ $t('files.scanning') }}... </template>
+                      <template v-else-if="task.stage === 'pending' || task.speed === 'pending'">{{ $t('files.waiting') }}... </template>
+                      <template v-else>
+                        {{ task.speed }}
+                      </template>
+                    </span>
+                  </div>
+
+                  <div class="progress-row child-progress-row">
+                    <div class="progress-container">
+                      <a-progress
+                        :percent="task.progress"
+                        size="small"
+                        class="file-progress"
+                        :status="mapAntdStatus(task.status, task.progress)"
+                      />
+                    </div>
+
+                    <a-button
+                      type="link"
+                      danger
+                      class="cancel-btn"
+                      @click="cancel(task.taskKey)"
+                    >
+                      <template #icon>
+                        <CloseOutlined />
+                      </template>
+                    </a-button>
+                  </div>
+
+                  <div
+                    v-if="task.message"
+                    class="message-row"
+                  >
+                    {{ task.message }}
+                  </div>
                 </div>
               </div>
             </div>
@@ -396,14 +441,14 @@
         </div>
       </div>
     </div>
-  </div>
+  </template>
 </template>
 
 <script setup lang="ts">
 import { downloadGroups, uploadGroups, r2rTaskGroups, transferTasks, type Task, type TaskStatus } from './fileTransfer'
-import { CloseOutlined, DownOutlined, RightOutlined } from '@ant-design/icons-vue'
+import { ArrowDownOutlined, ArrowUpOutlined, CloseOutlined, DownOutlined, MinusOutlined, RightOutlined, SwapOutlined } from '@ant-design/icons-vue'
 import { useI18n } from 'vue-i18n'
-import { onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { addSystemThemeListener, getActualTheme } from '@/utils/themeUtils'
 import { userConfigStore } from '@store/userConfigStore'
 const configStore = userConfigStore()
@@ -412,6 +457,20 @@ const { t: $t } = useI18n()
 const api = (window as any).api
 
 const expandedMap = ref<Record<string, boolean>>({})
+const collapsed = ref(false)
+
+const totalTaskCount = computed(() => downloadGroups.value.length + uploadGroups.value.length + r2rTaskGroups.value.length)
+
+const overallPercent = computed(() => {
+  const parents = [
+    ...downloadGroups.value.map((g) => g.parent),
+    ...uploadGroups.value.map((g) => g.parent),
+    ...r2rTaskGroups.value.map((g) => g.parent)
+  ]
+  if (!parents.length) return 0
+  const sum = parents.reduce((acc, p) => acc + (Number(p.progress) || 0), 0)
+  return Math.floor(sum / parents.length)
+})
 
 const toggleExpand = (taskKey: string) => {
   const next = !expandedMap.value[taskKey]
@@ -548,6 +607,101 @@ onBeforeUnmount(() => {
   font-size: 17px;
   border-bottom: 1px solid var(--text-color-tertiary);
   color: var(--text-color);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.collapse-btn {
+  padding: 0 !important;
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-color);
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.collapse-btn:hover {
+  color: var(--button-bg-color);
+  background: transparent;
+}
+
+.collapse-btn :deep(.anticon) {
+  font-size: 14px;
+}
+
+.transfer-fab {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  z-index: 100;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-color);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s ease;
+}
+
+.transfer-fab:hover {
+  transform: scale(1.05);
+}
+
+.transfer-fab .fab-ring {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.transfer-fab .fab-ring :deep(.ant-progress-inner) {
+  background: transparent;
+}
+
+.transfer-fab .fab-ring :deep(.ant-progress-circle-trail) {
+  stroke: var(--text-color-tertiary);
+  opacity: 0.4;
+}
+
+.transfer-fab .fab-ring :deep(.ant-progress-circle-path) {
+  stroke: var(--button-bg-color);
+}
+
+.transfer-fab .fab-icon {
+  position: relative;
+  z-index: 1;
+  color: var(--button-bg-color);
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.transfer-fab .fab-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #ff4d4f;
+  color: #fff;
+  font-size: 11px;
+  line-height: 18px;
+  text-align: center;
+  font-weight: 600;
+  box-shadow: 0 0 0 2px var(--bg-color);
 }
 
 .transferBody {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #2190 

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible floating action button (FAB) mode for file transfers, showing progress ring and task count badge (up to "99+").
  * Enables users to collapse and expand the transfer list panel.

* **Localization**
  * Added translations for new collapse/expand transfer list actions across 12 languages (English, German, French, Italian, Japanese, Korean, Portuguese, Russian, Arabic, and Simplified/Traditional Chinese).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->