### PR TITLE
chore: Install Electron binary for Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline
-
+        
+      - name: Install Electron binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: node node_modules/electron/install.js
+        
       - name: Build release packages
         shell: bash
         run: ${{ matrix.build_commands }}


### PR DESCRIPTION
Add step to install Electron binary on Windows.

<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows release builds by ensuring the required Electron binary is installed before packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->