### PR TITLE
chore: update ffmpeg KNOWN_HASH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline
-
+    
+      - name: Install Electron binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: node node_modules/electron/install.js
+        
       - name: Build release packages
         shell: bash
         run: ${{ matrix.build_commands }}

--- a/scripts/verify-ffmpeg.js
+++ b/scripts/verify-ffmpeg.js
@@ -7,7 +7,7 @@ if (process.platform !== 'win32') {
   process.exit(0)
 }
 
-const KNOWN_HASH = 'E7AEC5CA86D80540EA30C5ACDF0A13ACB34D1D9DD0F9E78B36FB21776B711A1E'
+const KNOWN_HASH = '31F21B81D743DCD2DC16190B246854E6B86211D2DC2F26B84B96E02DFA43D798'
 
 const ffmpegPath = path.join(__dirname, '../node_modules/electron/dist/ffmpeg.dll')
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -450,7 +450,7 @@ app.whenReady().then(async () => {
       try {
         const crypto = require('crypto')
         const ffmpegPath = path.join(path.dirname(process.execPath), 'ffmpeg.dll')
-        const KNOWN_HASH = 'E7AEC5CA86D80540EA30C5ACDF0A13ACB34D1D9DD0F9E78B36FB21776B711A1E'
+        const KNOWN_HASH = '31F21B81D743DCD2DC16190B246854E6B86211D2DC2F26B84B96E02DFA43D798'
 
         try {
           await fs.access(ffmpegPath)


### PR DESCRIPTION
<!--
Thank you for your contribution to Chaterm!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/chaterm/Chaterm/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolves #(issue_number)

## Description

## Checklist

- [ ] `npm run lint && npm run format && npm run typecheck` all pass; tests added/updated as needed.
- [ ] If UI or user-visible change: i18n and README updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Windows FFmpeg integrity verification to recognize the current bundled binary and prevent valid installations from being rejected.

- **Chores**
  - Cleaned up release workflow formatting without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->