### PR TITLE
feat: add cursorBlink and lineHeight configuration options with corresponding translations

### DIFF
--- a/src/renderer/src/locales/lang/ar-AR.ts
+++ b/src/renderer/src/locales/lang/ar-AR.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'مربع',
     cursorStyleBar: 'شريط',
     cursorStyleUnderline: 'تحتية',
+    cursorBlink: 'وميض المؤشر',
+    lineHeight: 'ارتفاع السطر',
     mouseEvent: 'حدث الماوس',
     middleMouseEvent: 'حدث الماوس الأوسط',
     rightMouseEvent: 'حدث الماوس الأيمن',

--- a/src/renderer/src/locales/lang/de-DE.ts
+++ b/src/renderer/src/locales/lang/de-DE.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Block',
     cursorStyleBar: 'Bar',
     cursorStyleUnderline: 'Unterstreichung',
+    cursorBlink: 'Cursor-Blinken',
+    lineHeight: 'Zeilenhöhe',
     mouseEvent: 'Maus-Ereignis',
     middleMouseEvent: 'Mittlere Maus-Ereignis',
     rightMouseEvent: 'Rechte Maus-Ereignis',

--- a/src/renderer/src/locales/lang/en-US.ts
+++ b/src/renderer/src/locales/lang/en-US.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Block',
     cursorStyleBar: 'Bar',
     cursorStyleUnderline: 'Underline',
+    cursorBlink: 'Cursor blink',
+    lineHeight: 'Line height',
     mouseEvent: 'Mouse Event',
     middleMouseEvent: 'Middle Mouse Event',
     rightMouseEvent: 'Right Mouse Event',

--- a/src/renderer/src/locales/lang/fr-FR.ts
+++ b/src/renderer/src/locales/lang/fr-FR.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Bloc',
     cursorStyleBar: 'Barre',
     cursorStyleUnderline: 'Sous-ligne',
+    cursorBlink: 'Clignotement du curseur',
+    lineHeight: 'Hauteur de ligne',
     mouseEvent: 'Événement de la souris',
     middleMouseEvent: 'Événement de la molette de la souris',
     rightMouseEvent: 'Événement du bouton droit de la souris',

--- a/src/renderer/src/locales/lang/it-IT.ts
+++ b/src/renderer/src/locales/lang/it-IT.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Blocco',
     cursorStyleBar: 'Barra',
     cursorStyleUnderline: 'Sottolineato',
+    cursorBlink: 'Lampeggio del cursore',
+    lineHeight: 'Altezza riga',
     mouseEvent: 'Evento mouse',
     middleMouseEvent: 'Evento mouse centrale',
     rightMouseEvent: 'Evento mouse destro',

--- a/src/renderer/src/locales/lang/ja-JP.ts
+++ b/src/renderer/src/locales/lang/ja-JP.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'ブロック',
     cursorStyleBar: 'バー',
     cursorStyleUnderline: '下線',
+    cursorBlink: 'カーソルの点滅',
+    lineHeight: '行の高さ',
     mouseEvent: 'マウスイベント',
     middleMouseEvent: 'マウス中ボタンイベント',
     rightMouseEvent: 'マウス右ボタンイベント',

--- a/src/renderer/src/locales/lang/ko-KR.ts
+++ b/src/renderer/src/locales/lang/ko-KR.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: '블록',
     cursorStyleBar: '바',
     cursorStyleUnderline: '밑줄',
+    cursorBlink: '커서 깜박임',
+    lineHeight: '줄 높이',
     mouseEvent: '마우스 이벤트',
     middleMouseEvent: '마우스 중간 버튼 이벤트',
     rightMouseEvent: '마우스 오른쪽 버튼 이벤트',

--- a/src/renderer/src/locales/lang/pt-PT.ts
+++ b/src/renderer/src/locales/lang/pt-PT.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Bloco',
     cursorStyleBar: 'Barra',
     cursorStyleUnderline: 'Sublinhado',
+    cursorBlink: 'Piscar do cursor',
+    lineHeight: 'Altura da linha',
     mouseEvent: 'Evento do mouse',
     middleMouseEvent: 'Evento do mouse do meio',
     rightMouseEvent: 'Evento do mouse direito',

--- a/src/renderer/src/locales/lang/ru-RU.ts
+++ b/src/renderer/src/locales/lang/ru-RU.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: 'Блок',
     cursorStyleBar: 'Полоса',
     cursorStyleUnderline: 'Подчеркивание',
+    cursorBlink: 'Мигание курсора',
+    lineHeight: 'Высота строки',
     mouseEvent: 'Событие мыши',
     middleMouseEvent: 'Событие средней кнопки мыши',
     rightMouseEvent: 'Событие правой кнопки мыши',

--- a/src/renderer/src/locales/lang/zh-CN.ts
+++ b/src/renderer/src/locales/lang/zh-CN.ts
@@ -255,6 +255,8 @@ export default {
     cursorStyleBlock: '块',
     cursorStyleBar: '竖线',
     cursorStyleUnderline: '下划线',
+    cursorBlink: '是否开启光标闪烁',
+    lineHeight: '行高',
     mouseEvent: '鼠标事件',
     middleMouseEvent: '鼠标中键事件',
     rightMouseEvent: '鼠标右键事件',

--- a/src/renderer/src/locales/lang/zh-TW.ts
+++ b/src/renderer/src/locales/lang/zh-TW.ts
@@ -257,6 +257,8 @@ export default {
     cursorStyleBlock: '塊',
     cursorStyleBar: '豎線',
     cursorStyleUnderline: '下劃線',
+    cursorBlink: '是否開啟游標閃爍',
+    lineHeight: '行高',
     mouseEvent: '滑鼠事件',
     middleMouseEvent: '鼠標中鍵事件',
     rightMouseEvent: '鼠標右鍵事件',

--- a/src/renderer/src/services/__tests__/userConfigStoreService.test.ts
+++ b/src/renderer/src/services/__tests__/userConfigStoreService.test.ts
@@ -276,4 +276,31 @@ describe('UserConfigStoreService', () => {
     expect(txWrites).toHaveLength(1)
     expect(txWrites[0]).toEqual(['userConfig', 'userConfigSyncMeta'])
   })
+
+  it('buildDefaultUserConfig should include cursorBlink and lineHeight defaults', async () => {
+    const { buildDefaultUserConfig } = await import('../userConfigStoreService')
+
+    const config = buildDefaultUserConfig()
+
+    expect(config.cursorBlink).toBe(true)
+    expect(config.lineHeight).toBe(1)
+  })
+
+  it('sync whitelist and validators should support cursorBlink and lineHeight', async () => {
+    const { SYNC_WHITELIST, SYNC_FIELD_VALIDATORS } = await import('../userConfigStoreService')
+
+    expect(SYNC_WHITELIST).toContain('cursorBlink')
+    expect(SYNC_WHITELIST).toContain('lineHeight')
+
+    expect(SYNC_FIELD_VALIDATORS.cursorBlink(true)).toBe(true)
+    expect(SYNC_FIELD_VALIDATORS.cursorBlink(false)).toBe(true)
+    expect(SYNC_FIELD_VALIDATORS.cursorBlink('true' as any)).toBe(false)
+
+    expect(SYNC_FIELD_VALIDATORS.lineHeight(1)).toBe(true)
+    expect(SYNC_FIELD_VALIDATORS.lineHeight(2.5)).toBe(true)
+    expect(SYNC_FIELD_VALIDATORS.lineHeight(3)).toBe(true)
+    expect(SYNC_FIELD_VALIDATORS.lineHeight(0.9)).toBe(false)
+    expect(SYNC_FIELD_VALIDATORS.lineHeight(3.1)).toBe(false)
+    expect(SYNC_FIELD_VALIDATORS.lineHeight('1.5' as any)).toBe(false)
+  })
 })

--- a/src/renderer/src/services/userConfigStoreService.ts
+++ b/src/renderer/src/services/userConfigStoreService.ts
@@ -65,6 +65,8 @@ export interface UserConfig {
   scrollBack: number
   language: SupportedLanguage
   cursorStyle: 'bar' | 'block' | 'underline' | undefined
+  cursorBlink?: boolean
+  lineHeight?: number
   terminalType?: string
   middleMouseEvent?: 'paste' | 'contextMenu' | 'closeTab' | 'none'
   rightMouseEvent?: 'paste' | 'contextMenu' | 'none'
@@ -165,6 +167,8 @@ export function buildDefaultUserConfig(now: number = Date.now()): UserConfig {
     scrollBack: 1000,
     language: 'zh-CN',
     cursorStyle: 'block',
+    cursorBlink: true,
+    lineHeight: 1,
     middleMouseEvent: 'paste',
     rightMouseEvent: 'contextMenu',
     watermark: 'open',
@@ -363,6 +367,8 @@ export const SYNC_WHITELIST = [
   'fontSize',
   'scrollBack',
   'cursorStyle',
+  'cursorBlink',
+  'lineHeight',
   'terminalType',
   'middleMouseEvent',
   'rightMouseEvent',
@@ -398,6 +404,8 @@ export const SYNC_FIELD_VALIDATORS: Record<SyncWhitelistKey, (val: unknown) => b
   fontSize: (val) => typeof val === 'number' && Number.isInteger(val) && val >= 8 && val <= 64,
   scrollBack: (val) => typeof val === 'number' && Number.isInteger(val) && val >= 1 && val <= 100000,
   cursorStyle: (val) => typeof val === 'string' && ['block', 'bar', 'underline'].includes(val),
+  cursorBlink: (val) => typeof val === 'boolean',
+  lineHeight: (val) => typeof val === 'number' && Number.isFinite(val) && val >= 1 && val <= 3,
   terminalType: (val) =>
     typeof val === 'string' && ['xterm', 'xterm-256color', 'vt100', 'vt102', 'vt220', 'vt320', 'linux', 'scoansi', 'ansi'].includes(val),
   middleMouseEvent: (val) => typeof val === 'string' && ['paste', 'contextMenu', 'closeTab', 'none'].includes(val),

--- a/src/renderer/src/views/components/K8s/K8sConnect.vue
+++ b/src/renderer/src/views/components/K8s/K8sConnect.vue
@@ -130,10 +130,11 @@ const initTerminal = async () => {
 
   terminal.value = new Terminal({
     scrollback: userConfig?.scrollBack || 5000,
-    cursorBlink: true,
+    cursorBlink: userConfig?.cursorBlink !== false,
     cursorStyle: userConfig?.cursorStyle || 'block',
     fontSize,
     fontFamily,
+    lineHeight: typeof userConfig?.lineHeight === 'number' ? userConfig.lineHeight : 1,
     allowTransparency: true,
     theme: getTerminalTheme()
   })

--- a/src/renderer/src/views/components/K8s/__tests__/K8sConnect.test.ts
+++ b/src/renderer/src/views/components/K8s/__tests__/K8sConnect.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { Terminal } from '@xterm/xterm'
 
 // Must be hoisted before vi.mock
 const mockK8sTerminalCreate = vi.fn()
@@ -24,6 +25,9 @@ const mockK8sOnTerminalData = vi.fn((_id: string, _cb: (data: string) => void) =
 const mockK8sOnTerminalExit = vi.fn((_id: string, _cb: () => void) => () => {})
 const mockK8sStore = vi.hoisted(() => ({
   connectCluster: vi.fn()
+}))
+const { mockUserConfigGetConfig } = vi.hoisted(() => ({
+  mockUserConfigGetConfig: vi.fn()
 }))
 
 const mockTerminalInstance = {
@@ -122,13 +126,7 @@ vi.mock('@/store/k8sStore', () => ({
 vi.mock('@/services/userConfigStoreService', () => {
   return {
     userConfigStore: {
-      getConfig: vi.fn().mockResolvedValue({
-        background: { image: null },
-        theme: 'dark',
-        fontSize: 13,
-        fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-        scrollBack: 5000
-      })
+      getConfig: mockUserConfigGetConfig
     }
   }
 })
@@ -239,6 +237,13 @@ describe('K8s Connect Component', () => {
     mockK8sStore.connectCluster.mockResolvedValue({ success: true })
     mockK8sOnTerminalData.mockReturnValue(() => {})
     mockK8sOnTerminalExit.mockReturnValue(() => {})
+    mockUserConfigGetConfig.mockResolvedValue({
+      background: { image: null },
+      theme: 'dark',
+      fontSize: 13,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      scrollBack: 5000
+    })
     // Restore writeToTerminal mock after clearAllMocks
     vi.mocked(k8sApi.writeToTerminal).mockResolvedValue(undefined as any)
     ;(mockTerminalInstance.buffer.active.getLine as ReturnType<typeof vi.fn>).mockImplementation((i: number) => ({
@@ -352,6 +357,31 @@ describe('K8s Connect Component', () => {
       await flushPromises()
       expect(mockK8sOnTerminalData).toHaveBeenCalled()
       expect(mockK8sOnTerminalExit).toHaveBeenCalled()
+    })
+
+    it('should initialize terminal with cursorBlink and lineHeight from user config', async () => {
+      mockUserConfigGetConfig.mockResolvedValue({
+        background: { image: null },
+        theme: 'dark',
+        fontSize: 13,
+        fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+        scrollBack: 5000,
+        cursorStyle: 'underline',
+        cursorBlink: false,
+        lineHeight: 1.7
+      })
+
+      wrapper = createWrapper()
+      await flushPromises()
+
+      const terminalConstructor = Terminal as unknown as ReturnType<typeof vi.fn>
+      expect(terminalConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cursorStyle: 'underline',
+          cursorBlink: false,
+          lineHeight: 1.7
+        })
+      )
     })
   })
 

--- a/src/renderer/src/views/components/LeftTab/setting/__tests__/terminal.test.ts
+++ b/src/renderer/src/views/components/LeftTab/setting/__tests__/terminal.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import TerminalComponent from '../terminal.vue'
+import { userConfigStore } from '@/services/userConfigStoreService'
+
+const { mockGetConfig, mockSaveConfig } = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockSaveConfig: vi.fn()
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('ant-design-vue', () => ({
+  notification: {
+    success: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/utils/eventBus', () => ({
+  default: {
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn()
+  }
+}))
+
+vi.mock('@/services/userConfigStoreService', () => ({
+  userConfigStore: {
+    getConfig: mockGetConfig,
+    saveConfig: mockSaveConfig
+  },
+  remoteApplyGuard: {
+    isApplying: false
+  }
+}))
+
+Object.defineProperty(globalThis, 'createRendererLogger', {
+  value: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })),
+  writable: true
+})
+
+describe('Terminal Settings Component', () => {
+  let wrapper: VueWrapper<any>
+  let pinia: ReturnType<typeof createPinia>
+
+  const createWrapper = () =>
+    mount(TerminalComponent, {
+      global: {
+        plugins: [pinia],
+        mocks: {
+          $t: (key: string) => key
+        },
+        stubs: {
+          'a-card': { template: '<div><slot /></div>' },
+          'a-form': { template: '<form><slot /></form>' },
+          'a-form-item': { template: '<div><slot name="label" /><slot /></div>' },
+          'a-select': { template: '<div><slot /></div>' },
+          'a-select-option': { template: '<div><slot /></div>' },
+          'a-input-number': { template: '<input />' },
+          'a-switch': { template: '<button />' },
+          'a-button': { template: '<button><slot /></button>' },
+          'a-modal': { template: '<div><slot /></div>' },
+          'a-table': { template: '<div><slot /></div>' },
+          'a-input': { template: '<input />' }
+        }
+      }
+    })
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    vi.clearAllMocks()
+    ;(globalThis as any).window = (globalThis as any).window || {}
+    ;(globalThis as any).window.api = {
+      getPlatform: vi.fn().mockResolvedValue('darwin'),
+      getKeyChainSelect: vi.fn().mockResolvedValue({ data: { keyChain: [] } }),
+      listKeys: vi.fn().mockResolvedValue({ keys: [] }),
+      removeKey: vi.fn().mockResolvedValue(undefined),
+      getKeyChainInfo: vi.fn().mockResolvedValue({}),
+      addKey: vi.fn().mockResolvedValue(undefined),
+      agentEnableAndConfigure: vi.fn().mockResolvedValue({ success: true })
+    }
+
+    mockGetConfig.mockResolvedValue({
+      fontSize: 12,
+      fontFamily: 'Menlo',
+      scrollBack: 1000,
+      cursorStyle: 'block'
+    })
+    mockSaveConfig.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    vi.clearAllMocks()
+  })
+
+  it('loads cursorBlink and lineHeight from saved config', async () => {
+    mockGetConfig.mockResolvedValue({
+      fontSize: 12,
+      fontFamily: 'Menlo',
+      scrollBack: 1000,
+      cursorStyle: 'underline',
+      cursorBlink: false,
+      lineHeight: 1.8
+    })
+
+    wrapper = createWrapper()
+    await nextTick()
+    await nextTick()
+
+    const vm = wrapper.vm as any
+    expect(vm.userConfig.cursorStyle).toBe('underline')
+    expect(vm.userConfig.cursorBlink).toBe(false)
+    expect(vm.userConfig.lineHeight).toBe(1.8)
+  })
+
+  it('falls back to defaults when cursorBlink and lineHeight are missing', async () => {
+    mockGetConfig.mockResolvedValue({
+      fontSize: 12,
+      fontFamily: 'Menlo',
+      scrollBack: 1000,
+      cursorStyle: 'bar'
+    })
+
+    wrapper = createWrapper()
+    await nextTick()
+    await nextTick()
+
+    const vm = wrapper.vm as any
+    expect(vm.userConfig.cursorBlink).toBe(true)
+    expect(vm.userConfig.lineHeight).toBe(1)
+  })
+
+  it('saveConfig persists cursorBlink and lineHeight', async () => {
+    wrapper = createWrapper()
+    await nextTick()
+    await nextTick()
+
+    vi.mocked(userConfigStore.saveConfig).mockClear()
+
+    const vm = wrapper.vm as any
+    vm.userConfig.cursorBlink = false
+    vm.userConfig.lineHeight = 2.2
+
+    await vm.saveConfig()
+
+    expect(userConfigStore.saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursorBlink: false,
+        lineHeight: 2.2
+      })
+    )
+  })
+
+  it('handleCursorBlinkChange updates local state', async () => {
+    wrapper = createWrapper()
+    await nextTick()
+
+    const vm = wrapper.vm as any
+    vm.handleCursorBlinkChange(false)
+
+    expect(vm.userConfig.cursorBlink).toBe(false)
+  })
+})

--- a/src/renderer/src/views/components/LeftTab/setting/terminal.vue
+++ b/src/renderer/src/views/components/LeftTab/setting/terminal.vue
@@ -78,14 +78,54 @@
           :label="$t('user.cursorStyle')"
           class="user_my-ant-form-item"
         >
-          <a-radio-group
-            v-model:value="userConfig.cursorStyle"
-            class="custom-radio-group"
+          <div
+            class="cursor-style-group"
+            role="radiogroup"
+            :aria-label="$t('user.cursorStyle')"
           >
-            <a-radio value="block">{{ $t('user.cursorStyleBlock') }}</a-radio>
-            <a-radio value="bar">{{ $t('user.cursorStyleBar') }}</a-radio>
-            <a-radio value="underline">{{ $t('user.cursorStyleUnderline') }}</a-radio>
-          </a-radio-group>
+            <button
+              v-for="option in cursorStyleOptions"
+              :key="option.value"
+              type="button"
+              role="radio"
+              :aria-checked="userConfig.cursorStyle === option.value"
+              :title="option.label"
+              class="cursor-style-item"
+              :class="{ active: userConfig.cursorStyle === option.value }"
+              @click="userConfig.cursorStyle = option.value"
+            >
+              <span
+                class="cursor-style-icon"
+                :class="`cursor-style-icon--${option.value}`"
+                aria-hidden="true"
+              ></span>
+            </button>
+          </div>
+        </a-form-item>
+        <a-form-item
+          :label="$t('user.cursorBlink')"
+          class="user_my-ant-form-item"
+        >
+          <a-switch
+            :checked="userConfig.cursorBlink"
+            class="user_my-ant-form-item-content"
+            @change="handleCursorBlinkChange"
+          />
+        </a-form-item>
+        <a-form-item
+          :label="$t('user.lineHeight')"
+          class="user_my-ant-form-item"
+        >
+          <a-input-number
+            v-model:value="userConfig.lineHeight"
+            :bordered="false"
+            style="width: 20%"
+            :min="1"
+            :max="3"
+            :step="0.1"
+            :precision="1"
+            class="user_my-ant-form-item-content"
+          />
         </a-form-item>
         <a-form-item
           :label="$t('user.pinchZoomStatus')"
@@ -409,7 +449,9 @@ const userConfig = ref<{
   fontSize: number
   fontFamily: string
   scrollBack: number
-  cursorStyle: string
+  cursorStyle: 'block' | 'bar' | 'underline'
+  cursorBlink: boolean
+  lineHeight: number
   middleMouseEvent: string
   rightMouseEvent: string
   terminalType: string
@@ -424,6 +466,8 @@ const userConfig = ref<{
   fontFamily: 'Menlo, Monaco, "Courier New", Consolas, Courier, monospace',
   scrollBack: 1000,
   cursorStyle: 'block',
+  cursorBlink: true,
+  lineHeight: 1,
   middleMouseEvent: 'paste',
   rightMouseEvent: 'contextMenu',
   terminalType: 'vt100',
@@ -453,6 +497,12 @@ const fontFamilyOptions = [
   { value: '"Inconsolata", "Courier New", Courier, monospace', label: 'Inconsolata' },
   { value: '"Roboto Mono", "Courier New", Courier, monospace', label: 'Roboto Mono' },
   { value: '"Maple Mono", "Courier New", Courier, monospace', label: 'Maple Mono' }
+]
+
+const cursorStyleOptions: Array<{ value: 'block' | 'bar' | 'underline'; label: string }> = [
+  { value: 'block', label: t('user.cursorStyleBlock') },
+  { value: 'bar', label: t('user.cursorStyleBar') },
+  { value: 'underline', label: t('user.cursorStyleUnderline') }
 ]
 
 const columns = [
@@ -531,7 +581,9 @@ const loadSavedConfig = async () => {
       userConfig.value = {
         ...userConfig.value,
         ...savedConfig,
-        cursorStyle: (savedConfig.cursorStyle || 'block') as string,
+        cursorStyle: (savedConfig.cursorStyle || 'block') as 'block' | 'bar' | 'underline',
+        cursorBlink: savedConfig.cursorBlink !== false,
+        lineHeight: typeof savedConfig.lineHeight === 'number' ? savedConfig.lineHeight : 1,
         sshProxyConfigs: (savedConfig.sshProxyConfigs || []) as ProxyConfig[]
       }
     } else {
@@ -561,6 +613,10 @@ const handleSshAgentsStatusChange = async (checked) => {
 const handlePinchZoomStatusChange = async (checked) => {
   userConfig.value.pinchZoomStatus = checked ? 1 : 2
   eventBus.emit('pinchZoomStatusChanged', checked)
+}
+
+const handleCursorBlinkChange = (checked: boolean) => {
+  userConfig.value.cursorBlink = checked
 }
 
 const handleShowCloseButtonChange = async (checked) => {
@@ -742,6 +798,8 @@ const saveConfig = async () => {
       fontFamily: userConfig.value.fontFamily,
       scrollBack: userConfig.value.scrollBack,
       cursorStyle: userConfig.value.cursorStyle,
+      cursorBlink: userConfig.value.cursorBlink,
+      lineHeight: userConfig.value.lineHeight,
       middleMouseEvent: userConfig.value.middleMouseEvent,
       rightMouseEvent: userConfig.value.rightMouseEvent,
       terminalType: userConfig.value.terminalType,
@@ -1038,6 +1096,65 @@ onBeforeUnmount(() => {
   text-align: left;
   opacity: 0.9;
   margin-right: 10px;
+}
+
+.cursor-style-group {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  background-color: var(--bg-color-octonary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  gap: 2px;
+}
+
+.cursor-style-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 26px;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-color);
+  transition:
+    background-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.cursor-style-item:hover {
+  background-color: var(--hover-bg-color);
+}
+
+.cursor-style-item.active {
+  background-color: var(--bg-color);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.cursor-style-icon {
+  display: inline-block;
+  background-color: currentColor;
+}
+
+.cursor-style-icon--block {
+  width: 8px;
+  height: 14px;
+  border-radius: 1px;
+}
+
+.cursor-style-icon--bar {
+  width: 2px;
+  height: 14px;
+  border-radius: 1px;
+}
+
+.cursor-style-icon--underline {
+  width: 12px;
+  height: 2px;
+  border-radius: 1px;
 }
 
 .mouse-event-select {

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -602,10 +602,11 @@ onMounted(async () => {
   const termInstance = markRaw(
     new Terminal({
       scrollback: config.scrollBack,
-      cursorBlink: true,
+      cursorBlink: config.cursorBlink !== false,
       cursorStyle: config.cursorStyle,
       fontSize: config.fontSize || 12,
       fontFamily: config.fontFamily || 'Menlo, Monaco, "Courier New", Consolas, Courier, monospace',
+      lineHeight: typeof config.lineHeight === 'number' ? config.lineHeight : 1,
       allowTransparency: true,
       theme: getResolvedTerminalTheme(config.theme as ThemeId, { hasCustomBg: hasCustomBg() })
     })


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor blink toggle to terminal settings, allowing users to enable/disable cursor blinking.
  * Added line height adjustment control to terminal settings for customizable spacing.
  * Added localization support across 11 languages for new settings.
  * New settings sync across devices.

* **Tests**
  * Added comprehensive test coverage for terminal settings functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->