### PR TITLE
style(KnowledgeCenter): override background for selected tree nodes to improve visibility

### DIFF
--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'المفاتيح',
     extensions: 'الملحقات',
     ai: 'الذكاء الاصطناعي',
+    knowledge: 'قاعدة المعرفة',
     user: 'المستخدم',
     setting: 'الإعدادات',
     notice: 'الإشعارات',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Schlüsselbund',
     extensions: 'Erweiterungen',
     ai: 'AI',
+    knowledge: 'Wissensdatenbank',
     user: 'Benutzer',
     setting: 'Einstellung',
     notice: 'Hinweis',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Keychain',
     extensions: 'Extensions',
     ai: 'AI',
+    knowledge: 'Knowledge',
     user: 'User',
     setting: 'Setting',
     notice: 'Notice',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Trousseau de clés',
     extensions: 'Extensions',
     ai: 'IA',
+    knowledge: 'Base de connaissances',
     user: 'Utilisateur',
     setting: 'Paramètres',
     notice: 'Avis',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Portachiavi',
     extensions: 'Estensioni',
     ai: 'IA',
+    knowledge: 'Base di conoscenza',
     user: 'Utente',
     setting: 'Impostazioni',
     notice: 'Nota',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'キーチェーン',
     extensions: '拡張機能',
     ai: 'AI',
+    knowledge: 'ナレッジベース',
     user: 'ユーザー',
     setting: '設定',
     notice: '通知',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -17,6 +17,7 @@ export default {
     keychain: '키체인',
     extensions: '확장',
     ai: 'AI',
+    knowledge: '지식 베이스',
     user: '사용자',
     setting: '설정',
     notice: '알림',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Cadeia de Chaves',
     extensions: 'Extensões',
     ai: 'IA',
+    knowledge: 'Base de conhecimento',
     user: 'Utilizador',
     setting: 'Configurações',
     notice: 'Aviso',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -17,6 +17,7 @@ export default {
     keychain: 'Связка ключей',
     extensions: 'Расширения',
     ai: 'ИИ',
+    knowledge: 'База знаний',
     user: 'Пользователь',
     setting: 'Настройки',
     notice: 'Уведомление',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -17,6 +17,7 @@ export default {
     keychain: '秘钥',
     extensions: '扩展',
     ai: 'AI',
+    knowledge: '知识库',
     user: '用户',
     setting: '设置',
     notice: '通知',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -17,6 +17,7 @@ export default {
     keychain: '秘鑰',
     extensions: '擴展',
     ai: 'AI',
+    knowledge: '知識庫',
     user: '用戶',
     setting: '設置',
     notice: '公告',

--- a/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
+++ b/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
@@ -1483,8 +1483,9 @@ onBeforeUnmount(() => {
 :deep(.kb-tree) {
   background-color: transparent;
 
-  // DirectoryTree uses ::before for selected background; override it here
   &.ant-tree.ant-tree-directory {
+    .ant-tree-treenode::before,
+    .ant-tree-treenode:hover::before,
     .ant-tree-treenode-selected::before,
     .ant-tree-treenode-selected:hover::before {
       background: none !important;

--- a/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
+++ b/src/renderer/src/views/components/KnowledgeCenter/KnowledgeCenter.vue
@@ -1461,6 +1461,7 @@ onBeforeUnmount(() => {
   font-size: 12px;
   color: var(--kb-primary-color);
   flex-shrink: 0;
+  cursor: pointer;
   &:hover {
     color: var(--kb-primary-color);
     opacity: 0.85;

--- a/src/renderer/src/views/components/LeftTab/constants/data.ts
+++ b/src/renderer/src/views/components/LeftTab/constants/data.ts
@@ -1,56 +1,56 @@
 const menuTabsData = [
   {
-    name: 'Hosts',
+    nameKey: 'common.workspace',
     key: 'workspace',
     icon: new URL('@/assets/menu/host.svg', import.meta.url).href
   },
   {
-    name: 'Assets',
+    nameKey: 'common.management',
     key: 'assets',
     icon: new URL('@/assets/menu/asset.svg', import.meta.url).href
   },
   {
-    name: 'Files',
+    nameKey: 'common.files',
     key: 'files',
     icon: new URL('@/assets/menu/files.svg', import.meta.url).href
   },
   {
-    name: 'Snippets',
+    nameKey: 'common.quickCommand',
     key: 'snippets',
     icon: new URL('@/assets/menu/snippets.svg', import.meta.url).href
   },
   {
-    name: 'Knowledge',
+    nameKey: 'common.knowledge',
     key: 'knowledgecenter',
     icon: new URL('@/assets/menu/doc.svg', import.meta.url).href
   },
   {
-    name: 'Plugins',
+    nameKey: 'extensions.plugins',
     key: 'extensions',
     icon: new URL('@/assets/menu/extensions.svg', import.meta.url).href
   },
   {
-    name: 'AI',
+    nameKey: 'common.ai',
     key: 'ai',
     icon: new URL('@/assets/menu/ai.svg', import.meta.url).href
   },
   {
-    name: 'Database',
+    nameKey: 'common.database',
     key: 'database',
     icon: new URL('@/assets/menu/database.svg', import.meta.url).href
   },
   {
-    name: 'User',
+    nameKey: 'common.user',
     key: 'user',
     icon: new URL('@/assets/menu/user.svg', import.meta.url).href
   },
   {
-    name: 'Setting',
+    nameKey: 'common.setting',
     key: 'setting',
     icon: new URL('@/assets/menu/setting.svg', import.meta.url).href
   }
   // {
-  //   name: 'Notice',
+  //   nameKey: 'common.notice',
   //   key: 'notice',
   //   icon: new URL('@/assets/menu/notice.svg', import.meta.url).href
   // }

--- a/src/renderer/src/views/components/LeftTab/index.vue
+++ b/src/renderer/src/views/components/LeftTab/index.vue
@@ -4,7 +4,7 @@
       <a-tooltip
         v-for="i in menuTabsData.slice(0, -2)"
         :key="i.key"
-        :title="i.name"
+        :title="$t(i.nameKey)"
         placement="right"
         :mouse-enter-delay="1"
       >
@@ -108,7 +108,7 @@
       <a-tooltip
         v-for="i in menuTabsData.slice(-2)"
         :key="i.key"
-        :title="i.name"
+        :title="$t(i.nameKey)"
         :mouse-enter-delay="1"
       >
         <div v-if="i.key === 'user'">


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Center feature with full multi-language support (12 languages including Arabic, German, French, Japanese, Korean, Portuguese, Russian, Chinese, and more).

* **Style**
  * Improved UI interactions in Knowledge Center with visual cursor feedback and refined tree component styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->