### PR TITLE
feat(ssh): add support for local shell startup modes and environment configuration

### DIFF
--- a/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
+++ b/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ipcHandleMock = vi.hoisted(() => vi.fn())
+const spawnMock = vi.hoisted(() => vi.fn())
+const originalEnv = { ...process.env }
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: ipcHandleMock },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('../../../agent/core/storage/state', () => ({
+  getUserConfig: vi.fn().mockResolvedValue({ language: 'zh-CN' })
+}))
+
+describe('localSSHHandle - local shell startup', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    vi.resetModules()
+    ipcHandleMock.mockClear()
+    spawnMock.mockReset()
+    spawnMock.mockReturnValue({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      kill: vi.fn(),
+      resize: vi.fn(),
+      write: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('starts local zsh without forcing login shell args by default', async () => {
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color'
+    })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      [],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24
+      })
+    )
+  })
+
+  it('starts local zsh with fast startup args when requested', async () => {
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color',
+      startupMode: 'fast'
+    })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-f'],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24
+      })
+    )
+  })
+
+  it('does not inherit IDE terminal identity into local shells', async () => {
+    process.env.TERM_PROGRAM = 'vscode'
+    process.env.VSCODE_GIT_ASKPASS_NODE = '/Applications/Cursor.app/Contents/Frameworks/Cursor'
+    process.env.CURSOR_WORKSPACE_LABEL = 'Chaterm'
+
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color'
+    })
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2]
+    expect(spawnOptions.env.TERM_PROGRAM).toBe('Chaterm')
+    expect(spawnOptions.env.VSCODE_GIT_ASKPASS_NODE).toBeUndefined()
+    expect(spawnOptions.env.CURSOR_WORKSPACE_LABEL).toBeUndefined()
+  })
+})

--- a/src/main/ssh/localSSHHandle.ts
+++ b/src/main/ssh/localSSHHandle.ts
@@ -67,6 +67,7 @@ interface LocalTerminalConfig {
   cols?: number
   rows?: number
   termType?: string
+  startupMode?: 'interactive' | 'fast'
 }
 
 interface LocalTerminal {
@@ -120,20 +121,46 @@ const getDefaultShell = (): string => {
   }
 }
 
+const getLocalShellStartupArgs = (shellBase: string, startupMode: LocalTerminalConfig['startupMode']): string[] => {
+  if (os.platform() === 'win32') return []
+  if (startupMode !== 'fast') return []
+
+  switch (shellBase) {
+    case 'zsh':
+      return ['-f']
+    case 'bash':
+      return ['--noprofile', '--norc']
+    case 'fish':
+      return ['--no-config']
+    default:
+      return []
+  }
+}
+
+const buildLocalTerminalEnv = (overrides?: Record<string, string>): NodeJS.ProcessEnv => {
+  const env = { ...process.env, ...overrides }
+
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('VSCODE_') || key.startsWith('CURSOR_')) {
+      delete env[key]
+    }
+  }
+
+  env.TERM_PROGRAM = 'Chaterm'
+  return env
+}
+
 const createTerminal = async (config: LocalTerminalConfig): Promise<LocalTerminal> => {
   const shell = config.shell || getDefaultShell()
   const cwd = config.cwd || os.homedir()
-  const env = { ...process.env, ...config.env }
-  let args: string[] = []
-
-  // Use login shell mode to ensure shell configuration files are loaded
-  // (e.g., .zprofile, .zshrc, .bash_profile, .bashrc)
+  const env = buildLocalTerminalEnv(config.env)
   const shellBase = path.basename(shell)
-  if (os.platform() !== 'win32') {
-    if (shellBase === 'zsh' || shellBase === 'bash' || shellBase === 'fish' || shellBase === 'sh') {
-      args = ['--login']
-    }
-  }
+  const startupMode = config.startupMode || 'interactive'
+  const args = getLocalShellStartupArgs(shellBase, startupMode)
+
+  // Fast mode intentionally skips shell startup files. This keeps the local
+  // terminal responsive when user shell configs are slow, at the cost of aliases
+  // or PATH mutations that only exist in those startup files.
 
   localLogger.info('Creating local terminal', {
     event: 'terminal.local.connect.start',

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -658,7 +658,23 @@ interface ApiType {
   }>
   getKbCloudStorage: () => Promise<{ usedBytes: number; totalBytes: number }>
   getLocalWorkingDirectory: () => Promise<{ success: boolean; cwd: string }>
+  connectLocal: (config: {
+    id: string
+    shell?: string
+    cwd?: string
+    env?: Record<string, string>
+    cols?: number
+    rows?: number
+    termType?: string
+    startupMode?: 'interactive' | 'fast'
+  }) => Promise<{ success: boolean; message?: string }>
+  sendDataLocal: (terminalId: string, data: string) => Promise<{ success: boolean; message?: string }>
+  resizeLocal: (terminalId: string, cols: number, rows: number) => Promise<{ success: boolean; status?: string; message?: string }>
+  closeLocal: (terminalId: string) => Promise<{ success: boolean; message?: string }>
   getShellsLocal: () => Promise<any>
+  onDataLocal: (id: string, callback: (data: string) => void) => () => void
+  onErrorLocal: (id: string, callback: (error: unknown) => void) => (() => void) | undefined
+  onExitLocal: (id: string, callback: (exitCode: unknown) => void) => () => void
   agentEnableAndConfigure: (opts: { enabled: boolean }) => Promise<any>
   addKey: (opts: { keyData: string; passphrase?: string; comment?: string }) => Promise<any>
   getSecurityConfigPath: () => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1388,8 +1388,15 @@ const api = {
   removeKey: (opts: { keyId: string }) => ipcRenderer.invoke('ssh:agent:remove-key', opts),
   listKeys: () => ipcRenderer.invoke('ssh:agent:list-key') as Promise<[]>,
 
-  connectLocal: (config: { id: string; shell?: string; cwd?: string; env?: Record<string, string>; cols?: number; rows?: number }) =>
-    ipcRenderer.invoke('local:connect', config),
+  connectLocal: (config: {
+    id: string
+    shell?: string
+    cwd?: string
+    env?: Record<string, string>
+    cols?: number
+    rows?: number
+    startupMode?: 'interactive' | 'fast'
+  }) => ipcRenderer.invoke('local:connect', config),
   sendDataLocal: (terminalId: string, data: string) => ipcRenderer.invoke('local:send:data', terminalId, data),
   resizeLocal: (terminalId: string, cols: number, rows: number) => ipcRenderer.invoke('local:resize', terminalId, cols, rows),
   closeLocal: (terminalId: string) => ipcRenderer.invoke('local:close', terminalId),

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -585,7 +585,8 @@ const handleMetaKeyUp = (e: KeyboardEvent) => {
 }
 
 onMounted(async () => {
-  await getUserInfo()
+  const isLocalShellConnection = props.connectData.asset_type === 'shell'
+  const userInfoReady = isLocalShellConnection ? Promise.resolve() : getUserInfo()
   config = await serviceUserConfig.getConfig()
   dbConfigStash = config
   queryCommandFlag.value = config.autoCompleteStatus == 1
@@ -886,12 +887,13 @@ onMounted(async () => {
     handleSendOrToggleAi()
   }
 
-  if (props.connectData.asset_type === 'shell') {
+  if (isLocalShellConnection) {
     config.highlightStatus = 2
     config.autoCompleteStatus = 2
     isLocalConnect.value = true
     connectLocalSSH()
   } else {
+    await userInfoReady
     connectSSH()
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable startup mode for local terminal connections (fast or interactive modes).

* **Bug Fixes**
  * Local shell connections now properly isolate IDE environment variables from spawned shells.
  * Optimized local shell connection initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->