### PR TITLE
feat: add context menu functionality to workspace component with MoreOutlined icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,21 +30,27 @@ This document is intended for "AI coding agents/Agent tools" (such as the built-
 ## Behavioral Rules
 
 ### Rule 1 — Think Before Coding
+
 State assumptions explicitly. If uncertain, ask rather than guess. Push back when a simpler approach exists. Stop when confused — name what's unclear.
 
 ### Rule 2 — Simplicity First
+
 Minimum code that solves the problem. No speculative features. No abstractions for single-use code. If a senior engineer would call it overcomplicated, simplify.
 
 ### Rule 3 — Surgical Changes
+
 Touch only what you must. Don't "improve" adjacent code, comments, or formatting. Don't refactor what isn't broken. Match existing style.
 
 ### Rule 7 — Surface Conflicts, Don't Average Them
+
 If two existing patterns contradict, pick one (more recent / more tested), explain why, and flag the other for cleanup. Don't blend conflicting patterns.
 
 ### Rule 8 — Read Before You Write
+
 Before adding code in a file, read its exports, the immediate caller, and any obvious shared utilities. "Looks orthogonal to me" is dangerous — if unsure why code is structured a certain way, ask.
 
 ### Rule 12 — Fail Loud
+
 "Completed" is wrong if anything was skipped silently. "Tests pass" is wrong if any were skipped. Default to surfacing uncertainty, not hiding it.
 
 ## Basic Principles (Required Reading for Agents)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,21 +27,27 @@ npm run lint && npm run typecheck && npm test       # pre-commit checks
 ## Behavioral Rules
 
 ### Rule 1 — Think Before Coding
+
 State assumptions explicitly. If uncertain, ask rather than guess. Push back when a simpler approach exists. Stop when confused — name what's unclear.
 
 ### Rule 2 — Simplicity First
+
 Minimum code that solves the problem. No speculative features. No abstractions for single-use code. If a senior engineer would call it overcomplicated, simplify.
 
 ### Rule 3 — Surgical Changes
+
 Touch only what you must. Don't "improve" adjacent code, comments, or formatting. Don't refactor what isn't broken. Match existing style.
 
 ### Rule 7 — Surface Conflicts, Don't Average Them
+
 If two existing patterns contradict, pick one (more recent / more tested), explain why, and flag the other for cleanup. Don't blend conflicting patterns.
 
 ### Rule 8 — Read Before You Write
+
 Before adding code in a file, read its exports, the immediate caller, and any obvious shared utilities. "Looks orthogonal to me" is dangerous — if unsure why code is structured a certain way, ask.
 
 ### Rule 12 — Fail Loud
+
 "Completed" is wrong if anything was skipped silently. "Tests pass" is wrong if any were skipped. Default to surfacing uncertainty, not hiding it.
 
 ## Code Standards
@@ -80,6 +86,7 @@ Extending a provider: create file in `api/providers/`, register in `api/provider
 ## Database Migrations
 
 New tables or schema changes:
+
 1. Create timestamped file in `migrations/`
 2. Ensure idempotent and replayable
 3. Add service methods in corresponding `.service.ts`

--- a/src/renderer/src/views/components/Files/tabIndex.vue
+++ b/src/renderer/src/views/components/Files/tabIndex.vue
@@ -1377,29 +1377,47 @@ onUnmounted(() => {
   }
 
   .ant-tree-node-content-wrapper {
+    display: flex;
+    align-items: center;
     width: 100%;
+    min-width: 0;
+    flex: 1 1 auto;
+
+    &:hover {
+      background-color: var(--hover-bg-color) !important;
+    }
+
+    &.ant-tree-node-selected {
+      background-color: var(--hover-bg-color) !important;
+    }
   }
 
   .ant-tree-switcher {
     color: var(--text-color-tertiary) !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .ant-tree-node-selected {
     background-color: transparent;
   }
 
-  // Enhanced selection state for right-clicked hosts
+  // Selected host: blue text + blue icon, no border
   .ant-tree-node-selected .title-with-icon {
-    border: 1px solid #1890ff !important;
-    // border-radius: 4px !important;
-    // box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2) !important;
+    color: #1890ff !important;
+
+    .computer-icon {
+      color: #1890ff !important;
+    }
   }
 
   .ant-tree-treenode {
     width: 100%;
-    &:hover {
-      background-color: var(--hover-bg-color);
-    }
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    align-items: center;
   }
 
   .ant-tree-indent {
@@ -1436,9 +1454,11 @@ onUnmounted(() => {
 
     // Selection state for right-clicked hosts
     &.selected {
-      // border: 1px solid #1890ff !important;
-      // box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2) !important;
       color: #1890ff !important;
+
+      .computer-icon {
+        color: #1890ff !important;
+      }
     }
 
     .computer-icon {

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -2493,11 +2493,13 @@ onUnmounted(() => {
     background-color: transparent;
   }
 
-  // Enhanced selection state for right-clicked hosts
+  // Selected host: blue text + blue icon, no border
   .ant-tree-node-selected .title-with-icon {
-    border: 1px solid #1890ff !important;
-    // border-radius: 4px !important;
-    // box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2) !important;
+    color: #1890ff !important;
+
+    .computer-icon {
+      color: #1890ff !important;
+    }
   }
 
   .ant-tree-treenode {
@@ -2541,9 +2543,11 @@ onUnmounted(() => {
 
     // Selection state for right-clicked hosts
     &.selected {
-      // border: 1px solid #1890ff !important;
-      // box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2) !important;
       color: #1890ff !important;
+
+      .computer-icon {
+        color: #1890ff !important;
+      }
     }
 
     .computer-icon {

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -167,6 +167,11 @@
                       />
                     </a-tooltip>
                   </span>
+                  <MoreOutlined
+                    v-if="hasContextMenu(dataRef)"
+                    class="more-icon"
+                    @click.stop="handleContextMenu($event, dataRef)"
+                  />
                 </div>
               </template>
             </a-tree>
@@ -282,6 +287,11 @@
                       </a-button>
                     </a-tooltip>
                   </div>
+                  <MoreOutlined
+                    v-if="hasContextMenu(dataRef)"
+                    class="more-icon"
+                    @click.stop="handleContextMenu($event, dataRef)"
+                  />
                 </div>
               </template>
             </a-tree>
@@ -635,7 +645,8 @@ import {
   AppstoreAddOutlined,
   SwapOutlined,
   ApiOutlined,
-  QuestionCircleOutlined
+  QuestionCircleOutlined,
+  MoreOutlined
 } from '@ant-design/icons-vue'
 import eventBus from '@/utils/eventBus'
 import i18n from '@/locales'
@@ -2096,6 +2107,19 @@ const handleFolderMouseLeave = (e: Event) => {
   if (target) target.style.backgroundColor = 'transparent'
 }
 
+const hasContextMenu = (dataRef: any): boolean => {
+  if (!dataRef) return false
+  const hasFavoriteOption = dataRef.favorite !== undefined
+  const hasCommentOption = isOrganizationAsset(dataRef.asset_type) && !dataRef.key.startsWith('common_')
+  const hasMoveOption = isOrganizationAsset(dataRef.asset_type) && !dataRef.key.startsWith('common_') && !dataRef.key.startsWith('folder_')
+  const hasTunnelOption = canCreateTunnel(dataRef)
+  const hasRemoveOption = isOrganizationAsset(dataRef.asset_type) && dataRef.key.startsWith('folder_') && dataRef.folderUuid
+  const hasEditFolderOption = dataRef.asset_type === 'custom_folder' && !dataRef.key.startsWith('common_')
+  const hasDeleteFolderOption = dataRef.asset_type === 'custom_folder' && !dataRef.key.startsWith('common_')
+
+  return hasFavoriteOption || hasCommentOption || hasMoveOption || hasTunnelOption || hasRemoveOption || hasEditFolderOption || hasDeleteFolderOption
+}
+
 const handleContextMenu = (event: MouseEvent, dataRef: any) => {
   event.preventDefault()
   event.stopPropagation()
@@ -2120,16 +2144,6 @@ const handleContextMenu = (event: MouseEvent, dataRef: any) => {
     !hasDeleteFolderOption
   ) {
     return
-  }
-
-  // Select the host when right-clicking to show selection state
-  if (isSecondLevel(dataRef)) {
-    selectedKeys.value = [dataRef.key]
-    // Update machines value to reflect the selection
-    machines.value = {
-      value: dataRef.key,
-      label: dataRef.title
-    }
   }
 
   // Calculate the number of menu items that will be shown
@@ -2523,6 +2537,29 @@ onUnmounted(() => {
   padding-right: 4px;
   min-width: 0;
   overflow: hidden;
+
+  &:hover .more-icon {
+    opacity: 1;
+  }
+
+  .more-icon {
+    margin-left: auto;
+    padding: 2px 4px;
+    color: var(--text-color-tertiary);
+    font-size: 14px;
+    cursor: pointer;
+    border-radius: 4px;
+    opacity: 0;
+    transition:
+      opacity 0.2s ease,
+      background-color 0.15s ease;
+    flex-shrink: 0;
+
+    &:hover {
+      background-color: var(--hover-bg-color);
+      color: var(--text-color);
+    }
+  }
 
   .title-with-icon {
     display: flex;

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -2469,6 +2469,14 @@ onUnmounted(() => {
     width: 100%;
     min-width: 0;
     flex: 1 1 auto;
+
+    &:hover {
+      background-color: var(--hover-bg-color) !important;
+    }
+
+    &.ant-tree-node-selected {
+      background-color: var(--hover-bg-color) !important;
+    }
   }
 
   .ant-tree-title {
@@ -2497,9 +2505,6 @@ onUnmounted(() => {
     max-width: 100%;
     min-width: 0;
     box-sizing: border-box;
-    &:hover {
-      background-color: var(--hover-bg-color);
-    }
   }
 
   .ant-tree-indent {

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -2501,6 +2501,9 @@ onUnmounted(() => {
 
   .ant-tree-switcher {
     color: var(--text-color-tertiary) !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .ant-tree-node-selected {
@@ -2521,6 +2524,7 @@ onUnmounted(() => {
     max-width: 100%;
     min-width: 0;
     box-sizing: border-box;
+    align-items: center;
   }
 
   .ant-tree-indent {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contextual "More" icon to tree node headers that appears when node-specific actions are available and opens the node context menu.

* **Style**
  * Improved tree hover and selected-state visuals with refined alignment and flex layout for consistent rendering.
  * Changed selection indication to use primary-color text/icon styling instead of border highlights.

* **Documentation**
  * Clarified behavioral rules by adding an explicit "Think Before Coding" heading and reorganizing related guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->