### PR TITLE
feat(locales): add 'knowledge' translations for multiple languages

### DIFF
--- a/src/renderer/src/views/layouts/TerminalLayout.vue
+++ b/src/renderer/src/views/layouts/TerminalLayout.vue
@@ -3704,4 +3704,25 @@ defineExpose({
   opacity: 0;
   transition: none;
 }
+
+.dockview-theme-light .dv-tab,
+.dockview-theme-dark .dv-tab {
+  max-width: 180px;
+  min-width: 0;
+}
+
+.dockview-theme-light .dv-default-tab,
+.dockview-theme-dark .dv-default-tab {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.dockview-theme-light .dv-default-tab .dv-default-tab-content,
+.dockview-theme-dark .dv-default-tab .dv-default-tab-content {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 </style>


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Knowledge" label across all supported languages (EN, DE, FR, IT, JA, KO, PT, RU, AR, ZH-CN, ZH-TW).

* **Improvements**
  * Left navigation now shows localized tab labels and tooltips.
  * Tab bar styling improved to prevent long titles from overflowing, keeping labels truncated and readable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->