### PR TITLE
fix: Render opened file content correctly on macOS

### DIFF
--- a/src/renderer/src/views/components/Editors/base/monacoEditor.vue
+++ b/src/renderer/src/views/components/Editors/base/monacoEditor.vue
@@ -82,6 +82,18 @@ const monacoVimInstance: any = null
 const hasCustomBg = ref(typeof document !== 'undefined' && !!document.body?.classList.contains('has-custom-bg'))
 let bgClassObserver: MutationObserver | null = null
 
+const layoutEditorSoon = (): void => {
+  const layout = () => editor?.layout()
+  if (typeof requestAnimationFrame !== 'function') {
+    layout()
+    return
+  }
+  requestAnimationFrame(() => {
+    layout()
+    requestAnimationFrame(layout)
+  })
+}
+
 // Global editor config store; use storeToRefs so config changes from settings trigger watch
 const editorConfigStore = useEditorConfigStore()
 const { config: storeConfig } = storeToRefs(editorConfigStore)
@@ -237,6 +249,8 @@ const createEditor = (): void => {
       emit('update:modelValue', value)
     }
   })
+
+  layoutEditorSoon()
 }
 
 onMounted(async () => {
@@ -267,6 +281,7 @@ watch(
   (newValue) => {
     if (editor && newValue !== editor.getValue()) {
       editor.setValue(newValue)
+      layoutEditorSoon()
     }
   }
 )

--- a/src/renderer/src/views/components/Files/index.vue
+++ b/src/renderer/src/views/components/Files/index.vue
@@ -2445,7 +2445,10 @@ const openFile = async (data) => {
       } as UnwrapRef<editorData>)
     } else if (existingEditor) {
       existingEditor.visible = true
-      existingEditor.vimText = data
+      existingEditor.vimText = stdout
+      existingEditor.originVimText = stdout
+      existingEditor.fileChange = false
+      existingEditor.saved = false
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor refresh behavior so content updates are laid out correctly after changes, reducing display glitches.
  * Fixed reopening an already open file so the editor now loads the latest file contents and correctly resets unsaved-change state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->