### PR TITLE
fix(ai): queue chatToAi text until chat session is ready

### DIFF
--- a/src/renderer/src/views/components/AiTab/composables/__tests__/useEventBusListeners.test.ts
+++ b/src/renderer/src/views/components/AiTab/composables/__tests__/useEventBusListeners.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useEventBusListeners } from '../useEventBusListeners'
+import { useSessionState } from '../useSessionState'
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: new Map<string, Set<(payload?: unknown) => void>>()
+}))
+
+vi.mock('@/utils/eventBus', () => ({
+  default: {
+    on: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      if (!handlers.has(event)) handlers.set(event, new Set())
+      handlers.get(event)!.add(handler)
+    }),
+    off: vi.fn((event: string, handler?: (payload?: unknown) => void) => {
+      if (!handler) {
+        handlers.delete(event)
+        return
+      }
+      handlers.get(event)?.delete(handler)
+    }),
+    emit: vi.fn((event: string, payload?: unknown) => {
+      handlers.get(event)?.forEach((handler) => handler(payload))
+    })
+  }
+}))
+
+vi.mock('../useTabManagement', () => ({
+  focusChatInput: vi.fn()
+}))
+
+vi.mock('@/locales', () => ({
+  default: {
+    global: {
+      t: vi.fn((key: string) => key)
+    }
+  }
+}))
+
+vi.mock('@/views/components/Notice', () => ({
+  Notice: {
+    open: vi.fn()
+  }
+}))
+
+vi.mock('../../utils', () => ({
+  isSwitchAssetType: vi.fn(() => false)
+}))
+
+describe('useEventBusListeners', () => {
+  beforeEach(() => {
+    handlers.clear()
+    const sessionState = useSessionState()
+    sessionState.chatTabs.value = []
+    sessionState.currentChatId.value = undefined
+  })
+
+  it('queues chatToAi text until a chat session exists', async () => {
+    const getCurentTabAssetInfo = vi.fn().mockResolvedValue(null)
+    const updateHosts = vi.fn()
+    const sessionState = useSessionState()
+
+    mount(
+      defineComponent({
+        setup() {
+          useEventBusListeners({
+            sendMessageWithContent: vi.fn(),
+            initModel: vi.fn(),
+            getCurentTabAssetInfo,
+            updateHosts,
+            isAgentMode: false
+          })
+        },
+        template: '<div />'
+      })
+    )
+
+    await nextTick()
+    const eventBus = (await import('@/utils/eventBus')).default
+
+    eventBus.emit('chatToAi', 'Terminal output')
+    await nextTick()
+
+    expect(sessionState.chatInputParts.value).toEqual([])
+
+    const chatId = 'chat-1'
+    sessionState.chatTabs.value.push({
+      id: chatId,
+      title: 'New chat',
+      hosts: [],
+      chatType: 'cmd',
+      autoUpdateHost: true,
+      session: sessionState.createEmptySessionState(),
+      chatInputParts: [],
+      modelValue: '',
+      welcomeTip: ''
+    })
+    sessionState.currentChatId.value = chatId
+    await nextTick()
+    await nextTick()
+
+    expect(sessionState.chatInputParts.value).toEqual([{ type: 'text', text: 'Terminal output\n' }])
+    expect(getCurentTabAssetInfo).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/views/components/AiTab/composables/useEventBusListeners.ts
+++ b/src/renderer/src/views/components/AiTab/composables/useEventBusListeners.ts
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import eventBus from '@/utils/eventBus'
 import { useSessionState } from './useSessionState'
 import { focusChatInput } from './useTabManagement'
@@ -62,8 +62,9 @@ interface TabInfo {
 export function useEventBusListeners(params: UseEventBusListenersParams) {
   const { t } = i18n.global
   const { sendMessageWithContent, initModel, getCurentTabAssetInfo, updateHosts, isAgentMode = false, workspace = AI_TAB_DEFAULT_WORKSPACE } = params
-  const { chatTabs, currentSession, autoUpdateHost, chatTypeValue, appendTextToInputParts } = useSessionState()
+  const { chatTabs, currentChatId, currentSession, autoUpdateHost, chatTypeValue, appendTextToInputParts } = useSessionState()
   const isDatabaseWorkspace = workspace === 'database'
+  const pendingChatToAiTexts: string[] = []
 
   // Check and handle network switch device mode restriction
   const checkAndHandleSwitchMode = async (): Promise<boolean> => {
@@ -140,14 +141,34 @@ export function useEventBusListeners(params: UseEventBusListenersParams) {
     await sendMessageWithContent(content.trim(), 'commandSend', tabId, undefined, undefined, undefined, toolResult)
   }
 
+  const appendChatToAiText = async (text: string) => {
+    if (!currentChatId.value || !currentSession.value) {
+      pendingChatToAiTexts.push(text)
+      return
+    }
+
+    appendTextToInputParts(text, '\n', '\n')
+    await initAssetInfo()
+    focusChatInput()
+  }
+
+  const flushPendingChatToAiTexts = async () => {
+    if (!currentChatId.value || !currentSession.value || pendingChatToAiTexts.length === 0) {
+      return
+    }
+
+    const texts = pendingChatToAiTexts.splice(0)
+    for (const text of texts) {
+      await appendChatToAiText(text)
+    }
+  }
+
   const handleChatToAi = async (text: string) => {
     if (isAgentMode) {
       logger.debug('Ignoring chatToAi event in agent mode')
       return
     }
-    appendTextToInputParts(text, '\n', '\n')
-    await initAssetInfo()
-    focusChatInput()
+    await appendChatToAiText(text)
   }
 
   const handleActiveTabChanged = async (tabInfo: TabInfo) => {
@@ -225,4 +246,12 @@ export function useEventBusListeners(params: UseEventBusListenersParams) {
       eventBus.off('switchAiMode', handleSwitchAiMode)
     }
   })
+
+  watch(
+    [currentChatId, currentSession],
+    () => {
+      void flushPendingChatToAiTexts()
+    },
+    { flush: 'post' }
+  )
 }


### PR DESCRIPTION
When terminal output is sent to AI before a chat tab exists, buffer the text and flush it once currentChatId and currentSession become available.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit test coverage for AI tab event handling, including scenarios where events arrive before chat sessions are initialized.

* **Improvements**
  * Enhanced message delivery reliability with an event queueing mechanism that buffers incoming messages when chat sessions aren't ready, ensuring no messages are lost during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaterm/Chaterm/pull/2263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->