### PR TITLE
fix: resolve OpenAI compatible API errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
         "superjson": "^2.2.5",
         "tiktoken": "^1.0.22",
+        "undici": "^7.28.0",
         "v-contextmenu": "^3.2.0",
         "vue-i18n": "^11.4.8",
         "zmodem.js": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
     "superjson": "^2.2.5",
     "tiktoken": "^1.0.22",
+    "undici": "^7.28.0",
     "v-contextmenu": "^3.2.0",
     "vue-i18n": "^11.4.8",
     "zmodem.js": "^0.1.10",

--- a/src/main/agent/api/__tests__/index.test.ts
+++ b/src/main/agent/api/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import { createServer, type Server } from 'node:http'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildApiHandler } from '../index'
+
+describe('buildApiHandler OpenAI provider', () => {
+  let server: Server | undefined
+
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    if (!server) return
+    await new Promise<void>((resolve, reject) => {
+      server!.close((error) => (error ? reject(error) : resolve()))
+    })
+    server = undefined
+  })
+
+  it('validates the existing OpenAI provider without relying on the host global fetch', async () => {
+    let requestPath: string | undefined
+    server = createServer((request, response) => {
+      requestPath = request.url
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          id: 'chatcmpl-openai-provider-test',
+          object: 'chat.completion',
+          model: 'relay-openai-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }]
+        })
+      )
+    })
+    await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('Test server did not expose a port')
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('host global fetch should not be used')
+      })
+    )
+
+    const handler = buildApiHandler({
+      apiProvider: 'openai',
+      needProxy: false,
+      openAiBaseUrl: `http://127.0.0.1:${address.port}`,
+      openAiApiKey: 'openai-provider-test-key',
+      openAiModelId: 'relay-openai-model'
+    })
+
+    await expect(handler.validateApiKey()).resolves.toEqual({ isValid: true })
+    expect(requestPath).toBe('/v1/chat/completions')
+  })
+})

--- a/src/main/agent/api/providers/openai.ts
+++ b/src/main/agent/api/providers/openai.ts
@@ -5,7 +5,8 @@
 // Licensed under the Apache License, Version 2.0
 
 import { Anthropic } from '@anthropic-ai/sdk'
-import OpenAI, { AzureOpenAI } from 'openai'
+import OpenAI, { AzureOpenAI, type ClientOptions } from 'openai'
+import { fetch as undiciFetch, ProxyAgent as UndiciProxyAgent } from 'undici'
 import { withRetry } from '../retry'
 import { ApiHandlerOptions, azureOpenAiDefaultApiVersion, ModelInfo, openAiModelInfoSaneDefaults } from '@shared/api'
 import { ApiHandler } from '../index'
@@ -14,9 +15,26 @@ import { convertToResponsesInput } from '../transform/responses-format'
 import type { ApiStream } from '../transform/stream'
 import { convertToR1Format } from '../transform/r1-format'
 import type { ChatCompletionReasoningEffort } from 'openai/resources/chat/completions'
-import { checkProxyConnectivity, createProxyAgent } from './proxy/index'
-import type { Agent } from 'http'
+import { buildProxyUrl } from './proxy/user-proxy'
+import { checkProxyConnectivity } from './proxy/index'
 const logger = createLogger('agent')
+
+type OpenAiFetch = NonNullable<ClientOptions['fetch']>
+
+// OpenAI-compatible relays may reject the official SDK fingerprint headers
+// (especially User-Agent) at their WAF layer. Keep authentication and custom
+// headers intact while omitting the SDK-specific defaults.
+const OPENAI_SDK_FINGERPRINT_HEADERS: Record<string, null> = {
+  'User-Agent': null,
+  'X-Stainless-Arch': null,
+  'X-Stainless-Lang': null,
+  'X-Stainless-OS': null,
+  'X-Stainless-Package-Version': null,
+  'X-Stainless-Retry-Count': null,
+  'X-Stainless-Runtime': null,
+  'X-Stainless-Runtime-Version': null,
+  'X-Stainless-Timeout': null
+}
 
 function isAzureEndpoint(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false
@@ -68,32 +86,41 @@ export class OpenAiHandler implements ApiHandler {
     this.options = options
     // Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
     // Use azureApiVersion to determine if this is an Azure endpoint, since the URL may not always contain 'azure.com'
-    let httpAgent: Agent | undefined = undefined
-    if (this.options.needProxy !== false) {
-      const proxyConfig = this.options.proxyConfig
-      httpAgent = createProxyAgent(proxyConfig)
-    }
     const timeoutMs = this.options.requestTimeoutMs || 20000
+    const clientOptions: Pick<ClientOptions, 'baseURL' | 'defaultHeaders' | 'fetch' | 'fetchOptions' | 'timeout'> = {
+      baseURL: normalizeBaseUrl(this.options.openAiBaseUrl),
+      defaultHeaders: {
+        ...OPENAI_SDK_FINGERPRINT_HEADERS,
+        ...this.options.openAiHeaders
+      },
+      // Electron's global fetch can fail with AggregateError/EACCES for
+      // external HTTPS requests. Use the Node undici implementation for all
+      // OpenAI-compatible providers, and attach the configured dispatcher
+      // only when a user proxy is enabled.
+      fetch: undiciFetch as unknown as OpenAiFetch,
+      ...(this.options.needProxy !== false && this.options.proxyConfig
+        ? {
+            fetchOptions: {
+              dispatcher: new UndiciProxyAgent(buildProxyUrl(this.options.proxyConfig))
+            }
+          }
+        : {}),
+      timeout: timeoutMs
+    }
 
     if (
       this.options.azureApiVersion ||
       (isAzureEndpoint(this.options.openAiBaseUrl) && !this.options.openAiModelId?.toLowerCase().includes('deepseek'))
     ) {
       this.client = new AzureOpenAI({
-        baseURL: normalizeBaseUrl(this.options.openAiBaseUrl),
-        apiKey: this.options.openAiApiKey,
-        apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
-        defaultHeaders: this.options.openAiHeaders,
-        ...(httpAgent && { fetchOptions: { agent: httpAgent } as any }),
-        timeout: timeoutMs
+        ...clientOptions,
+        apiKey: this.options.openAiApiKey ?? undefined,
+        apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion
       })
     } else {
       this.client = new OpenAI({
-        baseURL: normalizeBaseUrl(this.options.openAiBaseUrl),
-        apiKey: this.options.openAiApiKey,
-        defaultHeaders: this.options.openAiHeaders,
-        ...(httpAgent && { fetchOptions: { agent: httpAgent } as any }),
-        timeout: timeoutMs
+        ...clientOptions,
+        apiKey: this.options.openAiApiKey ?? undefined
       })
     }
   }
@@ -228,8 +255,8 @@ export class OpenAiHandler implements ApiHandler {
   async validateApiKey(): Promise<{ isValid: boolean; error?: string }> {
     try {
       // Validate proxy
-      if (this.options.needProxy) {
-        await checkProxyConnectivity(this.options.proxyConfig!)
+      if (this.options.needProxy && this.options.proxyConfig) {
+        await checkProxyConnectivity(this.options.proxyConfig)
       }
 
       const useResponsesApi = this.options.openAiModelInfo?.apiFormat === 'responses'


### PR DESCRIPTION
## Related Issue

N/A — no related issue.

## Description

This PR fixes OpenAI-compatible API requests in Electron.

Changes:
- Use Node.js `undici` fetch instead of Electron's global fetch.
- Remove OpenAI SDK fingerprint headers that may be rejected by relay WAFs.
- Preserve authentication and custom headers.
- Support configured HTTP/HTTPS/SOCKS proxy through `undici` ProxyAgent.
- Avoid proxy validation when no proxy configuration is provided.
- Add a regression test for OpenAI-compatible API validation.

## Verification

- OpenAI provider regression test passed.
- ESLint passed for changed files.
- Prettier check passed for changed files.

## Scope

This PR only contains the OpenAI-compatible API fix and its required dependency/test changes.
No login, custom model, model settings page, FFmpeg, or documentation changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenAI API key validation when using custom endpoints and proxies.
  - Prevented validation from relying on the host environment’s global network request implementation.
  - Preserved custom request headers while applying connection timeouts.

- **Tests**
  - Added coverage for successful API key validation against a local OpenAI-compatible endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->