### PR TITLE
chore: Unified logo processing

### DIFF
--- a/src/renderer/src/utils/__tests__/branding.test.ts
+++ b/src/renderer/src/utils/__tests__/branding.test.ts
@@ -59,7 +59,7 @@ describe('renderer branding utils', () => {
     expect(config.logoDarkUrl).toBe('/branding/logo-dark.svg')
   })
 
-  it('uses main-process display name but keeps renderer logo paths stable', async () => {
+  it('uses main-process display name and converts local branding file URLs for renderer usage', async () => {
     mockGetEditionConfig.mockReturnValue({
       edition: 'global',
       displayName: 'Chaterm',
@@ -83,9 +83,9 @@ describe('renderer branding utils', () => {
     const config = await loadBrandingConfig()
 
     expect(config.displayName).toBe('Hello AI Shell')
-    expect(config.logoUrl).toBe('/branding/logo.svg')
-    expect(config.logoLightUrl).toBe('/branding/logo-light.svg')
-    expect(config.logoDarkUrl).toBe('/branding/logo-dark.svg')
+    expect(config.logoUrl).toBe('local-resource:///broken/logo.svg')
+    expect(config.logoLightUrl).toBe('local-resource:///broken/logo-light.svg')
+    expect(config.logoDarkUrl).toBe('local-resource:///broken/logo-dark.svg')
   })
 
   it('falls back to default branding config when preload api is unavailable', async () => {

--- a/src/renderer/src/utils/branding.ts
+++ b/src/renderer/src/utils/branding.ts
@@ -2,6 +2,7 @@ import defaultLogoUrl from '@/assets/logo.svg'
 import defaultLogoLightUrl from '@/assets/img/logo-light.svg'
 import defaultLogoDarkUrl from '@/assets/img/logo-dark.svg'
 import { getEditionConfig } from './edition'
+import { convertFileLocalResourceSrc } from './convertFileLocalResourceSrc'
 
 const enterpriseLogoUrl = '/branding/logo.svg'
 const enterpriseLogoLightUrl = '/branding/logo-light.svg'
@@ -57,9 +58,9 @@ export const loadBrandingConfig = async (): Promise<BrandingConfig> => {
       ...defaultConfig,
       ...resolved,
       displayName: resolved.displayName || defaultConfig.displayName,
-      logoUrl: defaultConfig.logoUrl,
-      logoLightUrl: defaultConfig.logoLightUrl,
-      logoDarkUrl: defaultConfig.logoDarkUrl
+      logoUrl: convertFileLocalResourceSrc(resolved.logoUrl || null) || defaultConfig.logoUrl,
+      logoLightUrl: convertFileLocalResourceSrc(resolved.logoLightUrl || null) || defaultConfig.logoLightUrl,
+      logoDarkUrl: convertFileLocalResourceSrc(resolved.logoDarkUrl || null) || defaultConfig.logoDarkUrl
     }
   } catch (error) {
     return defaultConfig


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed branding logo URL conversion in the renderer. Enterprise branding logo assets (`logo`, `logoLight`, `logoDark`) are now properly converted to local resource format, ensuring branding configurations display correctly within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->