### PR TITLE
fix: use correct URL scheme for SOCKS4/SOCKS5 proxies

### DIFF
--- a/src/main/agent/api/providers/proxy/user-proxy.fuzz.test.ts
+++ b/src/main/agent/api/providers/proxy/user-proxy.fuzz.test.ts
@@ -87,4 +87,25 @@ describe('buildProxyUrl property tests', () => {
     expect(parsed.username).toBe('')
     expect(parsed.password).toBe('')
   })
+
+  // Scheme must match the proxy type so the correct agent protocol is selected
+  test.prop({
+    host: fc.oneof(fc.domain(), fc.ipV4()),
+    port: fc.integer({ min: 1, max: 65535 })
+  })('derives URL scheme from proxy type', ({ host, port }) => {
+    const cases: Record<string, string> = {
+      HTTP: 'http:',
+      HTTPS: 'https:',
+      SOCKS4: 'socks4:',
+      SOCKS5: 'socks5:'
+    }
+
+    for (const [type, expectedProtocol] of Object.entries(cases)) {
+      const url = buildProxyUrl({ type, host, port })
+      const parsed = new URL(url)
+      expect(parsed.protocol).toBe(expectedProtocol)
+      expect(parsed.hostname).toBe(host)
+      expect(Number(parsed.port)).toBe(port)
+    }
+  })
 })

--- a/src/main/agent/api/providers/proxy/user-proxy.ts
+++ b/src/main/agent/api/providers/proxy/user-proxy.ts
@@ -9,12 +9,29 @@ import type { Agent } from 'http'
 import { ProxyConfig } from '@shared/Proxy'
 
 /**
+ * Map proxy type to its URL scheme
+ */
+function proxyScheme(type?: string): string {
+  switch (type) {
+    case 'HTTPS':
+      return 'https'
+    case 'SOCKS4':
+      return 'socks4'
+    case 'SOCKS5':
+      return 'socks5'
+    case 'HTTP':
+    default:
+      return 'http'
+  }
+}
+
+/**
  * Build proxy URL from configuration
  */
 export function buildProxyUrl(config: ProxyConfig): string {
   const { host, port, enableProxyIdentity, username, password } = config
   const auth = enableProxyIdentity && username && password ? `${encodeURIComponent(username)}:${encodeURIComponent(password)}@` : ''
-  const scheme = config.type === 'HTTPS' ? 'https' : 'http'
+  const scheme = proxyScheme(config.type)
   return `${scheme}://${auth}${host}:${port}`
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue
https://github.com/chaterm/Chaterm/pull/2415

Resolves #(issue_number)

## Description
Follow-up to #2415. The HTTPS fix was correct but incomplete: buildProxyUrl only special-cased HTTPS, so SOCKS4/SOCKS5 fell through to the http scheme. socks-proxy-agent v8 validates the scheme and
  throws \"A 'socks' protocol must be specified\", breaking SOCKS proxies. Now maps each type to its scheme (http/https/socks4/socks5) with an http fallback, plus tests.

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy connections now use the correct URL protocol for HTTP, HTTPS, SOCKS4, and SOCKS5 configurations.
  * Proxy host, port, and authentication details continue to be preserved when building connection URLs.

* **Tests**
  * Added coverage across proxy types and varied host and port combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->