### PR TITLE
feat: The enterprise version adds Agent usage statistics

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -132,6 +132,7 @@ export default defineConfig(({ mode }) => {
         'process.env.CHATERM_KB_SEARCH_ENABLED': JSON.stringify(env.RENDERER_KB_SEARCH_ENABLED || ''),
         'process.env.CHATERM_TELEMETRY_ENABLED': JSON.stringify(env.RENDERER_TELEMETRY_ENABLED || ''),
         'process.env.CHATERM_DATA_SYNC_ENABLED': JSON.stringify(env.RENDERER_DATA_SYNC_ENABLED || ''),
+        'process.env.CHATERM_ENTERPRISE_STATS_ENABLED': JSON.stringify(env.RENDERER_ENTERPRISE_STATS_ENABLED || ''),
         'process.env.CHATERM_OAUTH_DEEPLINK_SIGNATURE_ENABLED': JSON.stringify(env.RENDERER_OAUTH_DEEPLINK_SIGNATURE_ENABLED || ''),
         'process.env.CHATERM_DEPLOY_STATUS': JSON.stringify(env.RENDERER_DEPLOY_STATUS || '0'),
         'process.env.CHATERM_PREINSTALLED_PLUGINS': JSON.stringify(env.RENDERER_PREINSTALLED_PLUGINS || '')

--- a/src/main/agent/core/task/index.ts
+++ b/src/main/agent/core/task/index.ts
@@ -116,6 +116,7 @@ import { connectAssetInfo } from '../../../storage/database'
 import { findWakeupConnectionInfoByHost } from '../../../ssh/agentHandle'
 import { getMessages, formatMessage, Messages } from './messages'
 import { decodeHtmlEntities } from '@utils/decodeHtmlEntities'
+import { classifyAgentCommand, enterpriseUsageStatsService } from '../../../services/enterpriseUsageStatsService'
 import { McpHub } from '@services/mcp/McpHub'
 import { SkillsManager } from '@services/skills'
 import { ChatermDatabaseService } from '../../../storage/db/chaterm.service'
@@ -656,9 +657,62 @@ export class Task {
     if (task) {
       // New task started
       telemetryService.captureTaskCreated(this.taskId, apiConfiguration.apiProvider)
+      this.captureAgentSessionStarted()
     } else {
       // Open task from history
       telemetryService.captureTaskRestarted(this.taskId, apiConfiguration.apiProvider)
+    }
+  }
+
+  private captureAgentSessionStarted(): void {
+    void (async () => {
+      const chatSettings = await getGlobalState('chatSettings')
+      if (chatSettings?.mode !== 'agent' && chatSettings?.mode !== 'cmd') {
+        return
+      }
+      await enterpriseUsageStatsService.captureEvent({
+        eventType: 'agent_session_started',
+        eventAt: new Date().toISOString()
+      })
+    })().catch((error) => {
+      logger.warn('Failed to capture agent session usage stats event', { error })
+    })
+  }
+
+  private captureExecuteCommandUsage(command: string): void {
+    const normalizedCommand = command.trim()
+    if (!normalizedCommand) {
+      return
+    }
+
+    void enterpriseUsageStatsService.captureEvent({
+      eventType: 'agent_command_executed',
+      eventAt: new Date().toISOString(),
+      commandCategory: classifyAgentCommand(normalizedCommand)
+    })
+  }
+
+  private captureAgentTargetConnected(): void {
+    void enterpriseUsageStatsService.captureEvent({
+      eventType: 'agent_ssh_connected',
+      eventAt: new Date().toISOString()
+    })
+  }
+
+  private captureTargetConnectionUsageIfNeeded(targetHosts?: string): void {
+    const hosts = (targetHosts || '')
+      .split(',')
+      .map((host) => host.trim())
+      .filter((host) => host.length > 0)
+
+    for (const host of hosts) {
+      const isLocal = this.isLocalHost(host)
+      const key = isLocal ? 'local:localhost' : `remote:${host}`
+      if (this.connectedHosts.has(key)) {
+        continue
+      }
+      this.connectedHosts.add(key)
+      this.captureAgentTargetConnected()
     }
   }
 
@@ -1079,6 +1133,13 @@ export class Task {
    */
   private async executeCommandInLocalHost(command: string, cwd?: string): Promise<string> {
     try {
+      const chatSettings = await getGlobalState('chatSettings')
+      const localConnectionId = 'local:localhost'
+      if ((chatSettings?.mode === 'agent' || chatSettings?.mode === 'cmd') && !this.connectedHosts.has(localConnectionId)) {
+        this.captureAgentTargetConnected()
+        this.connectedHosts.add(localConnectionId)
+      }
+
       const result = await this.localTerminalManager.executeCommand(command, cwd)
       if (result.success) {
         return result.output || ''
@@ -1293,6 +1354,10 @@ export class Task {
               partial: false
             }
           })
+        }
+
+        if (chatSettings?.mode === 'agent' || chatSettings?.mode === 'cmd') {
+          this.captureAgentTargetConnected()
         }
 
         // Mark this host as connected
@@ -3063,7 +3128,7 @@ export class Task {
           }
 
           // Unified user confirmation (including security confirmation and command execution confirmation)
-          const didApprove = await this.askApproval(toolDescription, 'command', command)
+          const didApprove = await this.askApproval(toolDescription, 'command', command, { command, targetHosts: ip, toolName: 'execute_command' })
           if (!didApprove) {
             if (needsSecurityApproval) {
               await this.say('error', formatMessage(this.messages.userRejectedCommand, { command }), false)
@@ -3109,7 +3174,7 @@ export class Task {
             didAutoApprove = true
           } else {
             this.showNotificationIfNeeded(`Chaterm wants to execute a command: ${command}`)
-            const didApprove = await this.askApproval(toolDescription, 'command', command)
+            const didApprove = await this.askApproval(toolDescription, 'command', command, { command, targetHosts: ip, toolName: 'execute_command' })
             logger.debug(`[Command Execution] User approval result: ${didApprove}`)
             if (!didApprove) {
               await this.saveCheckpoint()
@@ -3142,6 +3207,10 @@ export class Task {
         }
         if (timeoutId) {
           clearTimeout(timeoutId)
+        }
+
+        if (chatSettings?.mode === 'agent') {
+          this.captureExecuteCommandUsage(command!)
         }
 
         // Record tool call to active todo
@@ -3394,7 +3463,12 @@ export class Task {
     }
   }
 
-  private async askApproval(toolDescription: string, type: ChatermAsk, partialMessage?: string): Promise<boolean> {
+  private async askApproval(
+    toolDescription: string,
+    type: ChatermAsk,
+    partialMessage?: string,
+    usageMeta?: { command?: string; targetHosts?: string; toolName?: string }
+  ): Promise<boolean> {
     const { response, text, contentParts, toolResult } = await this.ask(type, partialMessage, false)
     const approved = response === 'yesButtonClicked' || response === 'autoApproveReadOnlyClicked'
 
@@ -3418,6 +3492,10 @@ export class Task {
         hosts: this.hosts,
         isError: toolResult.isError
       })
+      if ((usageMeta?.toolName ?? toolResult.toolName) === 'execute_command' && usageMeta?.command) {
+        this.captureTargetConnectionUsageIfNeeded(usageMeta.targetHosts)
+        this.captureExecuteCommandUsage(usageMeta.command)
+      }
       await this.saveUserMessage(toolResult.output, undefined, 'command_output')
       await this.saveCheckpoint()
     } else if (text) {
@@ -3571,7 +3649,7 @@ export class Task {
           await this.saveCheckpoint(true)
         }
 
-        const didApprove = await this.askApproval(toolDescription, 'command', command)
+        const didApprove = await this.askApproval(toolDescription, 'command', command, { command, targetHosts: ip, toolName: 'execute_command' })
         if (!didApprove) {
           await this.saveCheckpoint()
           return
@@ -4777,6 +4855,7 @@ export class Task {
               // If it's local host, directly get system information
               if (this.isLocalHost(host.host)) {
                 const localSystemInfo = await this.localTerminalManager.getSystemInfo()
+                this.captureTargetConnectionUsageIfNeeded(host.host)
                 systemInfoOutput = `OS_VERSION:${localSystemInfo.osVersion}
 DEFAULT_SHELL:${localSystemInfo.defaultShell}
 HOME_DIR:${localSystemInfo.homeDir}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,6 +57,7 @@ import { telemetryService, checkIsFirstLaunch, getMacAddress } from './agent/ser
 import { envelopeEncryptionService } from './storage/data_sync/envelope_encryption/service'
 import { versionPromptService } from './version/versionPromptService'
 import { authFailureNotifier } from './services/authFailureNotifier'
+import { enterpriseUsageStatsService } from './services/enterpriseUsageStatsService'
 
 import * as fsSync from 'fs'
 import { createHash, createVerify, randomUUID } from 'crypto'
@@ -3142,6 +3143,10 @@ ipcMain.handle('capture-telemetry-event', async (_, { eventType, data }) => {
     logger.error('Failed to capture telemetry event', { error: error })
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
   }
+})
+
+ipcMain.handle('usage-stats:capture', async (_, payload) => {
+  return await enterpriseUsageStatsService.captureEvent(payload)
 })
 
 // Plugins

--- a/src/main/services/__tests__/enterpriseUsageStatsService.test.ts
+++ b/src/main/services/__tests__/enterpriseUsageStatsService.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { classifyAgentCommand, enterpriseUsageStatsService } from '../enterpriseUsageStatsService'
+
+const authMock = vi.hoisted(() => ({
+  getAuthToken: vi.fn(),
+  getCurrentUserId: vi.fn()
+}))
+
+vi.mock('@logging/index', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn()
+  })
+}))
+
+vi.mock('../config/edition', () => ({
+  getApiBaseUrl: () => 'https://api.example.test'
+}))
+
+vi.mock('../storage/data_sync/envelope_encryption/services/auth', () => ({
+  chatermAuthAdapter: authMock
+}))
+
+describe('enterpriseUsageStatsService', () => {
+  const oldEnabled = process.env.CHATERM_ENTERPRISE_STATS_ENABLED
+  const oldFetch = globalThis.fetch
+
+  afterEach(() => {
+    if (oldEnabled === undefined) {
+      delete process.env.CHATERM_ENTERPRISE_STATS_ENABLED
+    } else {
+      process.env.CHATERM_ENTERPRISE_STATS_ENABLED = oldEnabled
+    }
+    globalThis.fetch = oldFetch
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['ps -ef', 'inspect'],
+    ['top -n 1', 'inspect'],
+    ['powershell -Command "(Get-Process).Count"', 'inspect'],
+    ['mysql -u root -proot -e "SELECT user, host FROM mysql.user"', 'inspect'],
+    ['psql -c "UPDATE users SET status=\'active\' WHERE id=1"', 'change'],
+    ['apt-get update -qq && apt-get install -y nginx', 'change'],
+    ['journalctl -u nginx --since today | grep error', 'diagnose'],
+    ['cd /tmp && systemctl restart nginx', 'change'],
+    ['unknown-tool --flag', 'unknown']
+  ])('classifies %s as %s', (command, expected) => {
+    expect(classifyAgentCommand(command)).toBe(expected)
+  })
+
+  it.each([
+    [undefined, false],
+    ['', false],
+    ['true', true],
+    ['1', true],
+    ['yes', true],
+    ['on', true],
+    ['false', false],
+    ['0', false],
+    ['no', false],
+    ['off', false],
+    ['unexpected', false]
+  ])('enables reporting only for explicit truthy policy value %s', (raw, expected) => {
+    if (raw === undefined) {
+      delete process.env.CHATERM_ENTERPRISE_STATS_ENABLED
+    } else {
+      process.env.CHATERM_ENTERPRISE_STATS_ENABLED = raw
+    }
+
+    expect(enterpriseUsageStatsService.isEnabled()).toBe(expected)
+  })
+
+  it('skips upload when the feature flag is disabled', async () => {
+    process.env.CHATERM_ENTERPRISE_STATS_ENABLED = ''
+    globalThis.fetch = vi.fn()
+
+    await expect(enterpriseUsageStatsService.captureEvent({ eventType: 'client_active' })).resolves.toEqual({
+      success: false,
+      skipped: 'disabled'
+    })
+    expect(authMock.getAuthToken).not.toHaveBeenCalled()
+    expect(authMock.getCurrentUserId).not.toHaveBeenCalled()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('skips upload when the user is not authenticated', async () => {
+    process.env.CHATERM_ENTERPRISE_STATS_ENABLED = 'true'
+    globalThis.fetch = vi.fn()
+    authMock.getAuthToken.mockResolvedValue('guest_token')
+    authMock.getCurrentUserId.mockResolvedValue('guest_user')
+
+    await expect(enterpriseUsageStatsService.captureEvent({ eventType: 'client_active' })).resolves.toEqual({
+      success: false,
+      skipped: 'unauthenticated'
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/enterpriseUsageStatsService.ts
+++ b/src/main/services/enterpriseUsageStatsService.ts
@@ -1,0 +1,428 @@
+import { getApiBaseUrl } from '../config/edition'
+import { chatermAuthAdapter } from '../storage/data_sync/envelope_encryption/services/auth'
+
+const logger = createLogger('usageStats')
+
+type UsageStatsEventType = 'client_active' | 'agent_session_started' | 'agent_command_executed' | 'agent_ssh_connected' | 'desktop_ssh_connected'
+type UsageStatsCommandCategory = 'diagnose' | 'inspect' | 'change' | 'unknown'
+
+export interface UsageStatsEventPayload {
+  eventType: UsageStatsEventType
+  eventAt?: string
+  commandCategory?: UsageStatsCommandCategory
+  targetCount?: number
+}
+
+const parsePolicyEnabled = (raw: unknown): boolean | null => {
+  if (typeof raw !== 'string') return null
+  const normalized = raw.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return null
+}
+
+const categoryPriority = (category: UsageStatsCommandCategory): number => {
+  switch (category) {
+    case 'change':
+      return 4
+    case 'diagnose':
+      return 3
+    case 'inspect':
+      return 2
+    default:
+      return 1
+  }
+}
+
+const splitCommandSegments = (command: string): string[] => {
+  const trimmed = command.trim()
+  if (!trimmed) return []
+
+  const segments: string[] = []
+  let current = ''
+  let inSingleQuote = false
+  let inDoubleQuote = false
+  let escaped = false
+
+  const flush = () => {
+    const segment = current.trim()
+    if (segment) segments.push(segment)
+    current = ''
+  }
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]
+    if (escaped) {
+      current += ch
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      current += ch
+      escaped = true
+      continue
+    }
+    if (ch === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote
+      current += ch
+      continue
+    }
+    if (ch === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote
+      current += ch
+      continue
+    }
+    if (!inSingleQuote && !inDoubleQuote && ['&', '|', ';'].includes(ch)) {
+      flush()
+      if ((ch === '&' || ch === '|') && trimmed[i + 1] === ch) i++
+      continue
+    }
+    current += ch
+  }
+
+  flush()
+  return segments
+}
+
+const extractWrappedCommand = (normalized: string): string => {
+  const wrappers = [
+    ['powershell', '-command', '-c'],
+    ['powershell.exe', '-command', '-c'],
+    ['pwsh', '-command', '-c'],
+    ['pwsh.exe', '-command', '-c'],
+    ['cmd', '/c', '/k'],
+    ['cmd.exe', '/c', '/k']
+  ]
+
+  for (const wrapper of wrappers) {
+    const prefix = wrapper[0]
+    if (normalized !== prefix && !normalized.startsWith(`${prefix} `)) continue
+    for (const flag of wrapper.slice(1)) {
+      const needle = ` ${flag} `
+      const index = normalized.indexOf(needle)
+      if (index < 0) continue
+      return normalized
+        .slice(index + needle.length)
+        .trim()
+        .replace(/^[\s"'`]+|[\s"'`]+$/g, '')
+    }
+  }
+
+  return ''
+}
+
+const containsSqlVerb = (normalized: string, verbs: string[]): boolean => {
+  return verbs.some((verb) => {
+    if (normalized.startsWith(`${verb} `)) return true
+    return [` ${verb} `, `"${verb} `, `'${verb} `, `(${verb} `, `\`${verb} `].some((pattern) => normalized.includes(pattern))
+  })
+}
+
+const normalizeCommandPrimary = (token: string): string => {
+  const candidate = token.replace(/^[`"'({\[$@]+/, '')
+  return candidate.match(/^([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)+)/)?.[1] || token
+}
+
+const classifyCommandSegment = (segment: string): UsageStatsCommandCategory => {
+  const normalized = segment.trim().toLowerCase()
+  if (!normalized) return 'unknown'
+
+  const inner = extractWrappedCommand(normalized)
+  if (inner && inner !== normalized) return classifyAgentCommand(inner)
+
+  const filtered = normalized
+    .split(/\s+/)
+    .filter((part) => part && part !== 'sudo')
+    .filter((part) => !(part.includes('=') && !part.startsWith('=') && !part.includes('/')))
+
+  if (filtered.length === 0) return 'unknown'
+
+  const [rawPrimary, sub = '', third = ''] = filtered
+  const primary = normalizeCommandPrimary(rawPrimary)
+  if (['cd', 'source', '.', 'export'].includes(primary)) return 'unknown'
+
+  const containsLogPath =
+    normalized.includes('.log') ||
+    normalized.includes('/log') ||
+    normalized.includes('\\log') ||
+    normalized.includes('/logs/') ||
+    normalized.includes('\\logs\\')
+  const containsLogKeyword = normalized.includes('journalctl') || normalized.includes('syslog') || normalized.includes('error.log')
+  const containsWriteSql = containsSqlVerb(normalized, ['insert', 'update', 'delete', 'create', 'alter', 'drop', 'grant', 'revoke', 'flush'])
+  const containsReadSql = containsSqlVerb(normalized, ['select', 'show', 'describe', 'explain', 'pragma', 'info'])
+
+  if (
+    [
+      'grep',
+      'rg',
+      'ag',
+      'zgrep',
+      'bzgrep',
+      'tail',
+      'head',
+      'less',
+      'more',
+      'journalctl',
+      'select-string',
+      'sls',
+      'get-winevent',
+      'get-eventlog'
+    ].includes(primary)
+  )
+    return 'diagnose'
+
+  if (['set-content', 'add-content', 'clear-content'].includes(primary)) return 'change'
+
+  if (['awk', 'sed', 'cat', 'get-content', 'gc', 'type'].includes(primary)) {
+    if (primary === 'sed' && (sub === '-i' || normalized.includes(' -i'))) return 'change'
+    if (containsLogPath || containsLogKeyword) return 'diagnose'
+    return 'inspect'
+  }
+
+  if (
+    [
+      'ls',
+      'pwd',
+      'ps',
+      'df',
+      'du',
+      'free',
+      'find',
+      'whoami',
+      'id',
+      'uname',
+      'env',
+      'printenv',
+      'which',
+      'whereis',
+      'history',
+      'alias',
+      'netstat',
+      'ss',
+      'dir',
+      'get-ciminstance',
+      'get-process',
+      'gps',
+      'get-service',
+      'gsv',
+      'get-childitem',
+      'gci',
+      'get-item',
+      'gi',
+      'get-location',
+      'gl',
+      'get-volume',
+      'get-disk',
+      'get-computerinfo',
+      'test-connection',
+      'select-object',
+      'sort-object',
+      'format-table',
+      'format-list',
+      'format-wide',
+      'measure-object',
+      'where-object',
+      'foreach-object',
+      'top',
+      'htop',
+      'lsof',
+      'pgrep',
+      'pidof',
+      'iostat',
+      'vmstat',
+      'sar',
+      'nslookup',
+      'dig',
+      'host',
+      'traceroute',
+      'tracepath',
+      'ping'
+    ].includes(primary)
+  )
+    return 'inspect'
+
+  if (primary === 'curl' && ['-i', '--head', '-I'].includes(sub)) return 'inspect'
+  if (primary === 'wget' && sub === '--spider') return 'inspect'
+
+  if (['npm', 'pnpm', 'yarn'].includes(primary)) {
+    if (['list', 'ls'].includes(sub)) return 'inspect'
+    if (['run', 'build', 'start', 'dev', 'install', 'add', 'remove', 'test'].includes(sub)) return 'change'
+  }
+
+  if (['apt-get', 'apt', 'yum', 'dnf', 'apk', 'pacman', 'zypper', 'pip', 'pip3', 'gem', 'cargo', 'go'].includes(primary))
+    return ['list', 'ls', 'search', 'show', 'info', 'policy'].includes(sub) ? 'inspect' : 'change'
+
+  if (primary === 'systemctl') {
+    if (['status', 'is-active', 'is-enabled', 'show'].includes(sub)) return 'inspect'
+    if (['start', 'stop', 'restart', 'reload', 'enable', 'disable'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'service') {
+    if (sub === 'status') return 'inspect'
+    if (['start', 'stop', 'restart', 'reload'].includes(sub)) return 'change'
+  }
+
+  if (
+    [
+      'restart-service',
+      'stop-service',
+      'start-service',
+      'set-service',
+      'new-item',
+      'remove-item',
+      'copy-item',
+      'move-item',
+      'rename-item',
+      'set-item'
+    ].includes(primary)
+  )
+    return 'change'
+
+  if (primary === 'supervisorctl') {
+    if (sub === 'status') return 'inspect'
+    if (['start', 'stop', 'restart', 'reload', 'update'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'pm2') {
+    if (['list', 'status', 'show'].includes(sub)) return 'inspect'
+    if (sub === 'logs') return 'diagnose'
+    if (['start', 'stop', 'restart', 'reload', 'delete'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'kubectl') {
+    if (sub === 'logs') return 'diagnose'
+    if (['get', 'describe', 'top'].includes(sub)) return 'inspect'
+    if (['apply', 'delete', 'exec', 'scale', 'rollout', 'patch', 'cp'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'helm') {
+    if (['list', 'status', 'get', 'show', 'template'].includes(sub)) return 'inspect'
+    if (['install', 'upgrade', 'uninstall', 'rollback'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'docker-compose') {
+    if (['ps', 'images', 'config'].includes(sub)) return 'inspect'
+    if (sub === 'logs') return 'diagnose'
+    if (['up', 'down', 'start', 'stop', 'restart', 'pull', 'build'].includes(sub)) return 'change'
+  }
+
+  if (primary === 'docker') {
+    if (sub === 'compose') {
+      if (['ps', 'images', 'config'].includes(third)) return 'inspect'
+      if (third === 'logs') return 'diagnose'
+      if (['up', 'down', 'start', 'stop', 'restart', 'pull', 'build'].includes(third)) return 'change'
+    }
+    if (sub === 'logs') return 'diagnose'
+    if (['ps', 'images', 'inspect', 'stats'].includes(sub)) return 'inspect'
+    if (['run', 'exec', 'start', 'stop', 'restart', 'rm', 'cp'].includes(sub)) return 'change'
+  }
+
+  if (['mysql', 'mariadb', 'psql', 'sqlite3', 'sqlcmd', 'mongo', 'mongosh'].includes(primary)) {
+    if (containsWriteSql) return 'change'
+    if (containsReadSql) return 'inspect'
+  }
+
+  if (primary === 'redis-cli') {
+    if ([' flushall', ' flushdb', ' set ', ' del ', ' expire ', ' hset ', ' config set'].some((part) => normalized.includes(part))) return 'change'
+    if ([' info', ' get ', ' hgetall', ' ttl ', ' keys ', ' scan', ' ping'].some((part) => normalized.includes(part))) return 'inspect'
+  }
+
+  if (primary === 'tar') return normalized.includes(' -x') ? 'change' : 'inspect'
+  if (
+    [
+      'unzip',
+      'scp',
+      'rsync',
+      'rm',
+      'mv',
+      'cp',
+      'copy',
+      'move',
+      'rename',
+      'mkdir',
+      'touch',
+      'chmod',
+      'chown',
+      'kill',
+      'vim',
+      'nano',
+      'crontab',
+      'python',
+      'python3',
+      'node',
+      'bash',
+      'sh',
+      'ansible-playbook',
+      'terraform'
+    ].includes(primary)
+  )
+    return 'change'
+
+  if (containsLogPath || containsLogKeyword) return 'diagnose'
+  return 'unknown'
+}
+
+export const classifyAgentCommand = (command: string): UsageStatsCommandCategory => {
+  const segments = splitCommandSegments(command)
+  let best: UsageStatsCommandCategory = 'unknown'
+  for (const segment of segments) {
+    const category = classifyCommandSegment(segment)
+    if (categoryPriority(category) > categoryPriority(best)) best = category
+  }
+  return best
+}
+
+class EnterpriseUsageStatsService {
+  isEnabled(): boolean {
+    return parsePolicyEnabled(process.env.CHATERM_ENTERPRISE_STATS_ENABLED) === true
+  }
+
+  async captureEvent(payload: UsageStatsEventPayload): Promise<{ success: boolean; skipped?: string; error?: string }> {
+    try {
+      if (!this.isEnabled()) {
+        return { success: false, skipped: 'disabled' }
+      }
+
+      const token = await chatermAuthAdapter.getAuthToken()
+      const userId = await chatermAuthAdapter.getCurrentUserId()
+      if (!token || token === 'guest_token' || !userId || userId === 'guest_user') {
+        return { success: false, skipped: 'unauthenticated' }
+      }
+
+      const response = await fetch(`${getApiBaseUrl()}/user/usage-stats/events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token.startsWith('Bearer ') ? token : `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          eventType: payload.eventType,
+          eventAt: payload.eventAt || new Date().toISOString(),
+          commandCategory: payload.commandCategory || '',
+          targetCount: payload.targetCount || 0
+        })
+      })
+
+      if (!response.ok) {
+        logger.warn('Usage stats event request failed', {
+          event: 'usage.stats.capture.failed',
+          eventType: payload.eventType,
+          status: response.status,
+          targetCount: payload.targetCount || 0
+        })
+        return { success: false, error: `HTTP_${response.status}` }
+      }
+      return { success: true }
+    } catch (error) {
+      logger.warn('Usage stats event request error', {
+        event: 'usage.stats.capture.error',
+        eventType: payload.eventType,
+        targetCount: payload.targetCount || 0,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
+}
+
+export const enterpriseUsageStatsService = new EnterpriseUsageStatsService()

--- a/src/main/ssh/localSSHHandle.ts
+++ b/src/main/ssh/localSSHHandle.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { getUserConfig } from '../agent/core/storage/state'
 import { createTerminalOutputBuffer, type TerminalOutputBuffer } from '../services/terminalOutputBuffer'
+import { enterpriseUsageStatsService } from '../services/enterpriseUsageStatsService'
 const localLogger = createLogger('terminal')
 
 // Import language translations
@@ -389,6 +390,10 @@ export const registerLocalSSHHandlers = () => {
   ipcMain.handle('local:connect', async (_event, config: LocalTerminalConfig) => {
     try {
       await createTerminal(config)
+      void enterpriseUsageStatsService.captureEvent({
+        eventType: 'desktop_ssh_connected',
+        eventAt: new Date().toISOString()
+      })
       return { success: true, message: 'Local terminal connected successfully' }
     } catch (error: unknown) {
       localLogger.error('Local terminal connection failed', {

--- a/src/main/ssh/sshHandle.ts
+++ b/src/main/ssh/sshHandle.ts
@@ -56,6 +56,7 @@ import { getAlgorithmsByAssetType } from './algorithms'
 import { connectBastionByType, shellBastionSession, resizeBastionSession, writeBastionSession, disconnectBastionSession } from './bastionPlugin'
 import { shouldSkipPostConnectProbe } from './postConnectProbePolicy'
 import { sftpConnectionInfoMap } from './sftpTransfer'
+import { enterpriseUsageStatsService } from '../services/enterpriseUsageStatsService'
 
 // Maximum buffer size before forcing an immediate flush (prevents unbounded growth during bulk output)
 const MAX_BUFFER_SIZE = 64 * 1024 // 64KB
@@ -1538,6 +1539,14 @@ export const cleanSftpConnection = (id) => {
   }
 }
 
+const captureDesktopSshConnected = (result: unknown): void => {
+  if ((result as { status?: string } | null)?.status !== 'connected') return
+  void enterpriseUsageStatsService.captureEvent({
+    eventType: 'desktop_ssh_connected',
+    eventAt: new Date().toISOString()
+  })
+}
+
 export const registerSSHHandlers = () => {
   // Handle connection
   ipcMain.handle('ssh:connect', async (_event, connectionInfo) => {
@@ -1560,6 +1569,7 @@ export const registerSSHHandlers = () => {
       // Route to JumpServer connection
       try {
         const result = await handleJumpServerConnection(connectionInfo, _event)
+        captureDesktopSshConnected(result)
         return result
       } catch (error: unknown) {
         logger.error('JumpServer connection request failed', {
@@ -1573,14 +1583,17 @@ export const registerSSHHandlers = () => {
 
     const bastionResult = await connectBastionByType(sshType, connectionInfo, _event)
     if (bastionResult !== null) {
+      captureDesktopSshConnected(bastionResult)
       return bastionResult
     }
 
     // Default to SSH connection when sshType is missing or explicitly 'ssh'
     const retryCount = 0
-    return new Promise((resolve, reject) => {
+    const result = await new Promise((resolve, reject) => {
       handleAttemptConnection(_event, connectionInfo, resolve, reject, retryCount)
     })
+    captureDesktopSshConnected(result)
+    return result
   })
 
   ipcMain.handle('ssh:tunnel:start', async (_event, payload: SshTunnelStartPayload) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -500,6 +500,10 @@ interface ApiType {
   getAssetsInFolder: (data: { folderUuid: string }) => Promise<any>
   refreshOrganizationAssets: (data: { organizationUuid: string; jumpServerConfig: any }) => Promise<any>
   updateTheme: (params: any) => Promise<boolean>
+  captureUsageStatsEvent: (payload: {
+    eventType: 'client_active' | 'desktop_ssh_connected'
+    eventAt?: string
+  }) => Promise<{ success: boolean; skipped?: string; error?: string }>
   mainWindowShow: () => Promise<void>
   getVersionPrompt: () => Promise<{
     shouldShow: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1322,6 +1322,13 @@ const api = {
       return Promise.reject(error)
     }
   },
+  captureUsageStatsEvent: async (payload: { eventType: 'client_active' | 'desktop_ssh_connected'; eventAt?: string }) => {
+    try {
+      return await ipcRenderer.invoke('usage-stats:capture', payload)
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  },
   checkUpdate: () => ipcRenderer.invoke('update:checkUpdate'),
   download: () => ipcRenderer.invoke('update:download'),
   showOpenDialog: (options) => ipcRenderer.invoke('dialog:openFile', options),

--- a/src/renderer/src/router/guards.ts
+++ b/src/renderer/src/router/guards.ts
@@ -6,6 +6,7 @@ import { mark, reportMarksToMainAsync } from '@/utils/perf'
 
 const logger = createRendererLogger('router')
 let aiModelWarmupScheduled = false
+let lastClientActiveReportKey: string | null = null
 
 // 独立 axios 实例，仅用于启动时 token 验证，不挂任何全局 401 跳转拦截器
 const authCheckRequest = axios.create({ baseURL: config.api, timeout: 5000 })
@@ -55,6 +56,14 @@ async function verifyTokenWithServer(): Promise<'ok' | 'unauthorized' | 'network
     if (error?.response?.status === 401) return 'unauthorized'
     return 'network_error'
   }
+}
+
+function buildClientActiveReportKey(uid: number | string): string {
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${String(uid)}:${year}-${month}-${day}`
 }
 
 export const beforeEach = async (to, _from, next) => {
@@ -151,6 +160,19 @@ export const beforeEach = async (to, _from, next) => {
           mark('chaterm/renderer/didScheduleDataSync')
           if (tokenStatus === 'ok') {
             scheduleAiModelWarmup()
+            const reportKey = buildClientActiveReportKey(userInfo.uid)
+            if (lastClientActiveReportKey !== reportKey) {
+              lastClientActiveReportKey = reportKey
+              api
+                .captureUsageStatsEvent({
+                  eventType: 'client_active',
+                  eventAt: new Date().toISOString()
+                })
+                .catch((error) => {
+                  lastClientActiveReportKey = null
+                  logger.warn('Failed to capture client active usage stats event', { error })
+                })
+            }
           }
           finish()
         } else {


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enterprise usage statistics for authenticated activity, command execution, and successful local or SSH connections.
  * Added daily active-client reporting while preventing duplicate reports on the same day.
  * Usage events respect the configured enterprise statistics policy and are skipped when disabled or unauthenticated.

* **Bug Fixes**
  * Improved reliability of usage reporting by handling unavailable services and failed submissions without interrupting normal workflows.

* **Tests**
  * Added coverage for command classification, configuration behavior, authentication checks, and event submission safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->