### PR TITLE
feat(ssh): add support for local shell startup modes and environment configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline
 
-      - name: Rebuild native modules for current Node
-        run: npm rebuild better-sqlite3
+      - name: Rebuild SQLite native module for Electron
+        run: npx electron-rebuild -f -w better-sqlite3
 
       - name: Install Playwright Browsers (full)
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/src/main/services/database/__tests__/sqlite-driver.test.ts
+++ b/src/main/services/database/__tests__/sqlite-driver.test.ts
@@ -1,102 +1,20 @@
-import { mkdtempSync, rmSync } from 'fs'
-import { join } from 'path'
-import { tmpdir } from 'os'
-import Database from 'better-sqlite3'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SqliteDriverAdapter, fetchSqliteTableDdl } from '../drivers/sqlite-driver'
-import type { ResolvedDbCredential } from '../types'
-
-vi.mock('@logging/index', () => ({
-  createLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }))
-}))
+import { describe, it } from 'vitest'
+import { runElectronNativeSqliteCase } from '../../../test-utils/electron-native-sqlite'
 
 describe('SqliteDriverAdapter', () => {
-  let dir = ''
-  let file = ''
-  let adapter: SqliteDriverAdapter
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'chaterm-sqlite-driver-'))
-    file = join(dir, 'app.sqlite3')
-    const db = new Database(file)
-    db.exec(`
-      CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
-      CREATE TABLE orders (user_id INTEGER NOT NULL, seq INTEGER NOT NULL, total REAL, PRIMARY KEY (user_id, seq));
-      INSERT INTO users (name) VALUES ('Ada'), ('Linus');
-    `)
-    db.close()
-    adapter = new SqliteDriverAdapter()
-  })
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
-  })
-
-  function credential(overrides: Partial<ResolvedDbCredential> = {}): ResolvedDbCredential {
-    return {
-      dbType: 'sqlite',
-      host: null,
-      port: null,
-      username: null,
-      password: null,
-      database: 'main',
-      sslMode: null,
-      filePath: file,
-      connectionMode: 'readwrite',
-      ...overrides
-    }
-  }
-
   it('tests an existing sqlite file without creating missing files', async () => {
-    const ok = await adapter.testConnection(credential())
-    expect(ok.ok).toBe(true)
-    expect(ok.serverVersion).toMatch(/^\d+\.\d+/)
-
-    const missing = await adapter.testConnection(credential({ filePath: join(dir, 'missing.sqlite3') }))
-    expect(missing.ok).toBe(false)
+    await runElectronNativeSqliteCase('sqlite-driver:test-connection')
   })
 
   it('lists database aliases, tables, columns and primary keys', async () => {
-    const handle = await adapter.connect(credential())
-    try {
-      await expect(adapter.listDatabases(handle)).resolves.toContain('main')
-      await expect(adapter.listTables(handle, 'main')).resolves.toEqual(['orders', 'users'])
-      await expect(adapter.listColumns(handle, 'main', 'users')).resolves.toEqual(['id', 'name'])
-      await expect(adapter.detectPrimaryKey(handle, 'main', 'users')).resolves.toEqual(['id'])
-      await expect(adapter.detectPrimaryKey(handle, 'main', 'orders')).resolves.toEqual(['user_id', 'seq'])
-    } finally {
-      await adapter.disconnect(handle)
-    }
+    await runElectronNativeSqliteCase('sqlite-driver:metadata')
   })
 
   it('executes SELECT and write statements through the worker', async () => {
-    const handle = await adapter.connect(credential())
-    try {
-      const rows = await adapter.executeQuery(handle, 'SELECT id, name FROM users ORDER BY id')
-      expect(rows.columns).toEqual(['id', 'name'])
-      expect(rows.rows).toHaveLength(2)
-
-      const inserted = await adapter.executeQuery(handle, 'INSERT INTO users (name) VALUES (?)', ['Grace'])
-      expect(inserted.rowCount).toBe(1)
-      const count = await adapter.executeQuery(handle, 'SELECT COUNT(*) AS n FROM users')
-      expect(count.rows[0].n).toBe(3)
-    } finally {
-      await adapter.disconnect(handle)
-    }
+    await runElectronNativeSqliteCase('sqlite-driver:execute')
   })
 
   it('supports rollback and ddl lookup', async () => {
-    const handle = await adapter.connect(credential())
-    try {
-      await adapter.beginTransaction(handle)
-      await adapter.executeQuery(handle, 'INSERT INTO users (name) VALUES (?)', ['Rollback'])
-      await adapter.rollbackTransaction(handle)
-      const count = await adapter.executeQuery(handle, "SELECT COUNT(*) AS n FROM users WHERE name = 'Rollback'")
-      expect(count.rows[0].n).toBe(0)
-      const ddl = await fetchSqliteTableDdl(handle, 'main', 'users')
-      expect(ddl).toContain('CREATE TABLE users')
-    } finally {
-      await adapter.disconnect(handle)
-    }
+    await runElectronNativeSqliteCase('sqlite-driver:rollback-ddl')
   })
 })

--- a/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
+++ b/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ipcHandleMock = vi.hoisted(() => vi.fn())
+const spawnMock = vi.hoisted(() => vi.fn())
+const originalEnv = { ...process.env }
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: ipcHandleMock },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) }
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('../../../agent/core/storage/state', () => ({
+  getUserConfig: vi.fn().mockResolvedValue({ language: 'zh-CN' })
+}))
+
+describe('localSSHHandle - local shell startup', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    vi.resetModules()
+    ipcHandleMock.mockClear()
+    spawnMock.mockReset()
+    spawnMock.mockReturnValue({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      kill: vi.fn(),
+      resize: vi.fn(),
+      write: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('starts local zsh without forcing login shell args by default', async () => {
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color'
+    })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      [],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24
+      })
+    )
+  })
+
+  it('starts local zsh with fast startup args when requested', async () => {
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color',
+      startupMode: 'fast'
+    })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-f'],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24
+      })
+    )
+  })
+
+  it('does not inherit IDE terminal identity into local shells', async () => {
+    process.env.TERM_PROGRAM = 'vscode'
+    process.env.VSCODE_GIT_ASKPASS_NODE = '/Applications/Cursor.app/Contents/Frameworks/Cursor'
+    process.env.CURSOR_WORKSPACE_LABEL = 'Chaterm'
+
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color'
+    })
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2]
+    expect(spawnOptions.env.TERM_PROGRAM).toBe('Chaterm')
+    expect(spawnOptions.env.VSCODE_GIT_ASKPASS_NODE).toBeUndefined()
+    expect(spawnOptions.env.CURSOR_WORKSPACE_LABEL).toBeUndefined()
+  })
+})

--- a/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
+++ b/src/main/ssh/__tests__/localSSHHandle.startup.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as os from 'os'
 
 const ipcHandleMock = vi.hoisted(() => vi.fn())
 const spawnMock = vi.hoisted(() => vi.fn())
@@ -13,6 +14,15 @@ vi.mock('node-pty', () => ({
   spawn: spawnMock
 }))
 
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return {
+    ...actual,
+    platform: vi.fn(() => 'darwin'),
+    homedir: vi.fn(() => '/Users/test')
+  }
+})
+
 vi.mock('../../../agent/core/storage/state', () => ({
   getUserConfig: vi.fn().mockResolvedValue({ language: 'zh-CN' })
 }))
@@ -23,6 +33,8 @@ describe('localSSHHandle - local shell startup', () => {
     vi.resetModules()
     ipcHandleMock.mockClear()
     spawnMock.mockReset()
+    vi.mocked(os.platform).mockReturnValue('darwin')
+    vi.mocked(os.homedir).mockReturnValue('/Users/test')
     spawnMock.mockReturnValue({
       onData: vi.fn(),
       onExit: vi.fn(),
@@ -77,6 +89,33 @@ describe('localSSHHandle - local shell startup', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/zsh',
       ['-f'],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24
+      })
+    )
+  })
+
+  it('does not pass Unix fast startup args on Windows', async () => {
+    vi.mocked(os.platform).mockReturnValue('win32')
+
+    const { registerLocalSSHHandlers } = await import('../localSSHHandle')
+    registerLocalSSHHandlers()
+
+    const connectHandler = ipcHandleMock.mock.calls.find(([channel]) => channel === 'local:connect')?.[1]
+    expect(connectHandler).toBeTypeOf('function')
+
+    await connectHandler(null, {
+      id: 'local-test',
+      shell: '/bin/zsh',
+      termType: 'xterm-256color',
+      startupMode: 'fast'
+    })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/zsh',
+      [],
       expect.objectContaining({
         name: 'xterm-256color',
         cols: 80,

--- a/src/main/ssh/localSSHHandle.ts
+++ b/src/main/ssh/localSSHHandle.ts
@@ -67,6 +67,7 @@ interface LocalTerminalConfig {
   cols?: number
   rows?: number
   termType?: string
+  startupMode?: 'interactive' | 'fast'
 }
 
 interface LocalTerminal {
@@ -120,20 +121,46 @@ const getDefaultShell = (): string => {
   }
 }
 
+const getLocalShellStartupArgs = (shellBase: string, startupMode: LocalTerminalConfig['startupMode']): string[] => {
+  if (os.platform() === 'win32') return []
+  if (startupMode !== 'fast') return []
+
+  switch (shellBase) {
+    case 'zsh':
+      return ['-f']
+    case 'bash':
+      return ['--noprofile', '--norc']
+    case 'fish':
+      return ['--no-config']
+    default:
+      return []
+  }
+}
+
+const buildLocalTerminalEnv = (overrides?: Record<string, string>): NodeJS.ProcessEnv => {
+  const env = { ...process.env, ...overrides }
+
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('VSCODE_') || key.startsWith('CURSOR_')) {
+      delete env[key]
+    }
+  }
+
+  env.TERM_PROGRAM = 'Chaterm'
+  return env
+}
+
 const createTerminal = async (config: LocalTerminalConfig): Promise<LocalTerminal> => {
   const shell = config.shell || getDefaultShell()
   const cwd = config.cwd || os.homedir()
-  const env = { ...process.env, ...config.env }
-  let args: string[] = []
-
-  // Use login shell mode to ensure shell configuration files are loaded
-  // (e.g., .zprofile, .zshrc, .bash_profile, .bashrc)
+  const env = buildLocalTerminalEnv(config.env)
   const shellBase = path.basename(shell)
-  if (os.platform() !== 'win32') {
-    if (shellBase === 'zsh' || shellBase === 'bash' || shellBase === 'fish' || shellBase === 'sh') {
-      args = ['--login']
-    }
-  }
+  const startupMode = config.startupMode || 'interactive'
+  const args = getLocalShellStartupArgs(shellBase, startupMode)
+
+  // Fast mode intentionally skips shell startup files. This keeps the local
+  // terminal responsive when user shell configs are slow, at the cost of aliases
+  // or PATH mutations that only exist in those startup files.
 
   localLogger.info('Creating local terminal', {
     event: 'terminal.local.connect.start',

--- a/src/main/storage/db/migrations/__tests__/add-db-assets-support.test.ts
+++ b/src/main/storage/db/migrations/__tests__/add-db-assets-support.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import Database from 'better-sqlite3'
+import type Database from 'better-sqlite3'
+import { runElectronNativeSqliteCase } from '../../../../test-utils/electron-native-sqlite'
 
 vi.mock('@logging/index', () => ({
   createLogger: vi.fn(() => ({
@@ -119,60 +120,7 @@ describe('upgradeDbAssetsSupport', () => {
   })
 
   it('rebuilds legacy db_assets to relax host/port and add sqlite fields', async () => {
-    const realDb = new Database(':memory:')
-    realDb.exec(`
-      CREATE TABLE db_assets (
-        id TEXT PRIMARY KEY,
-        user_id INTEGER NOT NULL,
-        name TEXT NOT NULL,
-        group_name TEXT,
-        db_type TEXT NOT NULL,
-        environment TEXT,
-        host TEXT NOT NULL,
-        port INTEGER NOT NULL,
-        database_name TEXT,
-        schema_name TEXT,
-        auth_type TEXT NOT NULL DEFAULT 'password',
-        username TEXT,
-        password_ciphertext TEXT,
-        ssl_mode TEXT,
-        jdbc_url TEXT,
-        driver_name TEXT,
-        driver_class_name TEXT,
-        ssh_tunnel_enabled INTEGER DEFAULT 0,
-        ssh_tunnel_asset_uuid TEXT,
-        options_json TEXT,
-        tags_json TEXT,
-        status TEXT DEFAULT 'idle',
-        last_connected_at TEXT,
-        last_tested_at TEXT,
-        last_error_code TEXT,
-        last_error_message TEXT,
-        sort_order INTEGER DEFAULT 0,
-        deleted_at TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-      INSERT INTO db_assets (id, user_id, name, group_name, db_type, host, port, created_at, updated_at)
-      VALUES ('a1', 1, 'legacy', NULL, 'mysql', '127.0.0.1', 3306, 'x', 'x');
-    `)
-
-    await upgradeDbAssetsSupport(realDb)
-
-    const cols = realDb.prepare("PRAGMA table_info('db_assets')").all() as Array<{ name: string; notnull: number }>
-    const byName = new Map(cols.map((col) => [col.name, col]))
-    expect(byName.get('host')?.notnull).toBe(0)
-    expect(byName.get('port')?.notnull).toBe(0)
-    expect(byName.has('file_path')).toBe(true)
-    expect(byName.has('connection_mode')).toBe(true)
-    const row = realDb.prepare('SELECT name, host, port, connection_mode FROM db_assets WHERE id = ?').get('a1') as {
-      name: string
-      host: string
-      port: number
-      connection_mode: string
-    }
-    expect(row).toMatchObject({ name: 'legacy', host: '127.0.0.1', port: 3306, connection_mode: 'readwrite' })
-    realDb.close()
+    await runElectronNativeSqliteCase('db-assets:legacy-rebuild')
   })
 
   it('skips table creation when db_assets already exists', async () => {

--- a/src/main/test-utils/electron-native-sqlite.ts
+++ b/src/main/test-utils/electron-native-sqlite.ts
@@ -1,0 +1,129 @@
+import { execFile } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'vite'
+
+const RESULT_PREFIX = '__NATIVE_SQLITE_RESULT__'
+const projectRoot = resolve(process.cwd())
+const require = createRequire(import.meta.url)
+
+export type NativeSqliteCase =
+  | 'sqlite-driver:test-connection'
+  | 'sqlite-driver:metadata'
+  | 'sqlite-driver:execute'
+  | 'sqlite-driver:rollback-ddl'
+  | 'db-assets:legacy-rebuild'
+
+type NativeSqliteResult = {
+  ok: boolean
+  name?: string
+  error?: {
+    name?: string
+    message?: string
+    stack?: string
+  }
+}
+
+type ExecResult = {
+  error: Error | null
+  stdout: string
+  stderr: string
+}
+
+let bundlePromise: Promise<string> | null = null
+let tempDir: string | null = null
+
+function electronPath(): string {
+  const electron = require('electron') as string | { default?: string }
+  const path = typeof electron === 'string' ? electron : electron.default
+  if (!path) throw new Error('Unable to resolve Electron executable for native sqlite tests')
+  return path
+}
+
+async function bundleRunner(): Promise<string> {
+  if (bundlePromise) return bundlePromise
+  tempDir = mkdtempSync(join(tmpdir(), 'chaterm-native-sqlite-'))
+  const runnerPath = join(tempDir, 'electron-native-sqlite-runner.mjs')
+  bundlePromise = build({
+    configFile: false,
+    root: projectRoot,
+    publicDir: false,
+    logLevel: 'silent',
+    build: {
+      ssr: resolve(projectRoot, 'tests/native-sqlite/electron-native-sqlite-runner.ts'),
+      outDir: tempDir,
+      emptyOutDir: true,
+      target: 'node24',
+      minify: false,
+      sourcemap: 'inline',
+      rollupOptions: {
+        external: ['better-sqlite3', 'electron'],
+        output: {
+          format: 'es',
+          entryFileNames: 'electron-native-sqlite-runner.mjs'
+        }
+      }
+    }
+  }).then(() => runnerPath)
+  return bundlePromise
+}
+
+function execElectron(file: string, args: string[]): Promise<ExecResult> {
+  return new Promise((resolveExec) => {
+    execFile(
+      file,
+      args,
+      {
+        cwd: projectRoot,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        timeout: 30_000,
+        maxBuffer: 1024 * 1024
+      },
+      (error, stdout, stderr) => {
+        resolveExec({
+          error,
+          stdout: String(stdout),
+          stderr: String(stderr)
+        })
+      }
+    )
+  })
+}
+
+function parseResult(stdout: string): NativeSqliteResult | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .reverse()
+    .find((entry) => entry.startsWith(RESULT_PREFIX))
+  if (!line) return null
+  return JSON.parse(line.slice(RESULT_PREFIX.length)) as NativeSqliteResult
+}
+
+export async function runElectronNativeSqliteCase(name: NativeSqliteCase): Promise<void> {
+  const runnerPath = await bundleRunner()
+  const { error, stdout, stderr } = await execElectron(electronPath(), [runnerPath, name])
+  const result = parseResult(stdout)
+
+  if (!error && result?.ok) return
+
+  const detail = result?.error
+    ? `${result.error.name ?? 'Error'}: ${result.error.message ?? 'unknown error'}\n${result.error.stack ?? ''}`
+    : error?.message || 'Electron native sqlite runner failed without a result payload'
+
+  throw new Error(
+    [
+      `Electron native sqlite case failed: ${name}`,
+      detail.trim(),
+      stdout.trim() ? `stdout:\n${stdout.trim()}` : '',
+      stderr.trim() ? `stderr:\n${stderr.trim()}` : ''
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+  )
+}
+
+process.once('exit', () => {
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+})

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -658,7 +658,23 @@ interface ApiType {
   }>
   getKbCloudStorage: () => Promise<{ usedBytes: number; totalBytes: number }>
   getLocalWorkingDirectory: () => Promise<{ success: boolean; cwd: string }>
+  connectLocal: (config: {
+    id: string
+    shell?: string
+    cwd?: string
+    env?: Record<string, string>
+    cols?: number
+    rows?: number
+    termType?: string
+    startupMode?: 'interactive' | 'fast'
+  }) => Promise<{ success: boolean; message?: string }>
+  sendDataLocal: (terminalId: string, data: string) => Promise<{ success: boolean; message?: string }>
+  resizeLocal: (terminalId: string, cols: number, rows: number) => Promise<{ success: boolean; status?: string; message?: string }>
+  closeLocal: (terminalId: string) => Promise<{ success: boolean; message?: string }>
   getShellsLocal: () => Promise<any>
+  onDataLocal: (id: string, callback: (data: string) => void) => () => void
+  onErrorLocal: (id: string, callback: (error: unknown) => void) => (() => void) | undefined
+  onExitLocal: (id: string, callback: (exitCode: unknown) => void) => () => void
   agentEnableAndConfigure: (opts: { enabled: boolean }) => Promise<any>
   addKey: (opts: { keyData: string; passphrase?: string; comment?: string }) => Promise<any>
   getSecurityConfigPath: () => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1388,8 +1388,15 @@ const api = {
   removeKey: (opts: { keyId: string }) => ipcRenderer.invoke('ssh:agent:remove-key', opts),
   listKeys: () => ipcRenderer.invoke('ssh:agent:list-key') as Promise<[]>,
 
-  connectLocal: (config: { id: string; shell?: string; cwd?: string; env?: Record<string, string>; cols?: number; rows?: number }) =>
-    ipcRenderer.invoke('local:connect', config),
+  connectLocal: (config: {
+    id: string
+    shell?: string
+    cwd?: string
+    env?: Record<string, string>
+    cols?: number
+    rows?: number
+    startupMode?: 'interactive' | 'fast'
+  }) => ipcRenderer.invoke('local:connect', config),
   sendDataLocal: (terminalId: string, data: string) => ipcRenderer.invoke('local:send:data', terminalId, data),
   resizeLocal: (terminalId: string, cols: number, rows: number) => ipcRenderer.invoke('local:resize', terminalId, cols, rows),
   closeLocal: (terminalId: string) => ipcRenderer.invoke('local:close', terminalId),

--- a/src/renderer/src/views/components/Ssh/sshConnect.vue
+++ b/src/renderer/src/views/components/Ssh/sshConnect.vue
@@ -585,7 +585,8 @@ const handleMetaKeyUp = (e: KeyboardEvent) => {
 }
 
 onMounted(async () => {
-  await getUserInfo()
+  const isLocalShellConnection = props.connectData.asset_type === 'shell'
+  const userInfoReady = isLocalShellConnection ? Promise.resolve() : getUserInfo()
   config = await serviceUserConfig.getConfig()
   dbConfigStash = config
   queryCommandFlag.value = config.autoCompleteStatus == 1
@@ -886,12 +887,13 @@ onMounted(async () => {
     handleSendOrToggleAi()
   }
 
-  if (props.connectData.asset_type === 'shell') {
+  if (isLocalShellConnection) {
     config.highlightStatus = 2
     config.autoCompleteStatus = 2
     isLocalConnect.value = true
     connectLocalSSH()
   } else {
+    await userInfoReady
     connectSSH()
   }
 

--- a/tests/native-sqlite/electron-native-sqlite-runner.ts
+++ b/tests/native-sqlite/electron-native-sqlite-runner.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const projectRequire = createRequire(join(process.cwd(), 'package.json'))
+const Database = projectRequire('better-sqlite3') as typeof import('better-sqlite3')
+
+;(globalThis as unknown as { createLogger: unknown }).createLogger = () => ({
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined
+})
+
+type DriverContext = {
+  dir: string
+  file: string
+  SqliteDriverAdapter: typeof import('../../src/main/services/database/drivers/sqlite-driver').SqliteDriverAdapter
+  fetchSqliteTableDdl: typeof import('../../src/main/services/database/drivers/sqlite-driver').fetchSqliteTableDdl
+}
+
+function credential(filePath: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    dbType: 'sqlite',
+    host: null,
+    port: null,
+    username: null,
+    password: null,
+    database: 'main',
+    sslMode: null,
+    filePath,
+    connectionMode: 'readwrite',
+    ...overrides
+  }
+}
+
+async function withDriverDatabase(run: (ctx: DriverContext) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'chaterm-sqlite-driver-'))
+  const file = join(dir, 'app.sqlite3')
+  const db = new Database(file)
+  try {
+    db.exec(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+      CREATE TABLE orders (user_id INTEGER NOT NULL, seq INTEGER NOT NULL, total REAL, PRIMARY KEY (user_id, seq));
+      INSERT INTO users (name) VALUES ('Ada'), ('Linus');
+    `)
+    const { SqliteDriverAdapter, fetchSqliteTableDdl } = await import('../../src/main/services/database/drivers/sqlite-driver')
+    await run({ dir, file, SqliteDriverAdapter, fetchSqliteTableDdl })
+  } finally {
+    db.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+async function testSqliteConnection(): Promise<void> {
+  await withDriverDatabase(async ({ dir, file, SqliteDriverAdapter }) => {
+    const adapter = new SqliteDriverAdapter()
+    const ok = await adapter.testConnection(credential(file) as never)
+    assert.equal(ok.ok, true)
+    assert.match(String(ok.serverVersion), /^\d+\.\d+/)
+
+    const missing = await adapter.testConnection(credential(join(dir, 'missing.sqlite3')) as never)
+    assert.equal(missing.ok, false)
+  })
+}
+
+async function testSqliteMetadata(): Promise<void> {
+  await withDriverDatabase(async ({ file, SqliteDriverAdapter }) => {
+    const adapter = new SqliteDriverAdapter()
+    const handle = await adapter.connect(credential(file) as never)
+    try {
+      assert.deepEqual(await adapter.listDatabases(handle), ['main'])
+      assert.deepEqual(await adapter.listTables(handle, 'main'), ['orders', 'users'])
+      assert.deepEqual(await adapter.listColumns(handle, 'main', 'users'), ['id', 'name'])
+      assert.deepEqual(await adapter.detectPrimaryKey(handle, 'main', 'users'), ['id'])
+      assert.deepEqual(await adapter.detectPrimaryKey(handle, 'main', 'orders'), ['user_id', 'seq'])
+    } finally {
+      await adapter.disconnect(handle)
+    }
+  })
+}
+
+async function testSqliteExecute(): Promise<void> {
+  await withDriverDatabase(async ({ file, SqliteDriverAdapter }) => {
+    const adapter = new SqliteDriverAdapter()
+    const handle = await adapter.connect(credential(file) as never)
+    try {
+      const rows = await adapter.executeQuery(handle, 'SELECT id, name FROM users ORDER BY id')
+      assert.deepEqual(rows.columns, ['id', 'name'])
+      assert.equal(rows.rows.length, 2)
+
+      const inserted = await adapter.executeQuery(handle, 'INSERT INTO users (name) VALUES (?)', ['Grace'])
+      assert.equal(inserted.rowCount, 1)
+      const count = await adapter.executeQuery(handle, 'SELECT COUNT(*) AS n FROM users')
+      assert.equal(count.rows[0].n, 3)
+    } finally {
+      await adapter.disconnect(handle)
+    }
+  })
+}
+
+async function testSqliteRollbackAndDdl(): Promise<void> {
+  await withDriverDatabase(async ({ file, SqliteDriverAdapter, fetchSqliteTableDdl }) => {
+    const adapter = new SqliteDriverAdapter()
+    const handle = await adapter.connect(credential(file) as never)
+    try {
+      await adapter.beginTransaction(handle)
+      await adapter.executeQuery(handle, 'INSERT INTO users (name) VALUES (?)', ['Rollback'])
+      await adapter.rollbackTransaction(handle)
+      const count = await adapter.executeQuery(handle, "SELECT COUNT(*) AS n FROM users WHERE name = 'Rollback'")
+      assert.equal(count.rows[0].n, 0)
+      const ddl = await fetchSqliteTableDdl(handle, 'main', 'users')
+      assert.match(ddl, /CREATE TABLE users/)
+    } finally {
+      await adapter.disconnect(handle)
+    }
+  })
+}
+
+async function testDbAssetsLegacyRebuild(): Promise<void> {
+  const { upgradeDbAssetsSupport } = await import('../../src/main/storage/db/migrations/add-db-assets-support')
+  const realDb = new Database(':memory:')
+  try {
+    realDb.exec(`
+      CREATE TABLE db_assets (
+        id TEXT PRIMARY KEY,
+        user_id INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        group_name TEXT,
+        db_type TEXT NOT NULL,
+        environment TEXT,
+        host TEXT NOT NULL,
+        port INTEGER NOT NULL,
+        database_name TEXT,
+        schema_name TEXT,
+        auth_type TEXT NOT NULL DEFAULT 'password',
+        username TEXT,
+        password_ciphertext TEXT,
+        ssl_mode TEXT,
+        jdbc_url TEXT,
+        driver_name TEXT,
+        driver_class_name TEXT,
+        ssh_tunnel_enabled INTEGER DEFAULT 0,
+        ssh_tunnel_asset_uuid TEXT,
+        options_json TEXT,
+        tags_json TEXT,
+        status TEXT DEFAULT 'idle',
+        last_connected_at TEXT,
+        last_tested_at TEXT,
+        last_error_code TEXT,
+        last_error_message TEXT,
+        sort_order INTEGER DEFAULT 0,
+        deleted_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO db_assets (id, user_id, name, group_name, db_type, host, port, created_at, updated_at)
+      VALUES ('a1', 1, 'legacy', NULL, 'mysql', '127.0.0.1', 3306, 'x', 'x');
+    `)
+
+    await upgradeDbAssetsSupport(realDb as never)
+
+    const cols = realDb.prepare("PRAGMA table_info('db_assets')").all() as Array<{ name: string; notnull: number }>
+    const byName = new Map(cols.map((col) => [col.name, col]))
+    assert.equal(byName.get('host')?.notnull, 0)
+    assert.equal(byName.get('port')?.notnull, 0)
+    assert.equal(byName.has('file_path'), true)
+    assert.equal(byName.has('connection_mode'), true)
+
+    const row = realDb.prepare('SELECT name, host, port, connection_mode FROM db_assets WHERE id = ?').get('a1') as {
+      name: string
+      host: string
+      port: number
+      connection_mode: string
+    }
+    assert.deepEqual(row, { name: 'legacy', host: '127.0.0.1', port: 3306, connection_mode: 'readwrite' })
+  } finally {
+    realDb.close()
+  }
+}
+
+const cases: Record<string, () => Promise<void>> = {
+  'sqlite-driver:test-connection': testSqliteConnection,
+  'sqlite-driver:metadata': testSqliteMetadata,
+  'sqlite-driver:execute': testSqliteExecute,
+  'sqlite-driver:rollback-ddl': testSqliteRollbackAndDdl,
+  'db-assets:legacy-rebuild': testDbAssetsLegacyRebuild
+}
+
+async function main(): Promise<void> {
+  const name = process.argv[2]
+  const run = cases[name]
+  if (!run) throw new Error(`unknown native sqlite test case: ${String(name)}`)
+  await run()
+  console.log(`__NATIVE_SQLITE_RESULT__${JSON.stringify({ ok: true, name })}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  console.log(
+    `__NATIVE_SQLITE_RESULT__${JSON.stringify({
+      ok: false,
+      error: {
+        name: error instanceof Error ? error.name : 'Error',
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined
+      }
+    })}`
+  )
+  process.exitCode = 1
+})


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup mode for local shell connections (interactive or fast), exposed to the connect API.

* **Performance Improvements**
  * Faster local shell startup by skipping unnecessary device/user lookups for local sessions.

* **Behavior Changes**
  * Local shell environment is sanitized of IDE-related vars and terminal identifier standardized; shell startup flags adjusted per shell and mode.

* **Tests**
  * Added local shell startup tests and an Electron-based native SQLite test runner.

* **Chores**
  * CI adjusted to rebuild SQLite native modules for Electron.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->