### PR TITLE
fix: ensure correct blob path handling in release artifact signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15930,7 +15930,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "^5.7.0",
     "js-cookie": "^3.0.7",
+    "qs": "^6.15.2",
     "uuid": "^14.0.0"
   },
   "optionalDependencies": {

--- a/scripts/sign-release-artifacts.sh
+++ b/scripts/sign-release-artifacts.sh
@@ -50,9 +50,13 @@ for file in "$OUTPUT_DIR"/*; do
 
   # cosign v3+ defaults to the new bundle format; pass it explicitly so the
   # --bundle path is interpreted consistently across cosign versions.
-  cosign sign-blob "$file" \
+  # The blob path must come after all flags (use `--` to separate) so cosign
+  # does not treat it as a flag value and leave --bundle empty.
+  cosign sign-blob \
+    --yes \
     --new-bundle-format \
-    --bundle "$file.cosign.bundle"
+    --bundle "$file.cosign.bundle" \
+    -- "$file"
 done
 
 echo "Generating SHA256SUMS.txt"

--- a/src/renderer/src/views/components/AiTab/composables/useContext.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useContext.ts
@@ -74,7 +74,7 @@ export const useContext = (options: UseContextOptions = {}) => {
     if (chatTypeValue.value !== 'chat' && chatTypeValue.value !== 'cmd') {
       items.push('hosts')
     }
-    items.push('docs', 'chats', 'skills')
+    items.push('docs', 'skills', 'chats')
     return items
   })
 

--- a/src/renderer/src/views/components/LeftTab/components/AssetForm.vue
+++ b/src/renderer/src/views/components/LeftTab/components/AssetForm.vue
@@ -585,6 +585,7 @@ watch(
 )
 
 const syncAuthType = () => {
+  if (!isOrganizationAsset(formData.asset_type)) return
   const resolved = resolveBastionAuthType(formData.asset_type, availableBastions.value, formData.auth_type)
   if (resolved !== formData.auth_type) {
     formData.auth_type = resolved


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release artifact signing invocation to avoid misinterpreting artifact paths and generate a separate signature bundle.
  * Added an npm override for qs (^6.15.2).
* **Bug Fixes**
  * Prevented authentication type from being overwritten for personal assets, preserving the selected auth setting.
* **New Features**
  * Adjusted main menu order to show docs, skills, then chats when a non-chat chat type is selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->