### PR TITLE
refactor: remove unused global state updates from removeToken function

### DIFF
--- a/src/renderer/src/utils/permission.ts
+++ b/src/renderer/src/utils/permission.ts
@@ -1,7 +1,6 @@
 export const CtmTokenKey: string = 'Ctm-Token'
 import { userInfoStore } from '@/store/index'
 import { pinia } from '@/main'
-import { updateGlobalState } from '@renderer/agent/storage/state'
 
 const baseSso = import.meta.env.RENDERER_SSO
 const currentUrl = location.href
@@ -14,8 +13,6 @@ export function removeToken() {
   localStorage.removeItem('bearer-token')
   localStorage.removeItem('userInfo')
   localStorage.removeItem('login-skipped')
-  void updateGlobalState('modelOptions', [])
-  void updateGlobalState('defaultLockedModelNames', [])
 }
 export const setUserInfo = (info) => {
   const userStore = userInfoStore(pinia)


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication token clearing logic to handle only authentication-related data, streamlining state management during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->