### PR TITLE
feat: add setup file for jsdom localStorage support in Vitest configuration

### DIFF
--- a/tests/setup-renderer.ts
+++ b/tests/setup-renderer.ts
@@ -1,0 +1,24 @@
+// Node.js 22+ ships an experimental built-in `localStorage` getter on the
+// global object. Without `--localstorage-file`, it is a useless empty object.
+// Vitest's `populateGlobal` skips copying jsdom's `localStorage` over to the
+// Node global because the key already exists, leaving tests with the broken
+// Node version. Re-expose jsdom's real Storage instances on the global so
+// tests can use localStorage/sessionStorage and dispatch StorageEvents.
+const jsdomWindow = (window as any).jsdom?.window as Window | undefined
+
+if (jsdomWindow) {
+  for (const name of ['localStorage', 'sessionStorage'] as const) {
+    const storage = jsdomWindow[name]
+    Object.defineProperty(window, name, {
+      configurable: true,
+      get: () => storage,
+      set: (next: Storage) => {
+        Object.defineProperty(window, name, {
+          configurable: true,
+          writable: true,
+          value: next
+        })
+      }
+    })
+  }
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -122,7 +122,8 @@ export default defineConfig({
             'src/renderer/src/utils/terminalOutputExtractor.test.ts',
             'src/renderer/**/*.component.test.ts' // Exclude component tests from jsdom
           ],
-          environment: 'jsdom'
+          environment: 'jsdom',
+          setupFiles: [resolve('tests/setup-renderer.ts')]
         },
         plugins: createRendererPlugins(),
         resolve: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 import vue from '@vitejs/plugin-vue'
@@ -95,6 +95,11 @@ export default defineConfig({
         test: {
           name: 'main-process',
           include: ['src/main/**/*.test.ts', 'src/main/**/*.spec.ts', 'src/shared/**/*.test.ts', 'src/shared/**/*.spec.ts'],
+          // db-assets.test.ts loads better-sqlite3, which is rebuilt against
+          // the Electron ABI by `postinstall` (electron-builder install-app-deps).
+          // Running it under the system Node fails with NODE_MODULE_VERSION
+          // mismatch. Run it via Electron-aware tooling instead.
+          exclude: [...configDefaults.exclude, 'src/main/storage/db/chaterm/__tests__/db-assets.test.ts'],
           environment: 'node'
         },
         plugins: createMainProcessPlugins(),


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test environment to ensure browser-like storage APIs work reliably under Node.js 22+.

* **Chores**
  * Updated test configuration to load the renderer setup file and adjust excluded tests for smoother test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->