### PR TITLE
fix: adjust release artifact signing to accommodate new bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,8 +326,6 @@ jobs:
           shopt -s nullglob
           staged=0
           for f in signed-release-assets/*.cosign.bundle \
-                   signed-release-assets/*.bundle.json \
-                   signed-release-assets/*.sig \
                    signed-release-assets/SHA256SUMS.txt; do
             [ -f "$f" ] || continue
             cp "$f" "release-upload/$(basename "$f")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,8 @@ jobs:
         run: |
           shopt -s nullglob
           staged=0
-          for f in signed-release-assets/*.bundle.json \
+          for f in signed-release-assets/*.cosign.bundle \
+                   signed-release-assets/*.bundle.json \
                    signed-release-assets/*.sig \
                    signed-release-assets/SHA256SUMS.txt; do
             [ -f "$f" ] || continue

--- a/scripts/sign-release-artifacts.sh
+++ b/scripts/sign-release-artifacts.sh
@@ -27,7 +27,7 @@ find "$SOURCE_DIR" -type f \( \
   -name "latest*.yml" \
 \) -exec cp {} "$OUTPUT_DIR"/ \;
 
-artifact_count="$(find "$OUTPUT_DIR" -maxdepth 1 -type f ! -name "*.sig" ! -name "*.bundle.json" ! -name "SHA256SUMS.txt" | wc -l | tr -d ' ')"
+artifact_count="$(find "$OUTPUT_DIR" -maxdepth 1 -type f ! -name "*.sig" ! -name "*.bundle.json" ! -name "*.cosign.bundle" ! -name "SHA256SUMS.txt" | wc -l | tr -d ' ')"
 
 if [ "$artifact_count" = "0" ]; then
   echo "Error: no release artifacts found in $SOURCE_DIR" >&2
@@ -41,16 +41,18 @@ for file in "$OUTPUT_DIR"/*; do
   [ -f "$file" ] || continue
 
   case "$file" in
-    *.sig|*.bundle.json|*SHA256SUMS.txt)
+    *.sig|*.bundle.json|*.cosign.bundle|*SHA256SUMS.txt)
       continue
       ;;
   esac
 
   echo "Signing: $file"
 
-  # Use cosign bundle output for new bundle format compatibility.
+  # cosign v3+ defaults to the new bundle format; pass it explicitly so the
+  # --bundle path is interpreted consistently across cosign versions.
   cosign sign-blob "$file" \
-    --bundle "$file.bundle.json"
+    --new-bundle-format \
+    --bundle "$file.cosign.bundle"
 done
 
 echo "Generating SHA256SUMS.txt"
@@ -73,7 +75,7 @@ subjects_file="$(mktemp)"
     [ -f "$artifact" ] || continue
 
     case "$artifact" in
-      *.sig|*.bundle.json|SHA256SUMS.txt)
+      *.sig|*.bundle.json|*.cosign.bundle|SHA256SUMS.txt)
         continue
         ;;
     esac

--- a/scripts/sign-release-artifacts.sh
+++ b/scripts/sign-release-artifacts.sh
@@ -27,7 +27,7 @@ find "$SOURCE_DIR" -type f \( \
   -name "latest*.yml" \
 \) -exec cp {} "$OUTPUT_DIR"/ \;
 
-artifact_count="$(find "$OUTPUT_DIR" -maxdepth 1 -type f ! -name "*.sig" ! -name "*.bundle.json" ! -name "*.cosign.bundle" ! -name "SHA256SUMS.txt" | wc -l | tr -d ' ')"
+artifact_count="$(find "$OUTPUT_DIR" -maxdepth 1 -type f ! -name "*.cosign.bundle" ! -name "SHA256SUMS.txt" | wc -l | tr -d ' ')"
 
 if [ "$artifact_count" = "0" ]; then
   echo "Error: no release artifacts found in $SOURCE_DIR" >&2
@@ -41,7 +41,7 @@ for file in "$OUTPUT_DIR"/*; do
   [ -f "$file" ] || continue
 
   case "$file" in
-    *.sig|*.bundle.json|*.cosign.bundle|*SHA256SUMS.txt)
+    *.cosign.bundle|*SHA256SUMS.txt)
       continue
       ;;
   esac
@@ -75,7 +75,7 @@ subjects_file="$(mktemp)"
     [ -f "$artifact" ] || continue
 
     case "$artifact" in
-      *.sig|*.bundle.json|*.cosign.bundle|SHA256SUMS.txt)
+      *.cosign.bundle|SHA256SUMS.txt)
         continue
         ;;
     esac


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release artifact signing process to use cosign's new bundle format, replacing the legacy format for improved security and consistency of signed artifacts in GitHub releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->