### PR TITLE
refactor: update folder item styles and remove mouse enter/leave handlers

### DIFF
--- a/src/renderer/src/views/components/Files/tabIndex.vue
+++ b/src/renderer/src/views/components/Files/tabIndex.vue
@@ -307,15 +307,13 @@
         <div
           v-for="folder in customFolders"
           :key="folder.uuid"
-          style="padding: 12px; border: 1px solid #d9d9d9; border-radius: 6px; margin-bottom: 8px; cursor: pointer; transition: all 0.2s"
+          class="move-folder-item"
           @click="handleMoveAssetToFolder(folder.uuid)"
-          @mouseenter="handleFolderMouseEnter"
-          @mouseleave="handleFolderMouseLeave"
         >
-          <div style="font-weight: 500; margin-bottom: 4px">{{ folder.name }}</div>
+          <div class="move-folder-item__name">{{ folder.name }}</div>
           <div
             v-if="folder.description"
-            style="color: #666; font-size: 12px"
+            class="move-folder-item__desc"
           >
             {{ folder.description }}
           </div>
@@ -1086,16 +1084,6 @@ const handleCreateFolderFromMoveModal = () => {
   showMoveToFolderModal.value = false
 }
 
-const handleFolderMouseEnter = (e: Event) => {
-  const target = e.target as HTMLElement
-  if (target) target.style.backgroundColor = '#f5f5f5'
-}
-
-const handleFolderMouseLeave = (e: Event) => {
-  const target = e.target as HTMLElement
-  if (target) target.style.backgroundColor = 'transparent'
-}
-
 const handleContextMenu = (event: MouseEvent, dataRef: any) => {
   event.preventDefault()
   event.stopPropagation()
@@ -1808,6 +1796,30 @@ onUnmounted(() => {
 }
 
 /* Context menu styles */
+.move-folder-item {
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: var(--hover-bg-color);
+  }
+
+  &__name {
+    font-weight: 500;
+    margin-bottom: 4px;
+    color: var(--text-color);
+  }
+
+  &__desc {
+    color: var(--text-color-secondary);
+    font-size: 12px;
+  }
+}
+
 .context-menu {
   background: var(--bg-color-secondary);
   border: 1px solid var(--border-color);

--- a/src/renderer/src/views/components/Workspace/index.vue
+++ b/src/renderer/src/views/components/Workspace/index.vue
@@ -376,15 +376,13 @@
         <div
           v-for="folder in customFolders"
           :key="folder.uuid"
-          style="padding: 12px; border: 1px solid #d9d9d9; border-radius: 6px; margin-bottom: 8px; cursor: pointer; transition: all 0.2s"
+          class="move-folder-item"
           @click="handleMoveAssetToFolder(folder.uuid)"
-          @mouseenter="handleFolderMouseEnter"
-          @mouseleave="handleFolderMouseLeave"
         >
-          <div style="font-weight: 500; margin-bottom: 4px">{{ folder.name }}</div>
+          <div class="move-folder-item__name">{{ folder.name }}</div>
           <div
             v-if="folder.description"
-            style="color: #666; font-size: 12px"
+            class="move-folder-item__desc"
           >
             {{ folder.description }}
           </div>
@@ -2114,16 +2112,6 @@ const handleCreateFolderFromMoveModal = () => {
   showMoveToFolderModal.value = false
 }
 
-const handleFolderMouseEnter = (e: Event) => {
-  const target = e.target as HTMLElement
-  if (target) target.style.backgroundColor = '#f5f5f5'
-}
-
-const handleFolderMouseLeave = (e: Event) => {
-  const target = e.target as HTMLElement
-  if (target) target.style.backgroundColor = 'transparent'
-}
-
 const hasContextMenu = (dataRef: any): boolean => {
   if (!dataRef) return false
   const hasDirectHostOption = canEditDirectHost(dataRef)
@@ -3237,6 +3225,30 @@ onUnmounted(() => {
   :deep(.ant-tabs-tab-btn) {
     width: 100%;
     text-align: center;
+  }
+}
+
+.move-folder-item {
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: var(--hover-bg-color);
+  }
+
+  &__name {
+    font-weight: 500;
+    margin-bottom: 4px;
+    color: var(--text-color);
+  }
+
+  &__desc {
+    color: var(--text-color-secondary);
+    font-size: 12px;
   }
 }
 


### PR DESCRIPTION

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined styling and interaction handling for the "Move to folder" modal's folder list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->