### PR TITLE
chore(deps): update dompurify to 3.4.11 and undici to 7.28.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "diff": "^9.0.0",
         "dockview-core": "^4.13.1",
         "dockview-vue": "^4.11.0",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.11",
         "dotenv": "^17.4.2",
         "electron-log": "^5.4.4",
         "electron-updater": "^6.8.9",
@@ -10396,9 +10396,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -14276,16 +14276,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
@@ -17046,9 +17036,9 @@
       "license": "ISC"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "diff": "^9.0.0",
     "dockview-core": "^4.13.1",
     "dockview-vue": "^4.11.0",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.11",
     "dotenv": "^17.4.2",
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.9",
@@ -126,6 +126,7 @@
     "js-cookie": "^3.0.7",
     "js-yaml": "^4.2.0",
     "qs": "^6.15.2",
+    "undici": "^7.28.0",
     "uuid": "^14.0.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [x] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [x] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `dompurify` package to the latest available patch version.
  * Added an explicit version constraint for the `undici` package to standardize builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->